### PR TITLE
Adds whatnot box and fixes relevance

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,12 @@
     "EDS_NO_ALEPH_URI": {
       "required": true
     },
+    "EDS_WHATNOT_PROFILE": {
+      "required": true
+    },
+    "EDS_WHATNOT_URI": {
+      "required": true
+    },
     "EDS_PASSWORD": {
       "required": true
     },

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -35,7 +35,7 @@ class SearchController < ApplicationController
 
   # Array of search endpoints that are supported
   def valid_targets
-    %w(articles books google worldcat)
+    %w(articles books google whatnot)
   end
 
   # Formatted date used in creating cache keys
@@ -46,8 +46,6 @@ class SearchController < ApplicationController
   def search_target
     if params[:target] == 'google'
       search_google
-    elsif params[:target] == 'worldcat'
-      search_worldcat
     else
       search_eds
     end
@@ -63,6 +61,8 @@ class SearchController < ApplicationController
   def eds_profile
     if params[:target] == 'articles'
       ENV['EDS_NO_ALEPH_PROFILE']
+    elsif params[:target] == 'whatnot'
+      ENV['EDS_WHATNOT_PROFILE']
     else
       ENV['EDS_ALEPH_PROFILE']
     end
@@ -72,12 +72,6 @@ class SearchController < ApplicationController
   def search_google
     raw_results = SearchGoogle.new.search(strip_q)
     NormalizeGoogle.new.to_result(raw_results)
-  end
-
-  # Searches Google Custom Search
-  def search_worldcat
-    raw_results = SearchWorldcat.new.search(strip_q)
-    NormalizeWorldcat.new.to_result(raw_results)
   end
 
   # Strips trailing and leading white space in search term

--- a/app/models/normalize_eds.rb
+++ b/app/models/normalize_eds.rb
@@ -47,8 +47,10 @@ class NormalizeEds
   end
 
   def title(record)
-    bibentity = record['RecordInfo']['BibRecord']['BibEntity']
-    bibentity['Titles'].first['TitleFull']
+    bib = record['RecordInfo']['BibRecord']['BibEntity']
+    bib['Titles'][0]['TitleFull']
+  rescue
+    'unknown title'
   end
 
   def year(record)

--- a/app/models/search_eds.rb
+++ b/app/models/search_eds.rb
@@ -27,7 +27,7 @@ class SearchEds
 
   def search_url(term)
     [EDS_URL, '/edsapi/rest/Search?query=', clean_term(term),
-     '&searchmode=any', "&resultsperpage=#{RESULTS_PER_BOX}",
+     '&searchmode=all', "&resultsperpage=#{RESULTS_PER_BOX}",
      '&pagenumber=1', '&sort=relevance', '&highlight=n', '&includefacets=n',
      '&view=detailed', '&autosuggest=n', '&expander=fulltext'].join('')
   end

--- a/app/views/layouts/_institute_footer.html.erb
+++ b/app/views/layouts/_institute_footer.html.erb
@@ -12,6 +12,5 @@
       <div class="license">Licensed under the <a href="http://creativecommons.org/licenses/by-nc/2.0/" class="license-cc">Creative Commons Attribution Non-Commercial License</a> unless otherwise noted. <a href="/research-support/notices/copyright-notify/">Notify us about copyright concerns</a>.
       </div><!-- end footer.footer-info-institure -->
     </footer>
-    <%= render partial: "toggle_boxes" %>
   </div>
 </div>

--- a/app/views/search/_toggle_boxes.html.erb
+++ b/app/views/search/_toggle_boxes.html.erb
@@ -1,9 +1,0 @@
-<ul>
-  <li><%= link_to('Toggle WorldCat', session_toggle_boxes_path(box: 'worldcat')) %></li>
-
-  <li><%= link_to('Toggle Google', session_toggle_boxes_path(box: 'website')) %></li>
-
-  <li><%= link_to('Toggle EDS Aleph', session_toggle_boxes_path(box: 'books')) %></li>
-
-  <li><%= link_to('Toggle EDS Non-Aleph', session_toggle_boxes_path(box: 'articles')) %></li>
-</ul>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -2,82 +2,36 @@
 
 <div class="results-summary">
   <p><span class="title">Found: </span>
-    <% if box_enabled?('articles') %>
-      <span class="results-summary-item" data-region="articles">Articles <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
-    <% end %>
+    <span class="results-summary-item" data-region="articles">Articles <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
 
