### PR TITLE
[WIP] First stab at recording interaction events

### DIFF
--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -1,2 +1,14 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
+
+function TrackLinks( element ) {
+  $( element ).click( function( e ) {
+    fields = {
+      hitType: 'event',
+      eventCategory: 'Bento',
+      eventAction: $( this ).parents( '.region' ).data( 'region' ),
+      eventLabel: e.target.text
+    };
+    ga( 'send', fields );
+  });
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,6 +41,12 @@
 
       ga('create', '<%= ENV['GOOGLE_ANALYTICS'] %>', 'auto');
       ga('send', 'pageview');
+
+      // Interaction tracking
+      $(document).ready(function(e) {
+        TrackLinks( $( '.region a' ) );
+      });
+
     </script>
     <% end %>
   </head>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="col-sm-4">
     <h2>Articles and Stuff</h2>
-    <div id="articles_content">
+    <div id="articles_content" class="region" data-region="articles">
       Loading results...
       <i class="fa fa-spinner fa-spin"></i>
     </div>
@@ -11,7 +11,7 @@
 
   <div class="col-sm-4">
     <h2>Books and Stuff</h2>
-    <div id="books_content">
+    <div id="books_content" class="region" data-region="books">
       Loading results...
       <i class="fa fa-spinner fa-spin"></i>
     </div>
@@ -19,7 +19,7 @@
 
   <div class="col-sm-4">
     <h2>Website and Guides</h2>
-    <div id="website_content">
+    <div id="website_content" class="region" data-region="website">
       Loading results...
       <i class="fa fa-spinner fa-spin"></i>
     </div>
@@ -28,7 +28,7 @@
 
 <hr />
 
-<div class="row">
+<div class="row region" data-region="other">
   <div class="col-sm-12">
     <h2>Not finding what you're looking for? Try these other tools:</h2>
     <dl>
@@ -46,9 +46,15 @@
 </div>
 
 <script>
-  $('#articles_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=articles")
+  $('#articles_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=articles", function() {
+    TrackLinks( $( this ).find( 'a' ) );
+  });
 
-  $('#books_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=books")
+  $('#books_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=books", function() {
+    TrackLinks( $( this ).find( 'a' ) );
+  });
 
-  $('#website_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=google")
+  $('#website_content').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=google", function() {
+    TrackLinks( $( this ).find( 'a' ) );
+  });
 </script>


### PR DESCRIPTION
This sets up event tracking when the user clicks on `a` tags in one of four defined regions: the three bento results areas, and the "other tools" area. What regions we focus on are obviously negotiable, as are how we call the listener in the first place.

If you look at the test discovery profile within GA, you'll see what events are being received.

I'd like to hear from @JPrevost and @szendeh about the technical side of this. The decision about whether to track this, or what to record at all, is probably something that should happen in Basecamp.

When merged, this would close #43 