### PR TITLE
Limit long subject lists

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -18,4 +18,8 @@ class Result
     return authors if authors.length <= ENV['MAX_AUTHORS'].to_i
     authors[0...ENV['MAX_AUTHORS'].to_i] << 'et al'
   end
+
+  def truncated_subjects
+    subjects[0..2]
+  end
 end

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -40,7 +40,7 @@
     <% if result.subjects.present? %>
       <div class="result-subjectheadings">
         <ul class="list-subjects">
-        <% result.subjects.each do |subject| %>
+        <% result.truncated_subjects.each do |subject| %>
           <li class="result-subjectheading">
             <%= link_to(subject[0], subject[1]) %>
           </li>

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -51,6 +51,14 @@ class ResultTest < ActiveSupport::TestCase
     assert_equal(r.truncated_authors, ['a', 'b', 'c', 'et al'])
   end
 
+  test 'long subject lists truncated' do
+    r = Result.new('title', 'http://example.com')
+    r.subjects = %w(a b c d e)
+    assert r.valid?
+    assert_equal(r.subjects, %w(a b c d e))
+    assert_equal(r.truncated_subjects, %w(a b c))
+  end
+
   test 'can set citation' do
     r = Result.new('title', 'http://example.com')
     r.citation = 'Journal of Stuff, vol.12, no.1, pp.2-12'


### PR DESCRIPTION
What:

* creates a convenience method for limiting display to 3 subjects

Why:

* some records have _lots_ of subjects and it is unlikely it will be
  useful to display them all
* https://mitlibraries.atlassian.net/browse/DI-127