### PR TITLE
Implements rudimentary summary bar

### DIFF
--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -12,3 +12,8 @@ function TrackLinks( element ) {
     ga( 'send', fields );
   });
 }
+
+function ReportSummary( category, count ) {
+  count = ( typeof count !== 'undefined' ) ? count : 0;
+  $( '.bento-summary-list li[data-region="' + category + '"] .count' ).html( count );
+}

--- a/app/assets/stylesheets/bento.css
+++ b/app/assets/stylesheets/bento.css
@@ -9,3 +9,30 @@
 .bento-year {
   color: gray;
 }
+
+.bento-summary h3 {
+  display: inline-block;
+}
+
+.bento-summary ul {
+  display: inline-block;
+  padding-left: 0;
+}
+
+.bento-summary li {
+  display: inline-block;
+  padding-left: 1em;
+}
+
+.bento-summary li .count {
+  float: right;
+  padding-left: 0.25em;
+}
+
+.bento-summary li .count:before {
+  content: '(';
+}
+
+.bento-summary li .count:after {
+  content: ')';
+}

--- a/app/views/search/_trigger_search.html.erb
+++ b/app/views/search/_trigger_search.html.erb
@@ -1,3 +1,4 @@
 $('#<%= id %>').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=<%= target %>", function() {
   TrackLinks( $( this ).find( 'a' ) );
+  ReportSummary( '<%= target %>', $( this ).find('[data-count]').data('count') );
 });

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -1,5 +1,26 @@
 <%= render partial: "form" %>
 
+<div class="row bento-summary">
+  <h3>Found</h3>
+  <ul class="bento-summary-list">
+    <% if box_enabled?('articles') %>
+      <li data-region="articles"><span class="count"><i class="fa fa-spinner fa-spin"></i></span> Articles</li>
+    <% end %>
+
+    <% if box_enabled?('books') %>
+      <li data-region="books"><span class="count"><i class="fa fa-spinner fa-spin"></i></span> Local Books</li>
+    <% end %>
+
+    <% if box_enabled?('worldcat') %>
+      <li data-region="worldcat"><span class="count"><i class="fa fa-spinner fa-spin"></i></span> Worldwide Books</li>
+    <% end %>
+
+    <% if box_enabled?('website') %>
+      <li data-region="google"><span class="count"><i class="fa fa-spinner fa-spin"></i></span> Webpages</li>
+    <% end %>
+  </ul>
+</div>
+
 <div class="row">
   <% if box_enabled?('articles') %>
     <%= render partial: "placeholders", locals: { heading: 'Articles and Stuff', id: 'articles_content'} %>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -6,19 +6,23 @@
   <% if params[:target] == 'google' %>
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} like this.",
-      "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}") %>
+      "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}",
+      data: {count: @results['total']}) %>
   <% elsif params[:target] == 'articles' %>
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} like this.",
-      "#{ENV['EDS_NO_ALEPH_URI']}#{params[:q]}") %>
+      "#{ENV['EDS_NO_ALEPH_URI']}#{params[:q]}",
+      data: {count: @results['total']}) %>
   <% elsif params[:target] == 'books' %>
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} like this.",
-      "#{ENV['EDS_ALEPH_URI']}#{params[:q]}") %>
+      "#{ENV['EDS_ALEPH_URI']}#{params[:q]}",
+      data: {count: @results['total']}) %>
   <% elsif params[:target] == 'worldcat' %>
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} like this.",
-      "http://mit.worldcat.org/search?qt=worldcat_org_all&&q=#{params[:q]}") %>
+      "http://mit.worldcat.org/search?qt=worldcat_org_all&&q=#{params[:q]}",
+      data: {count: @results['total']}) %>
   <% end %>
 <% else %>
   No results found.


### PR DESCRIPTION
I'm probably doing unholy things with the ReportSummary function, but this is a starting point. I still need to make the items an internal link to the actual panels.
## Markup and Accessibility

One question for @frrrances : the markup I'm using for the summary bar is:

```
<div class="row bento-summary">
  <h3>Found</h3>
  <ul class="bento-summary-list">
      <li data-region="articles"><span class="count">491</span> Articles</li>
      <li data-region="books"><span class="count">5</span> Local Books</li>
      <li data-region="worldcat"><span class="count">7</span> Worldwide Books</li>
  </ul>
</div>
```

which renders for now as 
![image](https://cloud.githubusercontent.com/assets/1403248/19809640/22625b8e-9cf8-11e6-80e6-8f1760d17b4e.png)

Some of this will be addressed in the UI work, but my thought here is to make screen reader output as simple as possible, like:

`List of three items. Item one 491 Articles. Item two 5 Local Books. Item three 7 Worldwide books` ... or some such - which is why I put the parentheses in via CSS rather than as characters.
## Application flow

@JPrevost the hope here is to populate each item in the summary bar as it comes back from the tool - rather than needing to wait until the end. I used the same `if box_enabled?()` construct in bento.html.erb that we use to toggle the various panels, and wrote a simple function called by _trigger_search.html.erb that handles the population. The `ReportSummary` function defines a default value, since I noticed that null results come back unpopulated.

The last piece to point out is that I added a data attribute to the markup via `search.html.erb`. This is what the javascript looks for to populate the summary bar.
