### PR TITLE
Adds jumpstart search links for author and subject

### DIFF
--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -6,7 +6,13 @@ class NormalizeEdsBooks
   end
 
   def subjects(record)
-    bibrecord(record)['BibEntity']['Subjects']&.map { |s| s['SubjectFull'] }
+    bibrecord(record)['BibEntity']['Subjects']&.map do |s|
+      [s['SubjectFull'], subject_link(s['SubjectFull'])]
+    end
+  end
+
+  def subject_link(subject)
+    ENV['EDS_ALEPH_URI'] + URI.encode_www_form_component("DE \"#{subject}\"")
   end
 
   def location(record)

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,5 +1,5 @@
 <div class="wrap-result">
-  
+
   <% if result.type %>
     <p class="result-type"><%= result.type %></p>
   <% end %>
@@ -18,7 +18,7 @@
       <p class="result-authors">
         <% result.truncated_authors.each do |author| %>
         <span class="result-author">
-          <%= link_to(author, "#") unless author == "et al" %>
+          <%= link_to(author[0], author[1]) unless author == "et al" %>
           <%= author if author == "et al" %>
         </span>
         <% end %>
@@ -41,7 +41,9 @@
       <div class="result-subjectheadings">
         <ul class="list-subjects">
         <% result.subjects.each do |subject| %>
-          <li class="result-subjectheading"><%= link_to(subject, "#") %></li>
+          <li class="result-subjectheading">
+            <%= link_to(subject[0], subject[1]) %>
+          </li>
         <% end %>
         </ul>
       </div>
@@ -51,7 +53,9 @@
       <div class="result-local-locations">
         <ul class="list-local-locations">
         <% result.location.each do |location| %>
-          <li class="result-local-location"><%= location[0] %>: <%= location[1] %></li>
+          <li class="result-local-location">
+            <%= location[0] %>: <%= location[1] %>
+          </li>
         <% end %>
         </ul>
       </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   ENV['WORLDCAT_API_KEY'] = 'FAKE_WORLDCAT_KEY'
   ENV['ENABLED_BOXES'] = 'website,books,articles,worldcat'
   ENV['MAX_AUTHORS'] = '3'
+  ENV['EDS_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3D'
+  ENV['EDS_NO_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedsnoaleph%26profile%3Dedsnoaleph%26bquery%3D'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -41,9 +41,16 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
   test 'normalized articles have expected authors' do
     assert_equal(
       'Moreira Ribeiro, Rodrigo',
-      popcorn_articles['results'].first.authors.first
+      popcorn_articles['results'][0].authors[0][0]
     )
     assert_equal(6, popcorn_articles['results'][0].authors.count)
+  end
+
+  test 'normalized articles have expected author links' do
+    assert_equal(
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedsnoaleph%26profile%3Dedsnoaleph%26bquery%3DAU+%22Moreira+Ribeiro%2C+Rodrigo%22',
+      popcorn_articles['results'][0].authors[0][1]
+    )
   end
 
   test 'normalized articles can handle no authors' do

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -24,7 +24,14 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   end
 
   test 'normalized books have expected authors' do
-    assert_equal(['Mulholland, Garry'], popcorn_books['results'].first.authors)
+    assert_equal('Mulholland, Garry', popcorn_books['results'][0].authors[0][0])
+  end
+
+  test 'normalized books have expected author links' do
+    assert_equal(
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3DAU+%22Mulholland%2C+Garry%22',
+      popcorn_books['results'][0].authors[0][1]
+    )
   end
 
   test 'normalized books have expected multiple authors' do
@@ -34,7 +41,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal(
         ['Vonnegut, Kurt', 'Wakefield, Dan'],
-        query['results'][0].authors
+        query['results'][0].authors.map { |a| a[0] }
       )
     end
   end
@@ -62,8 +69,15 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
 
   test 'normalized books have expected subjects' do
     assert_equal(
-      ['Rock films -- History and criticism'],
-      popcorn_books['results'][0].subjects
+      'Rock films -- History and criticism',
+      popcorn_books['results'][0].subjects[0][0]
+    )
+  end
+
+  test 'normalized books have expected subject links' do
+    assert_equal(
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3DDE+%22Rock+films+--+History+and+criticism%22',
+      popcorn_books['results'][0].subjects[0][1]
     )
   end
 


### PR DESCRIPTION
What:

* This commit provides jumpstart links into appropriate EDS
  profiles to allow users to start searches for an author or
  subject they click on in the bento interface.

Why:

* Users may want to run searches on specific authors or subjects
  they find in our bento search in order to find more results
  that are similar or related.
* https://mitlibraries.atlassian.net/browse/DI-95
* https://mitlibraries.atlassian.net/browse/DI-111

How:

* The normalized authors will now contain an array of arrays. The inner
  arrays will be ['Author Name', 'Link to jumpstart search'].
* The work of creating appropriate links is done in the normalizer so
  we can keep the views as clean as possible and make the logic more
  easily testable with unit tests.
* Each EDS profile has an ENV that sets the base of the URL, we then
  follow the example we see in the EDS UI itself in which to search
  for an author from a record they do a keyword search for:
  `AU "author name"` so we append that to the base URL.
* For Subject searches we append: `DE "subject string"`.