### PR TITLE
Adds link to sfx for journals

### DIFF
--- a/app/models/normalize_eds_articles.rb
+++ b/app/models/normalize_eds_articles.rb
@@ -10,7 +10,7 @@ class NormalizeEdsArticles
     {
       'rft.au' => authors&.join(';'),
       'rft_id' => "info:doi/#{doi(record)}",
-      'rft.jtitle' => journal_title(record),
+      'rft.jtitle' => journal_title(record)[0],
       'rft.volume' => volume(record),
       'rft.issue' => issue(record),
       'rft.year' => year,
@@ -27,7 +27,12 @@ class NormalizeEdsArticles
   end
 
   def journal_title(record)
-    bibentity(record)['Titles'][0]['TitleFull'] if bibentity(record)['Titles']
+    return unless bibentity(record)['Titles']
+    [bibentity(record)['Titles'][0]['TitleFull'],
+     'https://sfx.mit.edu/sfx_local?' + 'rft.jtitle=' +
+       URI.encode_www_form_component(
+         bibentity(record)['Titles'][0]['TitleFull']
+       ) + '&rfr_id=info:sid/MIT.BENTO']
   end
 
   def numbering(record)

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -33,7 +33,7 @@
 
     <% if result.in %>
       <p class="result-pubinfo">
-        In <%= link_to(result.in, "#") %> <%= result.citation %> (<%= result.year %>)<br />
+        In <%= link_to(result.in[0], result.in[1]) %> <%= result.citation %> (<%= result.year %>)<br />
       </p>
     <% end %>
 

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -75,10 +75,18 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
   test 'normalized articles have expected in' do
     assert_equal(
       'Acta Scientiarum: Agronomy',
-      popcorn_articles['results'][0].in
+      popcorn_articles['results'][0].in[0]
     )
-    assert_equal('Journal of Cereal Science', popcorn_articles['results'][1].in)
-    assert_equal('Procedia Food Science', popcorn_articles['results'][2].in)
+    assert_equal('Journal of Cereal Science',
+                 popcorn_articles['results'][1].in[0])
+    assert_equal('Procedia Food Science', popcorn_articles['results'][2].in[0])
+  end
+
+  test 'normalized articles have expected in url' do
+    assert_equal(
+      'https://sfx.mit.edu/sfx_local?rft.jtitle=Acta+Scientiarum%3A+Agronomy&rfr_id=info:sid/MIT.BENTO',
+      popcorn_articles['results'][0].in[1]
+    )
   end
 
   test 'normalized articles do not have subjects' do


### PR DESCRIPTION
What:

* This commit provides links into SFX for journals in our
  articles search bento box

Why:

* Users may want to find more information about a journal rather
  than linking to the specific article we have returned in the
  search results
* https://mitlibraries.atlassian.net/browse/DI-112

How:

* The normalized `in` will now contain an array of Journal Title
  and sfx link, like `['Journal Title', 'link to SFX for Journal']`
* The work of creating appropriate links is done in the normalizer so
  we can keep the views as clean as possible and make the logic more
  easily testable with unit tests