### PR TITLE
Updates encoding format for js triggered searches

### DIFF
--- a/app/views/search/_trigger_search.html.erb
+++ b/app/views/search/_trigger_search.html.erb
@@ -1,4 +1,4 @@
-$('#<%= id %>').load("/search/search?q=<%= URI.encode(params[:q]) %>&target=<%= target %>", function() {
+$('#<%= id %>').load("/search/search?q=<%= URI.encode_www_form_component(params[:q]) %>&target=<%= target %>", function() {
   TrackLinks( $( this ).find( 'a' ) );
   ReportSummary( '<%= target %>', $( this ).find('[data-count]').data('count') );
 });


### PR DESCRIPTION
Why:

* Searches with apostrophes were being redirected as having invalid
  search targets. https://mitlibraries.atlassian.net/browse/DI-61

This change addresses the need by:

* Switching to `URI.encode_www_form_component` prevents javascript from
  choking on the passed parameters. Previously, with `URI.encode`
  javascript would lose all values in the query string after an
  apostrophe, including the target parameter which was what was
  causing the problems.

* We don't have any full stack integration tests for this type of work
  where we do a full search in the UI, therefore no test was added which
  is obviously not ideal. As the UI matures, we'll likely add some full
  stack javascript-enabled tests to help ensure we don't have
  regressions on this type of bug.