### PR TITLE
Adds tests for normalized EDS data

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,6 +16,11 @@ class SearchController < ApplicationController
   private
 
   # Requests results from requested target
+  # NOTE: The cache keys used below use a combination of the api endpoint
+  # name, the search parameter, and today's date to allow us to cache calls
+  # for the current date without ever worrying about expiring caches.
+  # Instead, we'll rely on the cache itself to expire the oldest cached
+  # items when necessary.
   def search_results
     return unless valid_target?
     Rails.cache.fetch("#{params[:target]}_#{strip_q}_#{today}") do
@@ -38,11 +43,6 @@ class SearchController < ApplicationController
     Time.zone.today.strftime('%Y%m%d')
   end
 
-  # NOTE: The cache keys used below use a combination of the api endpoint
-  # name, the search parameter, and today's date to allow us to cache calls
-  # for the current date without ever worrying about expiring caches.
-  # Instead, we'll rely on the cache itself to expire the oldest cached
-  # items when necessary.
   def search_target
     if params[:target] == 'google'
       search_google

--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -13,20 +13,22 @@ class NormalizeEdsBooks
     copy(holdings(record))&.map { |l| [l['Sublocation'], l['ShelfLocator']] }
   end
 
-  def holdings(record)
-    record['Holdings']&.map { |h| h['HoldingSimple'] }
-  end
-
-  def copy(holdings)
-    holdings&.map { |c| c['CopyInformationList'] }&.flatten
-  end
-
   def publisher(record)
   end
 
   def thumbnail(record)
     return unless record['ImageInfo']
     record['ImageInfo'].select { |i| i['Size'] == 'thumb' }&.first['Target']
