### PR TITLE
Use normalizer classes

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -53,7 +53,8 @@ class SearchController < ApplicationController
 
   # Seaches EDS
   def search_eds
-    SearchEds.new.search(strip_q, eds_profile)
+    raw_results = SearchEds.new.search(strip_q, eds_profile)
+    NormalizeEds.new.to_result(raw_results)
   end
 
   # Determines appropriate EDS profile
@@ -67,7 +68,8 @@ class SearchController < ApplicationController
 
   # Searches Google Custom Search
   def search_google
-    SearchGoogle.new.search(strip_q)
+    raw_results = SearchGoogle.new.search(strip_q)
+    NormalizeGoogle.new.to_result(raw_results)
   end
 
   # Strips trailing and leading white space in search term

--- a/app/models/normalize_eds.rb
+++ b/app/models/normalize_eds.rb
@@ -1,0 +1,65 @@
+# Tranforms results from {SearchEds} into normalized {Result}s
+#
+class NormalizeEds
+  # Translate EDS results into local result model
+  def to_result(results)
+    norm = {}
+    norm['total'] = results['SearchResult']['Statistics']['TotalHits']
+    norm['results'] = []
+    extract_results(results, norm)
+    norm
+  end
+
+  private
+
+  def extract_results(results, norm)
+    return unless results['SearchResult']['Data']['Records']
+    results['SearchResult']['Data']['Records'].each do |record|
+      result = result(record)
+      result.authors = authors(record)
+      norm['results'] << result
+    end
+  end
+
+  def result(record)
+    Result.new(title(record), year(record), link(record), type(record))
+  end
+
+  def title(record)
+    bibentity = record['RecordInfo']['BibRecord']['BibEntity']
+    bibentity['Titles'].first['TitleFull']
+  end
+
+  def year(record)
+    return unless bibentity(record)['Dates']
+    bibentity(record)['Dates'][0]['Y']
+  end
+
+  def link(record)
+    record['PLink']
+  end
+
+  def type(record)
+    record.dig('Header', 'PubType')
+  end
+
+  def authors(record)
+    contributors(record)&.map { |r| r.dig('PersonEntity', 'Name', 'NameFull') }
+  end
+
+  def contributors(record)
+    relationships(record)['HasContributorRelationships']
+  end
+
+  def bibrecord(record)
+    record.dig('RecordInfo', 'BibRecord')
+  end
+
+  def bibentity(record)
+    relationships(record)['IsPartOfRelationships'][0]['BibEntity']
+  end
+
+  def relationships(record)
+    bibrecord(record)['BibRelationships']
+  end
+end

--- a/app/models/normalize_google.rb
+++ b/app/models/normalize_google.rb
@@ -1,0 +1,35 @@
+# Tranforms results from {SearchGoogle} into normalized {Result}s
+#
+class NormalizeGoogle
+  # Translate Google results into local result model
+  def to_result(results)
+    norm = {}
+    norm['total'] = results.queries['request'][0]
+                           .total_results.to_i
+    norm['results'] = []
+    extract_results(results, norm)
+    norm
+  end
+
+  private
+
+  # Extract the information we care about from the raw results and add them
+  # return them as an array of {result}s
+  def extract_results(results, norm)
+    return unless results.items
+    results.items.each do |item|
+      result = Result.new(item.title, year_from_dc_modified(item),
+                          item.link, 'website')
+      norm['results'] << result
+    end
+  end
+
+  # Extract year from dc.modified meta headers if available
+  def year_from_dc_modified(item)
+    return unless item.pagemap
+    return unless item.pagemap['metatags']
+    dc_mod = item.pagemap['metatags'][0]['dc.date.modified']
+    return unless dc_mod
+    Date.parse(dc_mod).year.to_s
+  end
+end

--- a/app/models/search_google.rb
+++ b/app/models/search_google.rb
@@ -26,43 +26,10 @@ class SearchGoogle
   # @param term [string] The string we are searching for
   # @return [Hash] A Hash with search metadata and an Array of {Result}s
   def search(term)