-    <% if box_enabled?('books') %>
-      <span class="results-summary-item" data-region="books">Local Books <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
-    <% end %>
+    <span class="results-summary-item" data-region="books">Books and Media <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
 
-    <% if box_enabled?('worldcat') %>
-      <span  class="results-summary-item"data-region="worldcat">Worldwide Books <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
-    <% end %>
+    <span  class="results-summary-item"data-region="whatnot">Whatnot <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
 
-    <% if box_enabled?('website') %>
-      <span class="results-summary-item" data-region="google">Webpages <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
-    <% end %>
-    </p>
+    <span class="results-summary-item" data-region="google">Webpages <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span>
+  </p>
 </div>
 
 <div class="row">
-  <% if box_enabled?('books') %>
-    <%= render partial: "placeholders", locals: { heading: 'Books', id: 'books_content', box_width: 6} %>
-  <% end %>
+  <%= render partial: "placeholders", locals: { heading: 'Books and Media', id: 'books_content', box_width: 6} %>
 
-  <% if box_enabled?('articles') %>
-    <%= render partial: "placeholders", locals: { heading: 'Articles', id: 'articles_content', box_width: 6} %>
-  <% end %>
-
-  <% if box_enabled?('worldcat') %>
-    <%= render partial: "placeholders", locals: { heading: 'WorldCat', id: 'worldcat_content', box_width: 6} %>
-  <% end %>
+  <%= render partial: "placeholders", locals: { heading: 'Articles', id: 'articles_content', box_width: 6} %>
 </div>
 
 <div class="row">
-  <div class="wrap-results col-sm-4">
-    <h2>Databases</h2>
-    Coming soon...
-  </div>
+  <%= render partial: "placeholders", locals: { heading: 'Whatnot', id: 'whatnot_content', box_width: 6} %>
 
-  <div class="wrap-results col-sm-4">
-    <h2>Journals</h2>
-    Coming soon...
-  </div>
-
-  <div class="wrap-results col-sm-4">
-    <h2>Other Resources</h2>
-    Coming soon...
-  </div>
-
-</div>
-
-<div class="row">
-  <% if box_enabled?('media') %>
-    <%= render partial: "placeholders", locals: { heading: 'Media and More', id: 'website_content', box_width: 12} %>
-  <% end %>
-
-  <% if box_enabled?('website') %>
-    <%= render partial: "placeholders", locals: { heading: 'Website and Guides', id: 'website_content', box_width: 12} %>
-  <% end %>
+  <%= render partial: "placeholders", locals: { heading: 'Website and Guides', id: 'website_content', box_width: 6} %>
 </div>
 
 <%= render partial: "help" %>
 
 <script>
-  <% if box_enabled?('articles') %>
-    <%= render partial: "trigger_search", locals: { target: 'articles', id: 'articles_content'} %>
-  <% end %>
+  <%= render partial: "trigger_search", locals: { target: 'articles', id: 'articles_content'} %>
 
-  <% if box_enabled?('books') %>
-    <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
-  <% end %>
+  <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
 
-  <% if box_enabled?('worldcat') %>
-    <%= render partial: "trigger_search", locals: { target: 'worldcat', id: 'worldcat_content'} %>
-  <% end %>
+  <%= render partial: "trigger_search", locals: { target: 'whatnot', id: 'whatnot_content'} %>
 
-  <% if box_enabled?('website') %>
-    <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
-  <% end %>
+  <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
 </script>

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -19,10 +19,10 @@
       "View all #{number_with_delimiter(@results['total'])} like this",
       "#{ENV['EDS_ALEPH_URI']}#{params[:q]}",
       data: {count: @results['total']}) %>
-  <% elsif params[:target] == 'worldcat' %>
+  <% elsif params[:target] == 'whatnot' %>
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} like this",
-      "http://mit.worldcat.org/search?qt=worldcat_org_all&&q=#{params[:q]}",
+      "#{ENV['EDS_WHATNOT_URI']}#{params[:q]}",
       data: {count: @results['total']}) %>
   <% end %>
 <% else %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
   ENV['EDS_PASSWORD'] = 'FAKE_EDS_PASSWORD'
   ENV['EDS_NO_ALEPH_PROFILE'] = 'apinoaleph'
   ENV['EDS_ALEPH_PROFILE'] = 'apibarton'