+  end
+
+  private
+
+  def holdings(record)
+    record['Holdings']&.map { |h| h['HoldingSimple'] }
+  end
+
+  def copy(holdings)
+    holdings&.map { |c| c['CopyInformationList'] }&.flatten
   end
 
   def bibrecord(record)

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -1,0 +1,92 @@
+require 'test_helper'
+
+class NormalizeEdsArticlesTest < ActiveSupport::TestCase
+  def popcorn_articles
+    VCR.use_cassette('popcorn articles',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      NormalizeEds.new.to_result(raw_query, 'articles')
+    end
+  end
+
+  test 'normalized articles have expected title' do
+    assert_equal(
+      'History of northern corn leaf blight disease in the',
+      popcorn_articles['results'][0].title.split[0...9].join(' ')
+    )
+  end
+
+  test 'normalized articles have expected year' do
+    assert_equal('2016', popcorn_articles['results'][0].year)
+  end
+
+  test 'normalized articles have expected url eds provided sfx link' do
+    assert_equal(
+      'https://sfx.mit.edu/sfx_local?rfr_id=info%3Asid%2FMIT.BENTO&rft.au=Moreira+Ribeiro%2C+Rodrigo%3Bdo+Amaral+J%C3%BAnior%2C+Ant%C3%B4nio+Teixeira%3BFerreira+Pena%2C+Guilherme%3BVivas%2C+Marcelo%3BNascimento+Kurosawa%2C+Railan%3BAzeredo+Gon%C3%A7alves%2C+Leandro+Sim%C3%B5es&rft.issue=4&rft.jtitle=Acta+Scientiarum%3A+Agronomy&rft.volume=38&rft.year=2016&rft_id=info%3Adoi%2F10.4025%2Factasciagron.v38i4.30573',
+      popcorn_articles['results'][0].url
+    )
+  end
+
+  test 'normalized articles have generated sfx link when not in eds' do
+    assert_equal(
+      'https://sfx.mit.edu/sfx_local?genre=article&isbn=&issn=07335210&title=Journal%20of%20Cereal%20Science&volume=69&issue=&date=20160501&atitle=Sensory%20and%20nutritional%20evaluation%20of%20popcorn%20kernels%20with%20yellow,%20white%20and%20red%20pericarps%20expanded%20in%20different%20ways&aulast=Paraginski,%20Ricardo%20Tadeu&spage=383&sid=EBSCO:ScienceDirect&pid=%3Cauthors%3EParaginski,%20Ricardo%20Tadeu%3C/authors%3E%3Cui%3ES0733521016300753%3C/ui%3E%3Cdate%3E20160501%3C/date%3E%3Cdb%3EScienceDirect%3C/db%3E&rfr_id=info:sid/MIT.BENTO',
+      popcorn_articles['results'][1].url
+    )
+  end
+
+  test 'normalized articles have expected type' do
+    assert_equal('Academic Journal', popcorn_articles['results'][0].type)
+  end
+
+  test 'normalized articles have expected authors' do
+    assert_equal(
+      'Moreira Ribeiro, Rodrigo',
+      popcorn_articles['results'].first.authors.first
+    )
+    assert_equal(6, popcorn_articles['results'][0].authors.count)
+  end
+
+  test 'normalized articles can handle no authors' do
+    VCR.use_cassette('no article authors',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('orange', 'apinoaleph')
+      query = NormalizeEds.new.to_result(raw_query, 'articles')
+      assert_nil(query['results'][0].authors)
+    end
+  end
+
+  test 'normalized articles have expected availability' do
+    skip('need to determine logic to how this will work without misleading')
+  end
+
+  test 'normalized articles have expected citation' do
+    assert_equal('volume 38 issue 4', popcorn_articles['results'][0].citation)
+    assert_equal('volume 69', popcorn_articles['results'][1].citation)
+    assert_equal('volume 6', popcorn_articles['results'][2].citation)
+  end
+
+  test 'normalized articles have expected in' do
+    assert_equal(
+      'Acta Scientiarum: Agronomy',
+      popcorn_articles['results'][0].in
+    )
+    assert_equal('Journal of Cereal Science', popcorn_articles['results'][1].in)
+    assert_equal('Procedia Food Science', popcorn_articles['results'][2].in)
+  end
+
+  test 'normalized articles do not have subjects' do
+    assert_nil(popcorn_articles['results'][0].subjects)
+  end
+
+  test 'normalized articles do not have location' do
+    assert_nil(popcorn_articles['results'][0].location)
+  end
+
+  test 'normalized articles do not have publisher' do
+    assert_nil(popcorn_articles['results'][0].publisher)
+  end
+
+  test 'normalized articles do not have thumbnail' do
+    assert_nil(popcorn_articles['results'][0].thumbnail)
+  end
+end

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class NormalizeEdsBooksTest < ActiveSupport::TestCase
+  def popcorn_books
+    VCR.use_cassette('popcorn books',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('popcorn', 'apibarton')
+      NormalizeEds.new.to_result(raw_query, 'books')
+    end
+  end
+
+  test 'normalized books have expected title' do
+    assert_equal(
+      "Popcorn : fifty years of rock 'n' roll movies.",
+      popcorn_books['results'].first.title
+    )
+  end
+
+  test 'normalized books have expected link' do
+    assert_equal(
+      'http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001739356',
+      popcorn_books['results'].first.url
+    )
+  end
+
+  test 'normalized books have expected authors' do
+    assert_equal(['Mulholland, Garry'], popcorn_books['results'].first.authors)
+  end
+
+  test 'normalized books have expected multiple authors' do
+    VCR.use_cassette('multiple book authors',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('vonnegut', 'apibarton')
+      query = NormalizeEds.new.to_result(raw_query, 'books')
+      assert_equal(
+        ['Vonnegut, Kurt', 'Wakefield, Dan'],
+        query['results'][0].authors
+      )
+    end
+  end
+
+  test 'normalized books can handle no authors' do
+    VCR.use_cassette('no book authors',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('orange', 'apibarton')
+      query = NormalizeEds.new.to_result(raw_query, 'books')
+      assert_nil(query['results'][0].authors)
+    end
+  end
+
+  test 'normalized books have expected year' do
+    assert_equal('2010', popcorn_books['results'].first.year)
+  end
+
+  test 'normalized books have expected type' do
+    assert_equal('Book', popcorn_books['results'][0].type)
+  end
+
+  test 'normalized books have expected availability' do
+    skip('need to determine logic to how this will work without misleading')
+  end
+
+  test 'normalized books have expected subjects' do
+    assert_equal(
+      ['Rock films -- History and criticism'],
+      popcorn_books['results'][0].subjects
+    )
+  end
+
+  test 'normalized books can handle no subjects' do
+    assert_nil(popcorn_books['results'][1].subjects)
+  end
+
+  test 'normalized books can handle multiple subjects' do
+    VCR.use_cassette('multiple book subjects',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('orange', 'apibarton')
+      query = NormalizeEds.new.to_result(raw_query, 'books')
+      assert_equal(4, query['results'][1].subjects.count)
+    end
+  end
+
+  test 'normalized books have expected location' do
+    assert_equal(
+      [['Hayden Library - Stacks', 'PN1995.9.M86 M855 2010']],
+      popcorn_books['results'].first.location
+    )
+  end
+
+  test 'normalized books can have multiple locations' do
+    assert_equal(4, popcorn_books['results'][1].location.count)
+  end
+
+  test 'normalized books can have no locations' do
+    VCR.use_cassette('multiple book subjects',
+                     allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search('orange', 'apibarton')
+      query = NormalizeEds.new.to_result(raw_query, 'books')
+      assert_nil(query['results'][1].location)
+    end
+  end
+
+  test 'normalized books have expected publisher' do
+    skip('eds data does not provide this data')
+  end
+
+  test 'normalized books have expected thumbnail' do
+    assert_equal(
+      'http://contentcafe2.btol.com/ContentCafe/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9780752889351',
+      popcorn_books['results'][0].thumbnail
+    )
+  end
+
+  test 'normalized books can have no thumbnail' do
+    assert_nil(popcorn_books['results'][1].thumbnail)
+  end
+
+  test 'normalized books do not have citation' do
+    assert_nil(popcorn_books['results'][0].citation)
+  end
+
+  test 'normalized books do not have in' do
+    assert_nil(popcorn_books['results'][0].in)
+  end
+end

--- a/test/models/normalize_eds_test.rb
+++ b/test/models/normalize_eds_test.rb
@@ -1,61 +1,6 @@
 require 'test_helper'
 
 class NormalizeEdsTest < ActiveSupport::TestCase
-  test 'normalized articles have expected title' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
-      assert_equal(
-        'History of northern corn leaf blight disease in the',
-        query['results'].first.title.split[0...9].join(' ')
-      )
-    end
-  end
-
-  test 'normalized articles have expected year' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
-      assert_equal('2016', query['results'].first.year)
-    end
-  end
-
-  test 'normalized articles have expected url' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
-      assert_equal(
-        'https://sfx.mit.edu/sfx_local?rfr_id=info%3Asid%2FMIT.BENTO&rft.au=Moreira+Ribeiro%2C+Rodrigo%3Bdo+Amaral+J%C3%BAnior%2C+Ant%C3%B4nio+Teixeira%3BFerreira+Pena%2C+Guilherme%3BVivas%2C+Marcelo%3BNascimento+Kurosawa%2C+Railan%3BAzeredo+Gon%C3%A7alves%2C+Leandro+Sim%C3%B5es&rft.issue=4&rft.jtitle=Acta+Scientiarum%3A+Agronomy&rft.volume=38&rft.year=2016&rft_id=info%3Adoi%2F10.4025%2Factasciagron.v38i4.30573',
-        query['results'].first.url
-      )
-    end
-  end
-
-  test 'normalized articles have expected type' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
-      assert_equal('Academic Journal', query['results'].first.type)
-    end
-  end
-
-  test 'normalized articles have expected authors' do
-    VCR.use_cassette('popcorn articles',
-                     allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
-      assert_equal(
-        'Moreira Ribeiro, Rodrigo',
-        query['results'].first.authors.first
-      )
-      assert_equal(6, query['results'].first.authors.count)
-    end
-  end
-
   test 'searches with no results do not error' do
     VCR.use_cassette('no results',
                      allow_playback_repeats: true) do

--- a/test/vcr_cassettes/multiple_book_authors.yml
+++ b/test/vcr_cassettes/multiple_book_authors.yml
@@ -1,0 +1,265 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:15:20 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:15:21 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 87d72f6b-465c-4bc2-b9b7-7131bf62ce67
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:15:21 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:15:21 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=vonnegut&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '10002'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 398bb32a-23de-48ce-9cfc-b0ccff792da3
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:15:21 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,vonnegut&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"vonnegut"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":136,"TotalSearchTime":444,"Databases":[{"Id":"ir00145a","Label":"MIT
+        DOME for Discovery","Status":"0","Hits":0},{"Id":"cat01763a","Label":"MIT
+        Course Reserves","Status":"0","Hits":1},{"Id":"cat01875a","Label":"MIT Test
+        Catalog","Status":"0","Hits":135}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.002129878","RelevancyScore":"2315","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.002129878","ImageInfo":[{"Size":"thumb","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9780385343756"},{"Size":"medium","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9780385343756"}],"CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/002129878?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Kurt
+        Vonnegut : letters \/ edited and with an introduction by Dan Wakefield."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Vonnegut%2C+Kurt%22&quot;&gt;Vonnegut,
+        Kurt&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book"},{"Name":"SubjectPerson","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vonnegut%2C+Kurt+--+Correspondence%22&quot;&gt;Vonnegut,
+        Kurt -- Correspondence&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Summary:
+        A compilation of personal correspondence written over a sixty-year period
+        offers insight into the iconic American author&#39;s literary personality,
+        his experiences as a German POW, his struggles with fame, and the inspirations
+        for his famous books."},{"Name":"Author","Label":"Other Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Wakefield%2C+Dan%22&quot;&gt;Wakefield,
+        Dan&lt;\/searchLink&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Vonnegut,
+        Kurt -- Correspondence","Type":"general"}],"Titles":[{"TitleFull":"Kurt Vonnegut
+        : letters.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Vonnegut,
+        Kurt"}}},{"PersonEntity":{"Name":{"NameFull":"Wakefield, Dan"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2012"}],"Identifiers":[{"Type":"isbn-print","Value":"9780385343756"},{"Type":"isbn-print","Value":"0385343752"},{"Type":"isbn-print","Value":"9780345535399"},{"Type":"isbn-print","Value":"0345535391"}],"Titles":[{"TitleFull":"Kurt
+        Vonnegut : letters \/ edited and with an introduction by Dan Wakefield.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"PS3572.O5 Z48 2012"}]}}]},{"ResultId":2,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.002035762","RelevancyScore":"2310","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.002035762","ImageInfo":[{"Size":"thumb","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9781612190907"},{"Size":"medium","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9781612190907"}],"CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/002035762?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Kurt
+        Vonnegut : the last interview and other conversations \/ [by Kurt Vonnegut]
+        ; edited by Tom McCartan."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Vonnegut%2C+Kurt%22&quot;&gt;Vonnegut,
+        Kurt&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Interview%22&quot;&gt;Interview&lt;\/searchLink&gt;"},{"Name":"SubjectPerson","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vonnegut%2C+Kurt+--+Interviews%22&quot;&gt;Vonnegut,
+        Kurt -- Interviews&lt;\/searchLink&gt;"},{"Name":"Author","Label":"Other Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22McCartan%2C+Tom%22&quot;&gt;McCartan,
+        Tom&lt;\/searchLink&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Vonnegut,
+        Kurt -- Interviews","Type":"general"},{"SubjectFull":"Interview","Type":"general"}],"Titles":[{"TitleFull":"Kurt
+        Vonnegut : the last interview and other conversations.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Vonnegut,
+        Kurt"}}},{"PersonEntity":{"Name":{"NameFull":"McCartan, Tom"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2011"}],"Identifiers":[{"Type":"isbn-print","Value":"9781612190907"},{"Type":"isbn-print","Value":"1612190901"}],"Titles":[{"TitleFull":"Kurt
+        Vonnegut : the last interview and other conversations \/ [by Kurt Vonnegut]
+        ; edited by Tom McCartan.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"PS3572.O5 Z754 2011"}]}}]},{"ResultId":3,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.002240168","RelevancyScore":"2272","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.002240168","ImageInfo":[{"Size":"thumb","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9781580933773"},{"Size":"medium","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9781580933773"}],"CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/002240168?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Kurt
+        Vonnegut Drawings \/ writings by Kurt Vonnegut ; introduction by Nanette Vonnegut
+        ; essay by Peter Reed."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Vonnegut%2C+Kurt%22&quot;&gt;Vonnegut,
+        Kurt&lt;\/searchLink&gt;, author"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Drawing%2C+American%22&quot;&gt;Drawing,
+        American&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Authors+as+artists+--+United+States%22&quot;&gt;Authors as artists
+        -- United States&lt;\/searchLink&gt;"},{"Name":"SubjectPerson","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vonnegut%2C+Kurt%22&quot;&gt;Vonnegut,
+        Kurt&lt;\/searchLink&gt;"},{"Name":"Author","Label":"Other Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Vonnegut%2C+Nanette%22&quot;&gt;Vonnegut,
+        Nanette&lt;\/searchLink&gt;, 1954-, writer of introduction"},{"Name":"Author","Label":"Other
+        Authors","Group":"Au","Data":"&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Reed%2C+Peter+J%2E%22&quot;&gt;Reed,
+        Peter J.&lt;\/searchLink&gt;, 1935-, writer of added text"},{"Name":"TitleAlt","Label":"Other
+        Titles","Group":"TiAlt","Data":"Drawings."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Vonnegut,
+        Kurt","Type":"general"},{"SubjectFull":"Drawing, American","Type":"general"},{"SubjectFull":"Authors
+        as artists -- United States","Type":"general"}],"Titles":[{"TitleFull":"Kurt
+        Vonnegut Drawings.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Vonnegut,
+        Kurt"}}},{"PersonEntity":{"Name":{"NameFull":"Vonnegut, Nanette"}}},{"PersonEntity":{"Name":{"NameFull":"Reed,
+        Peter J."}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2014"}],"Identifiers":[{"Type":"isbn-print","Value":"9781580933773"},{"Type":"isbn-print","Value":"1580933777"}],"Titles":[{"TitleFull":"Kurt
+        Vonnegut Drawings \/ writings by Kurt Vonnegut ; introduction by Nanette Vonnegut
+        ; essay by Peter Reed.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Rotch
+        Library - Stacks","ShelfLocator":"NC139.V66 A4 2014"}]}}]}]}}}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:15:22 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - c35dacdf-aa44-493a-96b4-49213f64aa27
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:15:21 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:15:22 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/multiple_book_subjects.yml
+++ b/test/vcr_cassettes/multiple_book_subjects.yml
@@ -1,0 +1,299 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Dynatrace:
+      - PT=6098238;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      - PT=6098238;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      Dynatrace:
+      - PT=6098238;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      - PT=6098238;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:41:31 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:41:31 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 9df060e5-50dd-4fc7-bd19-417a7d59fe7e
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:41:30 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:41:31 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '11544'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - cbdcd00f-c730-4e76-8477-ace1804a15ae
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:41:31 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":66,"Databases":[{"Id":"ir00145a","Label":"MIT
+        DOME for Discovery","Status":"0","Hits":63},{"Id":"cat01763a","Label":"MIT
+        Course Reserves","Status":"0","Hits":3},{"Id":"cat01875a","Label":"MIT Test
+        Catalog","Status":"0","Hits":1793}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001528789","RelevancyScore":"2483","PubType":"Audio","PubTypeId":"audio"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001528789","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001528789?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Orange
+        [sound recording] \/ [the Jon Spencer Blues Explosion]."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Jon+Spencer+Blues+Explosion+%28Musical+group%29%22&quot;&gt;Jon
+        Spencer Blues Explosion (Musical group)&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Audio"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Rock+music+--+1991-2000%22&quot;&gt;Rock
+        music -- 1991-2000&lt;\/searchLink&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Rock
+        music -- 1991-2000","Type":"general"}],"Titles":[{"TitleFull":"Orange. [sound
+        recording]","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1994"}],"Titles":[{"TitleFull":"Orange
+        [sound recording] \/ [the Jon Spencer Blues Explosion].","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Lewis
+        Music Library - Media","ShelfLocator":"PhonCD P J69 ora CD"}]}}]},{"ResultId":2,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001302768","RelevancyScore":"2314","PubType":"eBook","PubTypeId":"ebook"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001302768","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001302768?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Agent
+        Orange [electronic resource] : persisting problems with communication of Ranch
+        Hand study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Chan%2C+Kwai-Cheung%22&quot;&gt;Chan,
+        Kwai-Cheung&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book;
+        Computer File; eBook"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Operation+Ranch+Hand%2C+1962-1971%22&quot;&gt;Operation
+        Ranch Hand, 1962-1971&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Agent+Orange+--+Health+aspects+--+Research+--+United+States%22&quot;&gt;Agent
+        Orange -- Health aspects -- Research -- United States&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vietnam+War%2C+1961-1975+--+Veterans+--+Health+risk+assessment+--+Research+--+United+States%22&quot;&gt;Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Veterans+--+Diseases+--+Research+--+United+States%22&quot;&gt;Veterans
+        -- Diseases -- Research -- United States&lt;\/searchLink&gt;"},{"Name":"Author","Label":"Other
+        Authors","Group":"Au","Data":"&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22United+States%2E+General+Accounting+Office%2E%22&quot;&gt;United
+        States. General Accounting Office.&lt;\/searchLink&gt;"},{"Name":"URL","Label":"Online
+        Access","Group":"URL","Data":"&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/walter.mit.edu\/F\/?func=service-sfx&amp;doc_number=001302768&amp;line_number=0000&amp;service_type=RECORD&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access&lt;\/link&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Operation
+        Ranch Hand, 1962-1971","Type":"general"},{"SubjectFull":"Agent Orange -- Health
+        aspects -- Research -- United States","Type":"general"},{"SubjectFull":"Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States","Type":"general"},{"SubjectFull":"Veterans -- Diseases -- Research
+        -- United States","Type":"general"}],"Titles":[{"TitleFull":"Agent Orange.
+        [electronic resource] : persisting problems with communication of Ranch Hand
+        study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Chan,
+        Kwai-Cheung"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2000"}],"Titles":[{"TitleFull":"Agent
+        Orange [electronic resource] : persisting problems with communication of Ranch
+        Hand study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives.","Type":"main"}]}}]}}}},{"ResultId":3,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001038079","RelevancyScore":"2314","PubType":"eBook","PubTypeId":"ebook"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001038079","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001038079?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Agent
+        orange : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000 [microform]"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22United+States%2E+Congress%2E+House%2E+Committee+on+Government+Reform%2E+Subcommittee+on+National+Security%2C+Veterans+Affairs%2C+and+International+Relations%2E%22&quot;&gt;United
+        States. Congress. House. Committee on Government Reform. Subcommittee on National
+        Security, Veterans Affairs, and International Relations.&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book; eBook"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Operation+Ranch+Hand%2C+1962-1971%22&quot;&gt;Operation
+        Ranch Hand, 1962-1971&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Agent+Orange+--+Health+aspects+--+Research+--+United+States%22&quot;&gt;Agent
+        Orange -- Health aspects -- Research -- United States&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vietnam+War%2C+1961-1975+--+Veterans+--+Health+risk+assessment+--+Research+--+United+States%22&quot;&gt;Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Veterans+--+Diseases+--+Research+--+United+States%22&quot;&gt;Veterans
+        -- Diseases -- Research -- United States&lt;\/searchLink&gt;"},{"Name":"URL","Label":"Online
+        Access","Group":"URL","Data":"&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/owens.mit.edu\/sfx_test?url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi\/fmt:kev:mtx:ctx&amp;ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi\/enc:UTF-8&amp;rfr_id=info:sid\/ALEPH:MIT01&amp;856_url=http%3A%2F%2Fpurl.access.gpo.gov%2FGPO%2FLPS10469&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access - Text version:&lt;\/link&gt;&lt;br
+        \/&gt;&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/owens.mit.edu\/sfx_test?url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi\/fmt:kev:mtx:ctx&amp;ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi\/enc:UTF-8&amp;rfr_id=info:sid\/ALEPH:MIT01&amp;856_url=http%3A%2F%2Fpurl.access.gpo.gov%2FGPO%2FLPS10470&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access - PDF version: Adobe Acrobat
+        Reader required&lt;\/link&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Operation
+        Ranch Hand, 1962-1971","Type":"general"},{"SubjectFull":"Agent Orange -- Health
+        aspects -- Research -- United States","Type":"general"},{"SubjectFull":"Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States","Type":"general"},{"SubjectFull":"Veterans -- Diseases -- Research
+        -- United States","Type":"general"}],"Titles":[{"TitleFull":"Agent orange
+        : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000. [microform]","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2000"}],"Identifiers":[{"Type":"isbn-print","Value":"0160647908"}],"Titles":[{"TitleFull":"Agent
+        orange : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000 [microform]","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Dewey
+        Library - Microforms","ShelfLocator":"Y 4.G 74\/7:AG 3\/6 FICHE"}]}}]}]}}}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:41:31 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - df285bf6-7aae-495c-9fc0-00240912b220
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:41:30 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:41:31 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/no_article_authors.yml
+++ b/test/vcr_cassettes/no_article_authors.yml
@@ -1,0 +1,305 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 20:55:06 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Mon, 07 Nov 2016 20:55:07 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apinoaleph
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 4a2289df-0820-483e-bb57-dc9f78bb4cf0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 20:55:07 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version:
+  recorded_at: Mon, 07 Nov 2016 20:55:07 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '15574'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - c7604372-c614-469f-bf80-511b2f05d548
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 20:55:07 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":9842235,"TotalSearchTime":205,"Databases":[{"Id":"eric","Label":"ERIC","Status":"0","Hits":1036},{"Id":"bwh","Label":"","Status":"0","Hits":159325},{"Id":"egh","Label":"Environment
+        Index","Status":"0","Hits":10651},{"Id":"ecn","Label":"EconLit","Status":"0","Hits":1267},{"Id":"cmedm","Label":"MEDLINE","Status":"0","Hits":34384},{"Id":"ufh","Label":"Communication
+        & Mass Media Complete","Status":"0","Hits":7925},{"Id":"fyh","Label":"Women''s
+        Studies International","Status":"0","Hits":445},{"Id":"bth","Label":"Business
+        Source Complete","Status":"0","Hits":199285},{"Id":"lxh","Label":"Library,
+        Information Science & Technology Abstracts","Status":"0","Hits":1682},{"Id":"nih","Label":"The
+        Nation Archive","Status":"0","Hits":2616},{"Id":"mah","Label":"Music Index","Status":"0","Hits":1820},{"Id":"a9h","Label":"","Status":"0","Hits":311226},{"Id":"ahl","Label":"America:
+        History & Life","Status":"0","Hits":926},{"Id":"hia","Label":"Historical Abstracts","Status":"0","Hits":1011},{"Id":"8gh","Label":"GreenFILE","Status":"0","Hits":2364},{"Id":"edsnbk","Label":"NewsBank","Status":"0","Hits":4206102},{"Id":"edslns","Label":"LexisNexis
+        U.S. Serial Set Digital Collection","Status":"0","Hits":12274},{"Id":"hev","Label":"European
+        Views of the Americas: 1493 to 1750","Status":"0","Hits":8},{"Id":"edsbl","Label":"British
+        Library Document Supply Centre Inside Serials & Conference Proceedings","Status":"0","Hits":14747},{"Id":"edsnba","Label":"NewsBank
+        - Archives","Status":"0","Hits":3192331},{"Id":"edsgpr","Label":"Government
+        Printing Office Catalog","Status":"0","Hits":609},{"Id":"edspvh","Label":"PsycCRITIQUES","Status":"0","Hits":64},{"Id":"edspdh","Label":"PsycARTICLES","Status":"0","Hits":2772},{"Id":"edspzh","Label":"PsycBOOKS","Status":"0","Hits":2572},{"Id":"edswah","Label":"Arts
+        & Humanities Citation Index","Status":"0","Hits":961},{"Id":"edselp","Label":"ScienceDirect","Status":"0","Hits":343545},{"Id":"edspia","Label":"DBPIA","Status":"0","Hits":574},{"Id":"edsoso","Label":"Oxford
+        Scholarship Online","Status":"0","Hits":93},{"Id":"edsoho","Label":"Oxford
+        Handbooks Online","Status":"0","Hits":16},{"Id":"edsilc","Label":"Informit
+        Literature & Culture Collection","Status":"0","Hits":1688},{"Id":"edsind","Label":"Informit
+        Indigenous Collection","Status":"0","Hits":403},{"Id":"edsibc","Label":"Informit
+        Business Collection","Status":"0","Hits":337},{"Id":"edsiec","Label":"Informit
+        Engineering Collection","Status":"0","Hits":856},{"Id":"edsihc","Label":"Informit
+        Health Collection","Status":"0","Hits":851},{"Id":"edsihs","Label":"Informit
+        Humanities & Social Sciences Collection","Status":"0","Hits":2693},{"Id":"edslex","Label":"LexisNexis
+        Academic: Law Reviews","Status":"0","Hits":17276},{"Id":"edsasp","Label":"Alexander
+        Street Press","Status":"0","Hits":2325},{"Id":"asx","Label":"","Status":"0","Hits":50806},{"Id":"edo","Label":"","Status":"0","Hits":78776},{"Id":"edb","Label":"","Status":"0","Hits":994455},{"Id":"edsjpi","Label":"Japanese
+        Periodical Index - 雑誌記事索引","Status":"0","Hits":391},{"Id":"edsjst","Label":"J-STAGE","Status":"0","Hits":2338},{"Id":"edsoao","Label":"Grove
+        Art Online","Status":"0","Hits":10},{"Id":"edsoad","Label":"American National
+        Biography Online","Status":"0","Hits":2},{"Id":"edsomo","Label":"Grove Music
+        Online","Status":"0","Hits":7},{"Id":"edsupe","Label":"Archive of European
+        Integration","Status":"0","Hits":785},{"Id":"edsupi","Label":"Industry Studies
+        Working Papers","Status":"0","Hits":0},{"Id":"edsupa","Label":"Aphasiology
+        Archive","Status":"0","Hits":7},{"Id":"edsupp","Label":"PhilSci Archive","Status":"0","Hits":29},{"Id":"edsuph","Label":"Minority
+        Health Archive","Status":"0","Hits":16},{"Id":"edsebo","Label":"Britannica
+        Online","Status":"0","Hits":1490},{"Id":"edsdoj","Label":"Directory of Open
+        Access Journals","Status":"0","Hits":738},{"Id":"edsper","Label":"Persée","Status":"0","Hits":910},{"Id":"edspio","Label":"Public
+        Information Online","Status":"0","Hits":7},{"Id":"edsers","Label":"eArticle","Status":"0","Hits":133},{"Id":"edsoap","Label":"OAPEN
+        Library","Status":"0","Hits":1},{"Id":"edsffr","Label":"Freedonia Focus Reports","Status":"0","Hits":0},{"Id":"edsabc","Label":"ABC-CLIO
+        Social Studies Databases, School Edition","Status":"0","Hits":40},{"Id":"edsaca","Label":"ABC-CLIO
+        Social Studies Databases, Academic Edition","Status":"0","Hits":38},{"Id":"edsssb","Label":"Books24x7","Status":"0","Hits":5},{"Id":"edshol","Label":"HeinOnline","Status":"0","Hits":13707},{"Id":"edsgsf","Label":"SOFIS
+        - Sozialwissenschaftliche Forschungsinformationen","Status":"0","Hits":5},{"Id":"edsgsl","Label":"SOLIS
+        - Sozialwissenschaftliche Literatur","Status":"0","Hits":131},{"Id":"edsocd","Label":"China\/Asia
+        On Demand","Status":"0","Hits":1170},{"Id":"edsble","Label":"British Library
+        EThOS","Status":"0","Hits":225},{"Id":"edswbo","Label":"World Book","Status":"0","Hits":730},{"Id":"edsbre","Label":"Bridgeman
+        Education","Status":"0","Hits":5658},{"Id":"edshld","Label":"Digital Access
+        to Scholarship at Harvard (DASH)","Status":"0","Hits":6},{"Id":"edsarx","Label":"arXiv","Status":"0","Hits":98},{"Id":"nlebk","Label":"eBook
+        Collection (EBSCOhost)","Status":"0","Hits":3140},{"Id":"edsmer","Label":"Mergent
+        Annual Reports Collection","Status":"0","Hits":45},{"Id":"hma","Label":"Humanities
+        Abstracts (H.W. Wilson)","Status":"0","Hits":941},{"Id":"hsr","Label":"Humanities
+        & Social Sciences Index Retrospective: 1907-1984 (H.W. Wilson)","Status":"0","Hits":288},{"Id":"air","Label":"Art
+        Index Retrospective (H.W. Wilson)","Status":"0","Hits":797},{"Id":"rga","Label":"Readers''
+        Guide Abstracts (H.W. Wilson)","Status":"0","Hits":6252},{"Id":"rgr","Label":"Readers''
+        Guide Retrospective: 1890-1982 (H.W. Wilson)","Status":"0","Hits":1333},{"Id":"edsman","Label":"Manuscriptorium
+        Digital Library","Status":"0","Hits":0},{"Id":"edskis","Label":"Korean Studies
+        Information Service System (KISS)","Status":"0","Hits":645},{"Id":"edsaan","Label":"Accessible
+        Archives","Status":"0","Hits":13154},{"Id":"edscrc","Label":"Credo Reference
+        Collections","Status":"0","Hits":28562},{"Id":"edszbw","Label":"ECONIS","Status":"0","Hits":436},{"Id":"nsm","Label":"Newswires","Status":"0","Hits":89909},{"Id":"bpr","Label":"Business
+        Periodicals Index Retrospective: 1913-1982 (H.W. Wilson)","Status":"0","Hits":1249},{"Id":"edshvr","Label":"Hoover''s
+        Company Profiles","Status":"0","Hits":227},{"Id":"edsjsr","Label":"JSTOR Journals","Status":"0","Hits":3903}]},"Data":{"RecordFormat":"EP
+        Display","Records":[{"ResultId":1,"Header":{"DbId":"edsoao","DbLabel":"Grove
+        Art Online","An":"oao.B00133316","RelevancyScore":"2184","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edsoao&AN=oao.B00133316","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=bookitem&isbn=9780199773787&issn=&title=Benezit
+        Dictionary of Artists&volume=&issue=&date=20060101&btitle=ORANGE NASSAU, William
+        V&aulast=&spage=&sid=EBSCO:Grove%20Art%20Online&pid=<authors><\/authors><ui>oao.B00133316<\/ui><date>20060101<\/date><db>Grove%20Art%20Online<\/db>","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"ORANGE
+        NASSAU, William V"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"Benezit
+        Dictionary of Artists, 2006"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22art%22&quot;&gt;art&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22biography%22&quot;&gt;biography&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Draughtsman%22&quot;&gt;Draughtsman&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22engraver%22&quot;&gt;engraver&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Dutch%22&quot;&gt;Dutch&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Subject
+        Person","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22William+V+ORANGE+NASSAU%22&quot;&gt;William
+        V ORANGE NASSAU&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Time","Group":"Su","Data":"Birth:
+        8 March 1748&lt;br \/&gt;Death: 9 April 1806"},{"Name":"URL","Label":"Availability","Group":"URL","Data":"http:\/\/www.oxfordartonline.com\/subscriber\/article\/benezit\/B00133316"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1093\/benz\/9780199773787.article.B00133316"}],"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"art","Type":"general"},{"SubjectFull":"biography","Type":"general"},{"SubjectFull":"Draughtsman","Type":"general"},{"SubjectFull":"engraver","Type":"general"},{"SubjectFull":"William
+        V ORANGE NASSAU","Type":"general"},{"SubjectFull":"Dutch","Type":"general"}],"Titles":[{"TitleFull":"ORANGE
+        NASSAU, William V","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2006"}],"Identifiers":[{"Type":"isbn-print","Value":"9780199773787"},{"Type":"isbn-print","Value":"9780199899913"}],"Titles":[{"TitleFull":"Benezit
+        Dictionary of Artists","Type":"main"}]}}]}}}},{"ResultId":2,"Header":{"DbId":"edsoao","DbLabel":"Grove
+        Art Online","An":"oao.B00133314","RelevancyScore":"2184","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edsoao&AN=oao.B00133314","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=bookitem&isbn=9780199773787&issn=&title=Benezit
+        Dictionary of Artists&volume=&issue=&date=20060101&btitle=ORANGE NASSAU, Frederique
+        Louise Wilhelmine&aulast=&spage=&sid=EBSCO:Grove%20Art%20Online&pid=<authors><\/authors><ui>oao.B00133314<\/ui><date>20060101<\/date><db>Grove%20Art%20Online<\/db>","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"ORANGE
+        NASSAU, Frederique Louise Wilhelmine"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"Benezit
+        Dictionary of Artists, 2006"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22art%22&quot;&gt;art&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22biography%22&quot;&gt;biography&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Painter%22&quot;&gt;Painter&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Dutch%22&quot;&gt;Dutch&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Subject
+        Person","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Frederique+Louise+Wilhelmine+ORANGE+NASSAU%22&quot;&gt;Frederique
+        Louise Wilhelmine ORANGE NASSAU&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Time","Group":"Su","Data":"Death:
+        12 October 1837"},{"Name":"URL","Label":"Availability","Group":"URL","Data":"http:\/\/www.oxfordartonline.com\/subscriber\/article\/benezit\/B00133314"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1093\/benz\/9780199773787.article.B00133314"}],"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"art","Type":"general"},{"SubjectFull":"biography","Type":"general"},{"SubjectFull":"Painter","Type":"general"},{"SubjectFull":"Frederique
+        Louise Wilhelmine ORANGE NASSAU","Type":"general"},{"SubjectFull":"Dutch","Type":"general"}],"Titles":[{"TitleFull":"ORANGE
+        NASSAU, Frederique Louise Wilhelmine","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2006"}],"Identifiers":[{"Type":"isbn-print","Value":"9780199773787"},{"Type":"isbn-print","Value":"9780199899913"}],"Titles":[{"TitleFull":"Benezit
+        Dictionary of Artists","Type":"main"}]}}]}}}},{"ResultId":3,"Header":{"DbId":"edsoao","DbLabel":"Grove
+        Art Online","An":"oao.B00133315","RelevancyScore":"2184","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edsoao&AN=oao.B00133315","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=bookitem&isbn=9780199773787&issn=&title=Benezit
+        Dictionary of Artists&volume=&issue=&date=20060101&btitle=ORANGE NASSAU, Frederique
+        Sophie Wilhelmine&aulast=&spage=&sid=EBSCO:Grove%20Art%20Online&pid=<authors><\/authors><ui>oao.B00133315<\/ui><date>20060101<\/date><db>Grove%20Art%20Online<\/db>","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"ORANGE
+        NASSAU, Frederique Sophie Wilhelmine"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"Benezit
+        Dictionary of Artists, 2006"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22art%22&quot;&gt;art&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22biography%22&quot;&gt;biography&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Painter%22&quot;&gt;Painter&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22miniaturist%22&quot;&gt;miniaturist&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Dutch%22&quot;&gt;Dutch&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Subject
+        Person","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Frederique+Sophie+Wilhelmine+ORANGE+NASSAU%22&quot;&gt;Frederique
+        Sophie Wilhelmine ORANGE NASSAU&lt;\/searchLink&gt;"},{"Name":"Subject","Label":"Time","Group":"Su","Data":"Birth:
+        7 August 1751&lt;br \/&gt;Death: 9 June 1820"},{"Name":"URL","Label":"Availability","Group":"URL","Data":"http:\/\/www.oxfordartonline.com\/subscriber\/article\/benezit\/B00133315"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1093\/benz\/9780199773787.article.B00133315"}],"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"art","Type":"general"},{"SubjectFull":"biography","Type":"general"},{"SubjectFull":"Painter","Type":"general"},{"SubjectFull":"miniaturist","Type":"general"},{"SubjectFull":"Frederique
+        Sophie Wilhelmine ORANGE NASSAU","Type":"general"},{"SubjectFull":"Dutch","Type":"general"}],"Titles":[{"TitleFull":"ORANGE
+        NASSAU, Frederique Sophie Wilhelmine","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2006"}],"Identifiers":[{"Type":"isbn-print","Value":"9780199773787"},{"Type":"isbn-print","Value":"9780199899913"}],"Titles":[{"TitleFull":"Benezit
+        Dictionary of Artists","Type":"main"}]}}]}}}}]}}}'
+    http_version:
+  recorded_at: Mon, 07 Nov 2016 20:55:07 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - ba8774d4-efb3-49d2-a840-d503d012b342
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 20:55:07 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version:
+  recorded_at: Mon, 07 Nov 2016 20:55:07 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/no_book_authors.yml
+++ b/test/vcr_cassettes/no_book_authors.yml
@@ -1,0 +1,300 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:18:48 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:18:48 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - f6746545-b72d-490c-aa99-e0bd0a749af6
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:18:48 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"40b2b479-6ebe-41ca-9d9f-3fdae688b46e.j8lW\/tif+ooM9Bh2VGWd1kfOIusYNey7DxoGPfvbWj8="}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:18:48 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '11545'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - d67057da-5095-4dfd-98cd-c89105a20460
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:18:48 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":131,"Databases":[{"Id":"ir00145a","Label":"MIT
+        DOME for Discovery","Status":"0","Hits":63},{"Id":"cat01763a","Label":"MIT
+        Course Reserves","Status":"0","Hits":3},{"Id":"cat01875a","Label":"MIT Test
+        Catalog","Status":"0","Hits":1793}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001528789","RelevancyScore":"2483","PubType":"Audio","PubTypeId":"audio"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001528789","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001528789?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Orange
+        [sound recording] \/ [the Jon Spencer Blues Explosion]."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Jon+Spencer+Blues+Explosion+%28Musical+group%29%22&quot;&gt;Jon
+        Spencer Blues Explosion (Musical group)&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Audio"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Rock+music+--+1991-2000%22&quot;&gt;Rock
+        music -- 1991-2000&lt;\/searchLink&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Rock
+        music -- 1991-2000","Type":"general"}],"Titles":[{"TitleFull":"Orange. [sound
+        recording]","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1994"}],"Titles":[{"TitleFull":"Orange
+        [sound recording] \/ [the Jon Spencer Blues Explosion].","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Lewis
+        Music Library - Media","ShelfLocator":"PhonCD P J69 ora CD"}]}}]},{"ResultId":2,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001302768","RelevancyScore":"2314","PubType":"eBook","PubTypeId":"ebook"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001302768","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001302768?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Agent
+        Orange [electronic resource] : persisting problems with communication of Ranch
+        Hand study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Chan%2C+Kwai-Cheung%22&quot;&gt;Chan,
+        Kwai-Cheung&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book;
+        Computer File; eBook"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Operation+Ranch+Hand%2C+1962-1971%22&quot;&gt;Operation
+        Ranch Hand, 1962-1971&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Agent+Orange+--+Health+aspects+--+Research+--+United+States%22&quot;&gt;Agent
+        Orange -- Health aspects -- Research -- United States&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vietnam+War%2C+1961-1975+--+Veterans+--+Health+risk+assessment+--+Research+--+United+States%22&quot;&gt;Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Veterans+--+Diseases+--+Research+--+United+States%22&quot;&gt;Veterans
+        -- Diseases -- Research -- United States&lt;\/searchLink&gt;"},{"Name":"Author","Label":"Other
+        Authors","Group":"Au","Data":"&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22United+States%2E+General+Accounting+Office%2E%22&quot;&gt;United
+        States. General Accounting Office.&lt;\/searchLink&gt;"},{"Name":"URL","Label":"Online
+        Access","Group":"URL","Data":"&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/walter.mit.edu\/F\/?func=service-sfx&amp;doc_number=001302768&amp;line_number=0000&amp;service_type=RECORD&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access&lt;\/link&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Operation
+        Ranch Hand, 1962-1971","Type":"general"},{"SubjectFull":"Agent Orange -- Health
+        aspects -- Research -- United States","Type":"general"},{"SubjectFull":"Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States","Type":"general"},{"SubjectFull":"Veterans -- Diseases -- Research
+        -- United States","Type":"general"}],"Titles":[{"TitleFull":"Agent Orange.
+        [electronic resource] : persisting problems with communication of Ranch Hand
+        study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Chan,
+        Kwai-Cheung"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2000"}],"Titles":[{"TitleFull":"Agent
+        Orange [electronic resource] : persisting problems with communication of Ranch
+        Hand study data and results : statement of Kwai-Cheung Chan, Director, Special
+        Studies and Evaluations, National Security and International Affairs Division,
+        before the Subcommittee on National Security, Veterans Affairs, and International
+        Relations, Committee on Government Reform, House of Representatives.","Type":"main"}]}}]}}}},{"ResultId":3,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001038079","RelevancyScore":"2314","PubType":"eBook","PubTypeId":"ebook"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001038079","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001038079?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Agent
+        orange : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000 [microform]"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22United+States%2E+Congress%2E+House%2E+Committee+on+Government+Reform%2E+Subcommittee+on+National+Security%2C+Veterans+Affairs%2C+and+International+Relations%2E%22&quot;&gt;United
+        States. Congress. House. Committee on Government Reform. Subcommittee on National
+        Security, Veterans Affairs, and International Relations.&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book; eBook"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Operation+Ranch+Hand%2C+1962-1971%22&quot;&gt;Operation
+        Ranch Hand, 1962-1971&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Agent+Orange+--+Health+aspects+--+Research+--+United+States%22&quot;&gt;Agent
+        Orange -- Health aspects -- Research -- United States&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Vietnam+War%2C+1961-1975+--+Veterans+--+Health+risk+assessment+--+Research+--+United+States%22&quot;&gt;Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Veterans+--+Diseases+--+Research+--+United+States%22&quot;&gt;Veterans
+        -- Diseases -- Research -- United States&lt;\/searchLink&gt;"},{"Name":"URL","Label":"Online
+        Access","Group":"URL","Data":"&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/owens.mit.edu\/sfx_test?url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi\/fmt:kev:mtx:ctx&amp;ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi\/enc:UTF-8&amp;rfr_id=info:sid\/ALEPH:MIT01&amp;856_url=http%3A%2F%2Fpurl.access.gpo.gov%2FGPO%2FLPS10469&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access - Text version:&lt;\/link&gt;&lt;br
+        \/&gt;&lt;link linkTarget=&quot;URL&quot; linkTerm=&quot;http:\/\/owens.mit.edu\/sfx_test?url_ver=Z39.88-2004&amp;url_ctx_fmt=infofi\/fmt:kev:mtx:ctx&amp;ctx_ver=Z39.88-2004&amp;ctx_enc=info:ofi\/enc:UTF-8&amp;rfr_id=info:sid\/ALEPH:MIT01&amp;856_url=http%3A%2F%2Fpurl.access.gpo.gov%2FGPO%2FLPS10470&quot;
+        linkWindow=&quot;_blank&quot;&gt;Online Access - PDF version: Adobe Acrobat
+        Reader required&lt;\/link&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Operation
+        Ranch Hand, 1962-1971","Type":"general"},{"SubjectFull":"Agent Orange -- Health
+        aspects -- Research -- United States","Type":"general"},{"SubjectFull":"Vietnam
+        War, 1961-1975 -- Veterans -- Health risk assessment -- Research -- United
+        States","Type":"general"},{"SubjectFull":"Veterans -- Diseases -- Research
+        -- United States","Type":"general"}],"Titles":[{"TitleFull":"Agent orange
+        : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000. [microform]","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2000"}],"Identifiers":[{"Type":"isbn-print","Value":"0160647908"}],"Titles":[{"TitleFull":"Agent
+        orange : status of the Air Force Ranch Hand study : hearing before the Subcommittee
+        on National Security, Veterans Affairs, and International Relations of the
+        Committee on Government Reform, House of Representatives, One Hundred Sixth
+        Congress, second session, March 15, 2000 [microform]","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Dewey
+        Library - Microforms","ShelfLocator":"Y 4.G 74\/7:AG 3\/6 FICHE"}]}}]}]}}}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:18:48 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=40b2b479-6ebe-41ca-9d9f-3fdae688b46e.j8lW/tif%20ooM9Bh2VGWd1kfOIusYNey7DxoGPfvbWj8=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '201'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Dynatrace:
+      - PT=37612898;PA=-829545830;SP=EDSAPI;PS=-1981931378
+      - PT=37612898;PA=-829545830;SP=EDSAPI;PS=-1981931378
+      Dynatrace:
+      - PT=37612898;PA=-829545830;SP=EDSAPI;PS=-1981931378
+      - PT=37612898;PA=-829545830;SP=EDSAPI;PS=-1981931378
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 644250a2-d7bd-4472-bd10-c760d87eca48
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:18:47 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"DetailedErrorDescription":"Session token received: 40b2b479-6ebe-41ca-9d9f-3fdae688b46e.j8lW\/tif
+        ooM9Bh2VGWd1kfOIusYNey7DxoGPfvbWj8= ","ErrorDescription":"Session Token Invalid","ErrorNumber":"109"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:18:48 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/popcorn_books.yml
+++ b/test/vcr_cassettes/popcorn_books.yml
@@ -1,0 +1,266 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Dynatrace:
+      - PT=6076380;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      - PT=6076380;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      Dynatrace:
+      - PT=6076380;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      - PT=6076380;PA=-1516597674;SP=EDSAPI;PS=-1981931378
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:10:12 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:10:13 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 95978555-e954-4a72-9f7b-9da1d9b8e6bb
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:10:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:10:13 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '8412'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 6e786314-799d-4f16-9bcb-d705ddc6a902
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:10:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,popcorn&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"popcorn"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":78,"TotalSearchTime":181,"Databases":[{"Id":"ir00145a","Label":"MIT
+        DOME for Discovery","Status":"0","Hits":1},{"Id":"cat01763a","Label":"MIT
+        Course Reserves","Status":"0","Hits":0},{"Id":"cat01875a","Label":"MIT Test
+        Catalog","Status":"0","Hits":77}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001739356","RelevancyScore":"2633","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001739356","ImageInfo":[{"Size":"thumb","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9780752889351"},{"Size":"medium","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9780752889351"}],"CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001739356?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Popcorn
+        : fifty years of rock &#39;n&#39; roll movies \/ Garry Mulholland."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Mulholland%2C+Garry%22&quot;&gt;Mulholland,
+        Garry&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Rock+films+--+History+and+criticism%22&quot;&gt;Rock
+        films -- History and criticism&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Review:
+        &quot;Popcorn is no straight-forward &#39;best-of&#39; list; rather it is
+        part serious critical appreciation, part celebration of perceived B-movie
+        trash. Garry Mulholland is equally at home deconstructing the likes of Performance,
+        Gimme Shelter and Jubilee as celebrating Grease, Footloose and Glitter. Along
+        the way, classics of the genre are revisited. Turkeys are disinterred. Forgotten
+        gems are dusted down and re-examined; cult classics unearthed for a new generation.&quot;
+        &quot;The main aim is to get to the essence of the film and why it matters
+        ... or perhaps doesn&#39;t. In doing so, Popcorn reminds the reader why they
+        might have entered the cinema in the first place. As with Mulholland&#39;s
+        previous books on singles and albums, and as with all great criticism, the
+        reader will unquestionably return to the source galvanised, searching out
+        old, new and classic films on DVD.&quot;--BOOK JACKET."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Rock
+        films -- History and criticism","Type":"general"}],"Titles":[{"TitleFull":"Popcorn
+        : fifty years of rock ''n'' roll movies.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Mulholland,
+        Garry"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2010"}],"Identifiers":[{"Type":"isbn-print","Value":"9780752889351"},{"Type":"isbn-print","Value":"0752889354"}],"Titles":[{"TitleFull":"Popcorn
+        : fifty years of rock ''n'' roll movies \/ Garry Mulholland.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"PN1995.9.M86 M855 2010"}]}}]},{"ResultId":2,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.001245816","RelevancyScore":"2147","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.001245816","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/001245816?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Popcorn
+        Moms : decoding representations of motherhood in American popular cinema,
+        1979-1989 \/ by Robin Schneider Hauck."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Hauck%2C+Robin+Schneider%22&quot;&gt;Hauck,
+        Robin Schneider&lt;\/searchLink&gt;, 1969-"},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book"},{"Name":"Author","Label":"Other Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Massachusetts+Institute+of+Technology%2E+Department+of+Comparative+Media+Studies%2E%22&quot;&gt;Massachusetts
+        Institute of Technology. Department of Comparative Media Studies.&lt;\/searchLink&gt;"},{"Name":"TitleAlt","Label":"Other
+        Titles","Group":"TiAlt","Data":"Decoding representations of motherhood in
+        American popular cinema, 1979-1989."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Titles":[{"TitleFull":"Popcorn
+        Moms : decoding representations of motherhood in American popular cinema,
+        1979-1989.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Hauck,
+        Robin Schneider"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1993"}],"Titles":[{"TitleFull":"Popcorn
+        Moms : decoding representations of motherhood in American popular cinema,
+        1979-1989 \/ by Robin Schneider Hauck.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Institute
+        Archives - Microforms","ShelfLocator":"Thesis CMS 2003 S.M. THESIS"},{"Sublocation":"Institute
+        Archives - Noncirculating Collection 3","ShelfLocator":"Thesis CMS 2003 S.M.
+        THESIS"},{"Sublocation":"Hayden Library - Humanities Microforms","ShelfLocator":"Thesis
+        CMS 2003 S.M. THESIS"},{"Sublocation":"Hayden Library - Stacks","ShelfLocator":"Thesis
+        CMS 2003 S.M. THESIS"}]}}]},{"ResultId":3,"Header":{"DbId":"cat01875a","DbLabel":"MIT
+        Test Catalog","An":"mittest.000346597","RelevancyScore":"2147","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat01875a&AN=mittest.000346597","CustomLinks":[{"Url":"https:\/\/walter.mit.edu\/item\/000346597?","Name":"MIT
+        Test catalog2 (copy of cat00916a) (cat01875a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Popcorn
+        Venus \/ Marjorie Rosen."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Rosen%2C+Marjorie%22&quot;&gt;Rosen,
+        Marjorie&lt;\/searchLink&gt;"},{"Name":"TypePub","Label":"Publication Type","Group":"TypPub","Data":"Book"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Women+in+motion+pictures%22&quot;&gt;Women
+        in motion pictures&lt;\/searchLink&gt;"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Women
+        in motion pictures","Type":"general"}],"Titles":[{"TitleFull":"Popcorn Venus.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Rosen,
+        Marjorie"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1974"}],"Identifiers":[{"Type":"isbn-print","Value":"0380001772"}],"Titles":[{"TitleFull":"Popcorn
+        Venus \/ Marjorie Rosen.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"PN1995.9.W6.R6 1974"}]}}]}]}}}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:10:13 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 70c0f068-37a0-4173-abbd-23b9d5dcd741
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Mon, 07 Nov 2016 18:10:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version: 
+  recorded_at: Mon, 07 Nov 2016 18:10:13 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Why:

* the code that normalizes EDS article and book content did not
  contain a comprehensive set of tests. The tests here should provide
  better assurance that we are handling edge cases as expected.

This change addresses the need by:

* Adding lots of tests.

Tickets associated with this work:

* https://mitlibraries.atlassian.net/browse/DI-93

Merged code this is testing was tracked by:

* https://github.com/MITLibraries/bento/pull/59
* https://mitlibraries.atlassian.net/browse/DI-72
* https://mitlibraries.atlassian.net/browse/DI-73