-    raw_results = @service.list_cses(
+    @service.list_cses(
       term,
       cx: ENV['GOOGLE_CUSTOM_SEARCH_ID'],
       num: ENV['RESULTS_PER_BOX'] || 3
     )
-    to_result(raw_results)
-  end
-
-  private
-
-  # Translate Google results into local result model
-  def to_result(results)
-    norm = {}
-    norm['total'] = results.queries['request'][0]
-                           .total_results.to_i
-    norm['results'] = []
-    extract_results(results, norm)
-    norm
-  end
-
-  # Extract the information we care about from the raw results and add them
-  # return them as an array of {result}s
-  def extract_results(results, norm)
-    return unless results.items
-    results.items.each do |item|
-      result = Result.new(item.title, year_from_dc_modified(item),
-                          item.link, 'website')
-      norm['results'] << result
-    end
-  end
-
-  # Extract year from dc.modified meta headers if available
-  def year_from_dc_modified(item)
-    return unless item.pagemap
-    return unless item.pagemap['metatags']
-    dc_mod = item.pagemap['metatags'][0]['dc.date.modified']
-    return unless dc_mod
-    Date.parse(dc_mod).year.to_s
   end
 end

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -1,38 +1,21 @@
-<% if params[:target] == 'articles' %>
-  <% @results['apinoaleph']['results'].each do |result| %>
-    <%= render partial: "result", locals: {result: result} %>
-  <% end %>
-
-  <% if @results['apinoaleph']['total'] > 0 %>
-    <%= link_to("View all #{number_with_delimiter(@results['apinoaleph']['total'])} like this.",
-                "#{ENV['EDS_NO_ALEPH_URI']}#{params[:q]}") %>
-  <% else %>
-    No results found.
-  <% end %>
+<% @results['results'].each do |result| %>
+  <%= render partial: "result", locals: {result: result} %>
 <% end %>
 
-<% if params[:target] == 'books' %>
-  <% @results['apibarton']['results'].each do |result| %>
-    <%= render partial: "result", locals: {result: result} %>
+<% if @results['total'] > 0 %>
+  <% if params[:target] == 'google' %>
+    <%= link_to(
+      "View all #{number_with_delimiter(@results['total'])} like this.",
+      "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}") %>
+  <% elsif params[:target] == 'articles' %>
+    <%= link_to(
+      "View all #{number_with_delimiter(@results['total'])} like this.",
+      "#{ENV['EDS_NO_ALEPH_URI']}#{params[:q]}") %>
+  <% elsif params[:target] == 'books' %>
+    <%= link_to(
+      "View all #{number_with_delimiter(@results['total'])} like this.",
+      "#{ENV['EDS_ALEPH_URI']}#{params[:q]}") %>
   <% end %>
-
-  <% if @results['apibarton']['total'] > 0 %>
-    <%= link_to("View all #{number_with_delimiter(@results['apibarton']['total'])} like this.",
-                "#{ENV['EDS_ALEPH_URI']}#{params[:q]}") %>
-  <% else %>
-    No results found.
-  <% end %>
-<% end %>
-
-<% if params[:target] == 'google' %>
-  <% @results['results'].each do |result| %>
-    <%= render partial: "result", locals: {result: result} %>
-  <% end %>
-
-  <% if @results['total'] > 0 %>
-    <%= link_to("View all #{number_with_delimiter(@results['total'])} like this.",
-                "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}") %>
-  <% else %>
-    No results found.
-  <% end %>
+<% else %>
+  No results found.
 <% end %>

--- a/test/models/normalize_eds_test.rb
+++ b/test/models/normalize_eds_test.rb
@@ -1,0 +1,112 @@
+require 'test_helper'
+
+class NormalizeEdsTest < ActiveSupport::TestCase
+  test 'normalized articles have expected title' do
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(
+        'Popcorn! : 100 sweet and savory recipes.',
+        query['results'].first.title.split[0...9].join(' ')
+      )
+    end
+  end
+
+  test 'normalized articles have expected year' do
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal('2013', query['results'].first.year)
+    end
+  end
+
+  test 'normalized articles have expected url' do
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(
+        'http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=edshlc&AN=edshlc.013683931-2',
+        query['results'].first.url
+      )
+    end
+  end
+
+  test 'normalized articles have expected type' do
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal('Book', query['results'].first.type)
+    end
+  end
+
+  test 'normalized articles have expected authors' do
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(
+        'Beckerman, Carol',
+        query['results'].first.authors.first
+      )
+      assert_equal(1, query['results'].first.authors.count)
+    end
+  end
+
+  test 'searches with no results do not error' do
+    VCR.use_cassette('no results',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcornandorangejuice', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(0, query['total'])
+    end
+  end
+
+  test 'Handles NoMethodError: undefined method [] for nil:NilClass' do
+    # https://rollbar.com/mit-libraries/bento/items/4/
+    # The issue was the commas being treated delimiters
+    VCR.use_cassette('rollbar4') do
+      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
+                   'Macmillan, 1968'
+      raw_query = SearchEds.new.search(searchterm, 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(77_612_346, query['total'])
+    end
+  end
+
+  test 'Handles NoMethodError: undefined method [] for nil:NilClass again' do
+    # https://rollbar.com/mit-libraries/bento/items/4/
+    # The issue was the commas being treated delimiters
+    VCR.use_cassette('rollbar4a') do
+      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
+                   'Macmillan, 1968'
+      raw_query = SearchEds.new.search(searchterm, 'apibarton')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(1_268_662, query['total'])
+    end
+  end
+
+  test 'cleaner rf harrington' do
+    VCR.use_cassette('rollbar4b') do
+      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
+                   'Macmillan, 1968'
+      assert_equal(
+        'R.+F.+Harrington+Field+computation+by+moment+methods.+Macmillan+1968',
+        SearchEds.new.send(:clean_term, searchterm)
+      )
+    end
+  end
+
+  test 'can handle missing years' do
+    VCR.use_cassette('rollbar8') do
+      searchterm = 'web of science'
+      raw_query = SearchEds.new.search(searchterm, 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query)
+      assert_equal(37_667_909, query['total'])
+      assert_nil(query['results'].first.year)
+    end
+  end
+end

--- a/test/models/normalize_google_test.rb
+++ b/test/models/normalize_google_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+require 'google/apis/customsearch_v1'
+
+class NormalizeGoogleTest < ActiveSupport::TestCase
+  test 'normalized results have expected title' do
+    VCR.use_cassette('valid google search and credentials') do
+      raw_query = SearchGoogle.new.search('endnote')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal(
+        'EndNote with LaTeX & BibTeX - EndNote at MIT',
+        query['results'].first.title.split[0...9].join(' ')
+      )
+    end
+  end
+
+  test 'normalized articles have expected year' do
+    VCR.use_cassette('valid google search and credentials') do
+      raw_query = SearchGoogle.new.search('endnote')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal('2016', query['results'].first.year)
+    end
+  end
+
+  test 'normalized articles with no dc.date.modified have blank year' do
+    VCR.use_cassette('valid google search and credentials') do
+      raw_query = SearchGoogle.new.search('endnote')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal(nil, query['results'][2].year)
+    end
+  end
+
+  test 'normalized articles have expected url' do
+    VCR.use_cassette('valid google search and credentials') do
+      raw_query = SearchGoogle.new.search('endnote')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal(
+        'http://libguides.mit.edu/c.php?g=176170&p=1158648',
+        query['results'].first.url
+      )
+    end
+  end
+
+  test 'normalized articles have expected type' do
+    VCR.use_cassette('valid google search and credentials') do
+      raw_query = SearchGoogle.new.search('endnote')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal('website', query['results'].first.type)
+    end
+  end
+
+  test 'searches with no results do not error' do
+    VCR.use_cassette('google no results') do
+      raw_query = SearchGoogle.new.search('asdffdsaasdffdsa')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal(0, query['total'])
+    end
+  end
+
+  test 'handles pages with no metadata' do
+    VCR.use_cassette('google no metadata') do
+      raw_query = SearchGoogle.new.search('weather patterns')
+      query = NormalizeGoogle.new.to_result(raw_query)
+      assert_equal(88, query['total'])
+    end
+  end
+end

--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -5,7 +5,7 @@ class SearchEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
       query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal(39_479, query['apinoaleph']['total'])
+      assert_equal(Hash, query.class)
     end
   end
 
@@ -13,7 +13,7 @@ class SearchEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn non articles',
                      allow_playback_repeats: true) do
       query = SearchEds.new.search('popcorn', 'apibarton')
-      assert_equal(79, query['apibarton']['total'])
+      assert_equal(Hash, query.class)
     end
   end
 
@@ -21,106 +21,6 @@ class SearchEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('invalid credentials') do
       query = SearchEds.new.search('popcorn', 'apibarton')
       assert_equal('invalid credentials', query)
-    end
-  end
-
-  test 'normalized articles have expected title' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal(
-        'Popcorn! : 100 sweet and savory recipes.',
-        query['apinoaleph']['results'].first.title.split[0...9].join(' ')
-      )
-    end
-  end
-
-  test 'normalized articles have expected year' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal('2013', query['apinoaleph']['results'].first.year)
-    end
-  end
-
-  test 'normalized articles have expected url' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal(
-        'http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=edshlc&AN=edshlc.013683931-2',
-        query['apinoaleph']['results'].first.url
-      )
-    end
-  end
-
-  test 'normalized articles have expected type' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal('Book', query['apinoaleph']['results'].first.type)
-    end
-  end
-
-  test 'normalized articles have expected authors' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
-      assert_equal(
-        'Beckerman, Carol',
-        query['apinoaleph']['results'].first.authors.first
-      )
-      assert_equal(1, query['apinoaleph']['results'].first.authors.count)
-    end
-  end
-
-  test 'searches with no results do not error' do
-    VCR.use_cassette('no results',
-                     allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcornandorangejuice', 'apinoaleph')
-      assert_equal(0, query['apinoaleph']['total'])
-    end
-  end
-
-  test 'Handles NoMethodError: undefined method [] for nil:NilClass' do
-    # https://rollbar.com/mit-libraries/bento/items/4/
-    # The issue was the commas being treated delimiters
-    VCR.use_cassette('rollbar4') do
-      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
-                   'Macmillan, 1968'
-      query = SearchEds.new.search(searchterm, 'apinoaleph')
-      assert_equal(77_612_346, query['apinoaleph']['total'])
-    end
-  end
-
-  test 'Handles NoMethodError: undefined method [] for nil:NilClass again' do
-    # https://rollbar.com/mit-libraries/bento/items/4/
-    # The issue was the commas being treated delimiters
-    VCR.use_cassette('rollbar4a') do
-      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
-                   'Macmillan, 1968'
-      query = SearchEds.new.search(searchterm, 'apibarton')
-      assert_equal(1_268_662, query['apibarton']['total'])
-    end
-  end
-
-  test 'cleaner rf harrington' do
-    VCR.use_cassette('rollbar4b') do
-      searchterm = 'R. F. Harrington, Field computation by moment methods. '\
-                   'Macmillan, 1968'
-      assert_equal(
-        'R.+F.+Harrington+Field+computation+by+moment+methods.+Macmillan+1968',
-        SearchEds.new.send(:clean_term, searchterm)
-      )
-    end
-  end
-
-  test 'can handle missing years' do
-    VCR.use_cassette('rollbar8') do
-      searchterm = 'web of science'
-      query = SearchEds.new.search(searchterm, 'apinoaleph')
-      assert_equal(37_667_909, query['apinoaleph']['total'])
-      assert_nil(query['apinoaleph']['results'].first.year)
     end
   end
 end

--- a/test/models/search_google_test.rb
+++ b/test/models/search_google_test.rb
@@ -4,8 +4,8 @@ require 'google/apis/customsearch_v1'
 class SearchGoogleTest < ActiveSupport::TestCase
   test 'valid google search with valid credentials returns results' do
     VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal(1610, query['total'])
+      raw_query = SearchGoogle.new.search('endnote')
+      assert_equal('customsearch#search', raw_query.kind)
     end
   end
 
@@ -15,61 +15,6 @@ class SearchGoogleTest < ActiveSupport::TestCase
         SearchGoogle.new.search('endnote')
       end
       assert_equal('keyInvalid: Bad Request', msg.message)
-    end
-  end
-
-  test 'normalized results have expected title' do
-    VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal(
-        'EndNote with LaTeX & BibTeX - EndNote at MIT',
-        query['results'].first.title.split[0...9].join(' ')
-      )
-    end
-  end
-
-  test 'normalized articles have expected year' do
-    VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal('2016', query['results'].first.year)
-    end
-  end
-
-  test 'normalized articles with no dc.date.modified have blank year' do
-    VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal(nil, query['results'][2].year)
-    end
-  end
-
-  test 'normalized articles have expected url' do
-    VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal(
-        'http://libguides.mit.edu/c.php?g=176170&p=1158648',
-        query['results'].first.url
-      )
-    end
-  end
-
-  test 'normalized articles have expected type' do
-    VCR.use_cassette('valid google search and credentials') do
-      query = SearchGoogle.new.search('endnote')
-      assert_equal('website', query['results'].first.type)
-    end
-  end
-
-  test 'searches with no results do not error' do
-    VCR.use_cassette('google no results') do
-      query = SearchGoogle.new.search('asdffdsaasdffdsa')
-      assert_equal(0, query['total'])
-    end
-  end
-
-  test 'handles pages with no metadata' do
-    VCR.use_cassette('google no metadata') do
-      query = SearchGoogle.new.search('weather patterns')
-      assert_equal(88, query['total'])
     end
   end
 end


### PR DESCRIPTION
The search classes were getting a bit complicated because they were
concerned with both searching and normalizing. Switching to normalizer
classes allows each class to focus on a single concern.