+  ENV['EDS_WHATNOT_PROFILE'] = 'apiwhatnot'
   ENV['GOOGLE_API_KEY'] = 'FAKE_GOOGLE_API_KEY'
   ENV['GOOGLE_CUSTOM_SEARCH_ID'] = 'FAKE_GOOGLE_CUSTOM_SEARCH_ID'
   ENV['WORLDCAT_URI'] = 'http://www.worldcat.org/webservices/catalog/search/worldcat/'
@@ -14,6 +15,7 @@ Rails.application.configure do
   ENV['MAX_AUTHORS'] = '3'
   ENV['EDS_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3D'
   ENV['EDS_NO_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedsnoaleph%26profile%3Dedsnoaleph%26bquery%3D'
+  ENV['EDS_WHATNOT_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3D'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -61,13 +61,13 @@ class SearchTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'worldcat results are populated' do
-    VCR.use_cassette('popcorn worldcat',
+  test 'whatnot results are populated' do
+    VCR.use_cassette('popcorn whatnot',
                      allow_playback_repeats: true) do
-      get '/search/search?q=popcorn&target=worldcat'
+      get '/search/search?q=popcorn&target=whatnot'
       assert_response :success
       assert_select('a.bento-link') do |value|
-        assert(value.text.include?('Popcorn Venus'))
+        assert(value.text.include?('Sensory and nutritional evaluation'))
       end
     end
   end

--- a/test/vcr_cassettes/multiple_book_authors.yml
+++ b/test/vcr_cassettes/multiple_book_authors.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Mon, 07 Nov 2016 18:15:21 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=vonnegut&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=vonnegut&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,vonnegut&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"vonnegut"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":136,"TotalSearchTime":444,"Databases":[{"Id":"ir00145a","Label":"MIT
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,vonnegut&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"vonnegut"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":136,"TotalSearchTime":444,"Databases":[{"Id":"ir00145a","Label":"MIT
         DOME for Discovery","Status":"0","Hits":0},{"Id":"cat01763a","Label":"MIT
         Course Reserves","Status":"0","Hits":1},{"Id":"cat01875a","Label":"MIT Test
         Catalog","Status":"0","Hits":135}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT

--- a/test/vcr_cassettes/multiple_book_subjects.yml
+++ b/test/vcr_cassettes/multiple_book_subjects.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Mon, 07 Nov 2016 18:41:31 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''
@@ -146,7 +146,7 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":66,"Databases":[{"Id":"ir00145a","Label":"MIT
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":66,"Databases":[{"Id":"ir00145a","Label":"MIT
         DOME for Discovery","Status":"0","Hits":63},{"Id":"cat01763a","Label":"MIT
         Course Reserves","Status":"0","Hits":3},{"Id":"cat01875a","Label":"MIT Test
         Catalog","Status":"0","Hits":1793}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT

--- a/test/vcr_cassettes/no_article_authors.yml
+++ b/test/vcr_cassettes/no_article_authors.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Mon, 07 Nov 2016 20:55:07 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":9842235,"TotalSearchTime":205,"Databases":[{"Id":"eric","Label":"ERIC","Status":"0","Hits":1036},{"Id":"bwh","Label":"","Status":"0","Hits":159325},{"Id":"egh","Label":"Environment
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":9842235,"TotalSearchTime":205,"Databases":[{"Id":"eric","Label":"ERIC","Status":"0","Hits":1036},{"Id":"bwh","Label":"","Status":"0","Hits":159325},{"Id":"egh","Label":"Environment
         Index","Status":"0","Hits":10651},{"Id":"ecn","Label":"EconLit","Status":"0","Hits":1267},{"Id":"cmedm","Label":"MEDLINE","Status":"0","Hits":34384},{"Id":"ufh","Label":"Communication
         & Mass Media Complete","Status":"0","Hits":7925},{"Id":"fyh","Label":"Women''s
         Studies International","Status":"0","Hits":445},{"Id":"bth","Label":"Business

--- a/test/vcr_cassettes/no_book_authors.yml
+++ b/test/vcr_cassettes/no_book_authors.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Mon, 07 Nov 2016 18:18:48 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=orange&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":131,"Databases":[{"Id":"ir00145a","Label":"MIT
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,orange&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"orange"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1859,"TotalSearchTime":131,"Databases":[{"Id":"ir00145a","Label":"MIT
         DOME for Discovery","Status":"0","Hits":63},{"Id":"cat01763a","Label":"MIT
         Course Reserves","Status":"0","Hits":3},{"Id":"cat01875a","Label":"MIT Test
         Catalog","Status":"0","Hits":1793}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT

--- a/test/vcr_cassettes/no_results.yml
+++ b/test/vcr_cassettes/no_results.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:20:47 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcornandorangejuice&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcornandorangejuice&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_articles.yml
+++ b/test/vcr_cassettes/popcorn_articles.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_books.yml
+++ b/test/vcr_cassettes/popcorn_books.yml
@@ -100,7 +100,7 @@ http_interactions:
   recorded_at: Mon, 07 Nov 2016 18:10:13 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''
@@ -146,7 +146,7 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,popcorn&expander=fulltext&sort=relevance&includefacets=n&searchmode=any&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"popcorn"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":78,"TotalSearchTime":181,"Databases":[{"Id":"ir00145a","Label":"MIT
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,popcorn&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"popcorn"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":78,"TotalSearchTime":181,"Databases":[{"Id":"ir00145a","Label":"MIT
         DOME for Discovery","Status":"0","Hits":1},{"Id":"cat01763a","Label":"MIT
         Course Reserves","Status":"0","Hits":0},{"Id":"cat01875a","Label":"MIT Test
         Catalog","Status":"0","Hits":77}]},"Data":{"RecordFormat":"EP Display","Records":[{"ResultId":1,"Header":{"DbId":"cat01875a","DbLabel":"MIT

--- a/test/vcr_cassettes/popcorn_non_articles.yml
+++ b/test/vcr_cassettes/popcorn_non_articles.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:06:17 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_whatnot.yml
+++ b/test/vcr_cassettes/popcorn_whatnot.yml
@@ -1,0 +1,362 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Thu, 17 Nov 2016 19:31:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Thu, 17 Nov 2016 19:31:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '100'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 6602441f-eeb7-4dcb-a9a5-27269f12957e
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Thu, 17 Nov 2016 19:31:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version:
+  recorded_at: Thu, 17 Nov 2016 19:31:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '18086'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - d7bb2b72-6011-4119-9cb6-15718d93102b
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Thu, 17 Nov 2016 19:31:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,popcorn&expander=fulltext&sort=relevance&includefacets=n&autosuggest=n&view=detailed&resultsperpage=3&pagenumber=1&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"popcorn"},"RemoveAction":"removequery(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":56597,"TotalSearchTime":142,"Databases":[{"Id":"fyh","Label":"Women''s
+        Studies International","Status":"0","Hits":19},{"Id":"ahl","Label":"America:
+        History & Life","Status":"0","Hits":15},{"Id":"edselp","Label":"ScienceDirect","Status":"0","Hits":4435},{"Id":"edsoso","Label":"Oxford
+        Scholarship Online","Status":"0","Hits":4},{"Id":"rga","Label":"Readers''
+        Guide Abstracts (H.W. Wilson)","Status":"0","Hits":651},{"Id":"rgr","Label":"Readers''
+        Guide Retrospective: 1890-1982 (H.W. Wilson)","Status":"0","Hits":153},{"Id":"edsebo","Label":"Britannica
+        Online","Status":"0","Hits":11},{"Id":"edo","Label":"","Status":"0","Hits":2614},{"Id":"edb","Label":"","Status":"0","Hits":45315},{"Id":"edsjst","Label":"J-STAGE","Status":"0","Hits":38},{"Id":"edsoad","Label":"American
+        National Biography Online","Status":"0","Hits":0},{"Id":"edsodb","Label":"Oxford
+        Dictionary of National Biography","Status":"0","Hits":0},{"Id":"aci","Label":"Applied
+        Science & Technology Source","Status":"0","Hits":1721},{"Id":"edsmbo","Label":"Marquis
+        Biographies Online","Status":"0","Hits":23},{"Id":"htm","Label":"History of
+        Science, Technology & Medicine","Status":"0","Hits":0},{"Id":"ers","Label":"Research
+        Starters","Status":"0","Hits":44},{"Id":"edsrsa","Label":"ReferenceUSA - U.S.
+        Businesses","Status":"0","Hits":1511},{"Id":"edsspo","Label":"SpringerProtocols","Status":"0","Hits":10},{"Id":"edssmt","Label":"SpringerMaterials","Status":"0","Hits":1},{"Id":"edsoec","Label":"OECD
+        iLibrary","Status":"0","Hits":3},{"Id":"edsstc","Label":"SciTech Connect","Status":"0","Hits":25},{"Id":"edswbe","Label":"World
+        Bank eLibrary","Status":"0","Hits":0},{"Id":"edsmmd","Label":"ASM Medical
+        Materials Database","Status":"0","Hits":0},{"Id":"edsonp","Label":"OnePetro","Status":"0","Hits":4}]},"Data":{"RecordFormat":"EP
+        Display","Records":[{"ResultId":1,"Header":{"DbId":"edselp","DbLabel":"ScienceDirect","An":"S0733521016300753","RelevancyScore":"2090","PubType":"Academic
+        Journal","PubTypeId":"academicJournal"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edselp&AN=S0733521016300753","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/www.sciencedirect.com\/science\/article\/pii\/S0733521016300753?","Name":"ScienceDirect
+        (all content) - s8978330","Category":"fullText","Text":"View record from ScienceDirect"},{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=article&isbn=&issn=07335210&title=Journal
+        of Cereal Science&volume=69&issue=&date=20160501&atitle=Sensory and nutritional
+        evaluation of popcorn kernels with yellow, white and red pericarps expanded
+        in different ways&aulast=Paraginski, Ricardo Tadeu&spage=383&sid=EBSCO:ScienceDirect&pid=<authors>Paraginski,
+        Ricardo Tadeu<\/authors><ui>S0733521016300753<\/ui><date>20160501<\/date><db>ScienceDirect<\/db>","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Sensory
+        and nutritional evaluation of popcorn kernels with yellow, white and red pericarps
+        expanded in different ways"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Paraginski%2C+Ricardo+Tadeu%22&quot;&gt;Paraginski,
+        Ricardo Tadeu&lt;\/searchLink&gt; &lt;superscript&gt;a&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22de+Souza%2C+Nelisa+Lamas%22&quot;&gt;de
+        Souza, Nelisa Lamas&lt;\/searchLink&gt; &lt;superscript&gt;b&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Alves%2C+Gabriela+Hornke%22&quot;&gt;Alves,
+        Gabriela Hornke&lt;\/searchLink&gt; &lt;superscript&gt;b&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Ziegler%2C+Valmor%22&quot;&gt;Ziegler,
+        Valmor&lt;\/searchLink&gt; &lt;superscript&gt;b, ∗&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22de+Oliveira%2C+Maur&#237;cio%22&quot;&gt;de
+        Oliveira, Maur&#237;cio&lt;\/searchLink&gt; &lt;superscript&gt;b&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Elias%2C+Moacir+Cardoso%22&quot;&gt;Elias,
+        Moacir Cardoso&lt;\/searchLink&gt; &lt;superscript&gt;b&lt;\/superscript&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"In
+        &lt;searchLink fieldCode=&quot;JN&quot; term=&quot;%22Journal+of+Cereal+Science%22&quot;&gt;Journal
+        of Cereal Science&lt;\/searchLink&gt; May 2016 69:383-391"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"The
+        objective of this study was to evaluate the effects of pericarp color and
+        expansion process on the sensorial and nutritional quality of popcorn kernels.
+        Popcorn kernels with red, white or yellow pericarps underwent expansion using
+        one of these methods: in a pan with oil, in a microwave with oil, in a microwave
+        without oil, in an electric popcorn popper with oil, or in an electric popcorn
+        popper without oil. The pericarp color and method of processing primarily
+        affect the sensory quality of corn popcorn grains after the expansion. The
+        best sensory evaluations were observed in the popcorn grains expanded in a
+        pan with the presence of oil; these suffer the greatest physicochemical and
+        structural changes, represented by viscoamylographic properties, indicating
+        that in this form of processing, starch undergoes further expansion. However,
+        this form of processing features the highest energy value compared to other
+        forms of processing without compromising the amount of compounds with antioxidant
+        potential present in these grains."},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"•Popcorn
+        kernels with different colors of pericarp were expanded in different ways.•The
+        processing form affects the sensory quality of the expanded popcorn kernels.•Popcorn
+        processed in a pan with oil obtained the best sensory evaluations.•Popcorn
+        processed in a pan with oil had the highest nutritional value."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1016\/j.jcs.2016.05.013"}],"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"9","StartPage":"383"}},"Titles":[{"TitleFull":"Sensory
+        and nutritional evaluation of popcorn kernels with yellow, white and red pericarps
+        expanded in different ways","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Paraginski,
+        Ricardo Tadeu"}}},{"PersonEntity":{"Name":{"NameFull":"de Souza, Nelisa Lamas"}}},{"PersonEntity":{"Name":{"NameFull":"Alves,
+        Gabriela Hornke"}}},{"PersonEntity":{"Name":{"NameFull":"Ziegler, Valmor"}}},{"PersonEntity":{"Name":{"NameFull":"de
+        Oliveira, Maurício"}}},{"PersonEntity":{"Name":{"NameFull":"Elias, Moacir
+        Cardoso"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"05","Text":"May
+        2016","Type":"published","Y":"2016"}],"Identifiers":[{"Type":"issn-electronic","Value":"07335210"}],"Numbering":[{"Type":"volume","Value":"69"}],"Titles":[{"TitleFull":"Journal
+        of Cereal Science","Type":"main"}]}}]}}}},{"ResultId":2,"Header":{"DbId":"edselp","DbLabel":"ScienceDirect","An":"S2211601X16000353","RelevancyScore":"2090","PubType":"Academic
+        Journal","PubTypeId":"academicJournal"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edselp&AN=S2211601X16000353","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/www.sciencedirect.com\/science\/article\/pii\/S2211601X16000353?","Name":"ScienceDirect
+        (all content) - s8978330","Category":"fullText","Text":"View record from ScienceDirect"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Quality
+        Performance, Proximate Composition and Sensory Evaluation of Developed Flavoured
+        Instant Popcorn"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Ranathunga%2C+R%2EA%2EA%2E%22&quot;&gt;Ranathunga,
+        R.A.A.&lt;\/searchLink&gt; &lt;superscript&gt;a&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Gunasekara%2C+G%2ET%2EN%2E%22&quot;&gt;Gunasekara,
+        G.T.N.&lt;\/searchLink&gt; &lt;superscript&gt;a&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22Wijewardana%2C+D%2EC%2EM%2ES%2EI%2E%22&quot;&gt;Wijewardana,
+        D.C.M.S.I.&lt;\/searchLink&gt; &lt;superscript&gt;b, ⁎&lt;\/superscript&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"In
+        International Conference of Sabaragamuwa University of Sri Lanka 2015 (ICSUSL
+        2015), &lt;searchLink fieldCode=&quot;JN&quot; term=&quot;%22Procedia+Food+Science%22&quot;&gt;Procedia
+        Food Science&lt;\/searchLink&gt; 2016 6:143-146"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Popcorn
+        is a world famous snack food with significant commercial demand. Its market
+        has been continuously growing in Sri Lanka. At the same time, different variety
+        of instant popcorn products should be tested for sensory attributes, proximate
+        composition and quality performance. The flavoured instant products were developed
+        by adding 15%, 25% and 35% butter and butter oil as separately and 0.5g, 1.0g
+        and 1.5g salt respectively for 20g of raw popcorn grains. 35% butter incorporated
+        popcorn had significantly higher median score for appearance, taste and overall
+        acceptability. There was no any effect of level of salt added. Proximate composition
+        was determined for raw seed, raw popped flakes and flavoured popped flakes.
+        Butter flavoured popped corn flakes were showed higher level for crude fat
+        content and mineral content while lowest content for carbohydrate 16.71%,
+        2.4% and 64.2% respectively. Kernels were popped using a microwave oven and
+        visually sorted into three different polymorphisms depending on whether the
+        appendages were expanded unilaterally, bilaterally, or multilaterally. The
+        expansion volume before sorting was comparatively lower and it was 10-11cm3\/g.
+        When popped, 37.37%, 14.02%, and 33.57% of kernels were expanded unilaterally,
+        bilaterally, and multilaterally, respectively, while 14.2% of kernels remained
+        unpopped. Expansion volumes in respect to flake weight were shown significant
+        differences for unilaterally, bilaterally, and multilaterally expanded polymorphisms
+        of 9.34, 8.86 and 12.29cm3\/g, respectively."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1016\/j.profoo.2016.02.034"}],"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"4","StartPage":"143"}},"Titles":[{"TitleFull":"Quality
+        Performance, Proximate Composition and Sensory Evaluation of Developed Flavoured
+        Instant Popcorn","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Ranathunga,
+        R.A.A."}}},{"PersonEntity":{"Name":{"NameFull":"Gunasekara, G.T.N."}}},{"PersonEntity":{"Name":{"NameFull":"Wijewardana,
+        D.C.M.S.I."}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Text":"2016","Type":"published","Y":"2016"}],"Identifiers":[{"Type":"issn-electronic","Value":"2211601X"}],"Numbering":[{"Type":"volume","Value":"6"}],"Titles":[{"TitleFull":"Procedia
+        Food Science","Type":"main"}]}}]}}}},{"ResultId":3,"Header":{"DbId":"edselp","DbLabel":"ScienceDirect","An":"S2095311915610607","RelevancyScore":"2054","PubType":"Academic
+        Journal","PubTypeId":"academicJournal"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edselp&AN=S2095311915610607","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/www.sciencedirect.com\/science\/article\/pii\/S2095311915610607?","Name":"ScienceDirect
+        (all content) - s8978330","Category":"fullText","Text":"View record from ScienceDirect"},{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=article&isbn=&issn=20953119&title=Journal
+        of Integrative Agriculture&volume=14&issue=12&date=20151201&atitle=RESEARCH
+        ARTICLE: QTL consistency for agronomic traits across three generations and
+        potential applications in popcorn&aulast=DONG, Yong-bin&spage=2547&sid=EBSCO:ScienceDirect&pid=<authors>DONG,
+        Yong-bin<\/authors><ui>S2095311915610607<\/ui><date>20151201<\/date><db>ScienceDirect<\/db>","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"RESEARCH
+        ARTICLE: QTL consistency for agronomic traits across three generations and
+        potential applications in popcorn"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22DONG%2C+Yong-bin%22&quot;&gt;DONG,
+        Yong-bin&lt;\/searchLink&gt; &lt;superscript&gt;*&lt;\/superscript&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22ZHANG%2C+Zhong-wei%22&quot;&gt;ZHANG,
+        Zhong-wei&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;AR&quot;
+        term=&quot;%22SHI%2C+Qing-ling%22&quot;&gt;SHI, Qing-ling&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22WANG%2C+Qi-lei%22&quot;&gt;WANG,
+        Qi-lei&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;AR&quot;
+        term=&quot;%22ZHOU%2C+Qiang%22&quot;&gt;ZHOU, Qiang&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22DENG%2C+Fei%22&quot;&gt;DENG,
+        Fei&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;AR&quot;
+        term=&quot;%22MA%2C+Zhi-yan%22&quot;&gt;MA, Zhi-yan&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AR&quot; term=&quot;%22QIAO%2C+Da-he%22&quot;&gt;QIAO,
+        Da-he&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;AR&quot;
+        term=&quot;%22LI%2C+Yu-ling%22&quot;&gt;LI, Yu-ling&lt;\/searchLink&gt; &lt;superscript&gt;**&lt;\/superscript&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"In
+        &lt;searchLink fieldCode=&quot;JN&quot; term=&quot;%22Journal+of+Integrative+Agriculture%22&quot;&gt;Journal
+        of Integrative Agriculture&lt;\/searchLink&gt; December 2015 14(12):2547-2557"},{"Name":"Subject","Label":"Topics","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Crop+Genetics+•+Breeding+•+Germplasm+Resources%22&quot;&gt;Crop
+        Genetics • Breeding • Germplasm Resources&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Favorable
+        agronomic traits are important to improve productivity of popcorn. In this
+        study, a recombinant inbred line (RIL) population consisting of 258 lines
+        was evaluated to identify quantitative trait loci (QTLs) for nine agronomic
+        traits (plant height, ear height, top height (plant height subtracted ear
+        height), top height\/plant height, number of leaves above the top ear, leaf
+        area, stalk diameter, number of tassel branches and the length of tassel)
+        under three environments. Meta-analysis was conducted then to integrate QTLs
+        identified across three generations (RIL, F&lt;subscript&gt;2:3&lt;\/subscript&gt;
+        and BC&lt;subscript&gt;2&lt;\/subscript&gt;F&lt;subscript&gt;2&lt;\/subscript&gt;)
+        developed from the same crosses. In total, 179 QTLs and 36 meta-QTLs (mQTL)
+        were identified. The percentage of phenotypic variation (R&lt;superscript&gt;2&lt;\/superscript&gt;)
+        explained by any single QTL varied from 3.86 to 28.4%, and 24 QTLs with contributions
+        over 15%. Nine common QTLs located in the same or similar chromosome regions
+        were detected across three generations. Five meta-QTLs were identified including
+        QTLs in three independent studies. Seven important mQTLs were composed of
+        11–26 QTLs for 4–7 traits, respectively. Only 11 mQTLs were commonly identified
+        in the same or similar chromosome regions across agronomic traits, popping
+        characteristics (popping fold, popping volume and popping rate) and grain
+        yield components (ear weight per plant, grain weight per plant, 100-grain
+        weight, ear length, kernel number per row, ear diameter, row number per ear
+        and kernel ratio) by meta-QTL analysis. In conclusion, we identified a list
+        of QTLs, some of which with much higher contributions to agronomic traits
+        should be valuable for further study in improving both popping characteristics
+        and grain yield components in popcorn."}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.1016\/S2095-3119(15)61060-7"}],"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"11","StartPage":"2547"}},"Subjects":[{"SubjectFull":"Crop
+        Genetics • Breeding • Germplasm Resources","Type":"general"}],"Titles":[{"TitleFull":"RESEARCH
+        ARTICLE: QTL consistency for agronomic traits across three generations and
+        potential applications in popcorn","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"DONG,
+        Yong-bin"}}},{"PersonEntity":{"Name":{"NameFull":"ZHANG, Zhong-wei"}}},{"PersonEntity":{"Name":{"NameFull":"SHI,
+        Qing-ling"}}},{"PersonEntity":{"Name":{"NameFull":"WANG, Qi-lei"}}},{"PersonEntity":{"Name":{"NameFull":"ZHOU,
+        Qiang"}}},{"PersonEntity":{"Name":{"NameFull":"DENG, Fei"}}},{"PersonEntity":{"Name":{"NameFull":"MA,
+        Zhi-yan"}}},{"PersonEntity":{"Name":{"NameFull":"QIAO, Da-he"}}},{"PersonEntity":{"Name":{"NameFull":"LI,
+        Yu-ling"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"12","Text":"December
+        2015","Type":"published","Y":"2015"}],"Identifiers":[{"Type":"issn-electronic","Value":"20953119"}],"Numbering":[{"Type":"volume","Value":"14"},{"Type":"issue","Value":"12"}],"Titles":[{"TitleFull":"Journal
+        of Integrative Agriculture","Type":"main"}]}}]}}}}]}}}'
+    http_version:
+  recorded_at: Thu, 17 Nov 2016 19:31:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.1.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - b0607fd7-c86d-4e48-81cb-bb9306648a0d
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 28 Oct 2016 13:54:14 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version:
+  recorded_at: Thu, 17 Nov 2016 19:31:14 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/rollbar4.yml
+++ b/test/vcr_cassettes/rollbar4.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Wed, 14 Sep 2016 17:13:13 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=R.%20F.%20Harrington%20Field%20computation%20by%20moment%20methods.%20Macmillan%201968&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=R.%20F.%20Harrington%20Field%20computation%20by%20moment%20methods.%20Macmillan%201968&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/rollbar4a.yml
+++ b/test/vcr_cassettes/rollbar4a.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Wed, 14 Sep 2016 17:09:07 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=R.%20F.%20Harrington%20Field%20computation%20by%20moment%20methods.%20Macmillan%201968&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=R.%20F.%20Harrington%20Field%20computation%20by%20moment%20methods.%20Macmillan%201968&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/rollbar8.yml
+++ b/test/vcr_cassettes/rollbar8.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Tue, 27 Sep 2016 19:01:19 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=web%20of%20science&resultsperpage=3&searchmode=any&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=web%20of%20science&resultsperpage=3&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
What:

* Adds whatnot box
* Fixes relevance

Why:

* To allow our team to better evaluate what goes in each box, it was
  decided to create a temporary(?) EDS profile where we will put all the
  stuff that isn't obvious where to put.
* Relevance was reported as not matching the EDS UI for the same search.
  This changes from querying the API for "any" of the supplied words to
  querying for "all" supplied words and seems to match the UI from my
  initial testing.

See Also:

* https://mitlibraries.atlassian.net/browse/DI-121