### PR TITLE
Adds support for direct record url

### DIFF
--- a/app/models/normalize_eds_articles.rb
+++ b/app/models/normalize_eds_articles.rb
@@ -8,7 +8,28 @@ class NormalizeEdsArticles
   def article_metadata(result)
     result.citation = numbering
     result.in = journal_title
+    result.get_it_url = link(result)
     result
+  end
+
+  def link(result)
+    if sfx_link&.select { |l| l.include?('sfx.mit') }.present?
+      URI.escape(sfx_link&.select { |l| l.include?('sfx.mit') }.first +
+      '&rfr_id=info:sid/MIT.BENTO')
+    else
+      construct_open_url(result)
+    end
+  end
+
+  def construct_open_url(result)
+    'https://sfx.mit.edu/sfx_local?' +
+      openurl(
+        result.year, result.authors&.map(&:first)
+      )
+  end
+
+  def sfx_link
+    @record['FullText']['CustomLinks']&.map { |l| l['Url'] }
   end
 
   def openurl(year, authors)

--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -10,6 +10,7 @@ class NormalizeEdsBooks
     result.publisher = publisher
     result.location = location
     result.subjects = subjects
+    result.get_it_url = @record['PLink']
     result
   end
 

--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -41,29 +41,11 @@ class NormalizeEdsCommon
   end
 
   def link
-    if @type == 'books'
-      @record['PLink']
-    elsif sfx_link&.select { |l| l.include?('sfx.mit') }.present?
-      URI.escape(sfx_link&.select { |l| l.include?('sfx.mit') }.first +
-      '&rfr_id=info:sid/MIT.BENTO')
-    else
-      construct_open_url
-    end
-  end
-
-  def construct_open_url
-    'https://sfx.mit.edu/sfx_local?' +
-      NormalizeEdsArticles.new(@record).openurl(
-        year, authors&.map(&:first)
-      )
+    @record['PLink']
   end
 
   def availability
     @record['FullText']['Text']['Availability']&.to_i
-  end
-
-  def sfx_link
-    @record['FullText']['CustomLinks']&.map { |l| l['Url'] }
   end
 
   def type

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -6,7 +6,7 @@ class Result
 
   attr_accessor :title, :year, :url, :type, :authors, :citation, :online,
                 :year, :type, :in, :publisher, :location, :blurb, :subjects,
-                :available_url, :thumbnail
+                :available_url, :thumbnail, :get_it_url
 
   def initialize(title, url)
     @title = title

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -63,7 +63,7 @@
 
     <% if result.url %>
       <div class="result-get">
-        <%= link_to('Get it', result.url, class: 'button button-secondary') %>
+        <%= link_to('Get it', result.get_it_url, class: 'button button-secondary') %>
       </div>
     <% end %>
   </div>

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -20,17 +20,24 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
     assert_equal('2016', popcorn_articles['results'][0].year)
   end
 
+  test 'normalized articles have expected record link' do
+    assert_equal(
+      'http://search.ebscohost.com/login.aspx?direct=true&site=eds-live&db=a9h&AN=117972338',
+      popcorn_articles['results'][0].url
+    )
+  end
+
   test 'normalized articles have expected url eds provided sfx link' do
     assert_equal(
       'https://sfx.mit.edu/sfx_local?rfr_id=info%3Asid%2FMIT.BENTO&rft.au=Moreira+Ribeiro%2C+Rodrigo%3Bdo+Amaral+J%C3%BAnior%2C+Ant%C3%B4nio+Teixeira%3BFerreira+Pena%2C+Guilherme%3BVivas%2C+Marcelo%3BNascimento+Kurosawa%2C+Railan%3BAzeredo+Gon%C3%A7alves%2C+Leandro+Sim%C3%B5es&rft.issue=4&rft.jtitle=Acta+Scientiarum%3A+Agronomy&rft.volume=38&rft.year=2016&rft_id=info%3Adoi%2F10.4025%2Factasciagron.v38i4.30573',
-      popcorn_articles['results'][0].url
+      popcorn_articles['results'][0].get_it_url
     )
   end
 
   test 'normalized articles have generated sfx link when not in eds' do
     assert_equal(
       'https://sfx.mit.edu/sfx_local?genre=article&isbn=&issn=07335210&title=Journal%20of%20Cereal%20Science&volume=69&issue=&date=20160501&atitle=Sensory%20and%20nutritional%20evaluation%20of%20popcorn%20kernels%20with%20yellow,%20white%20and%20red%20pericarps%20expanded%20in%20different%20ways&aulast=Paraginski,%20Ricardo%20Tadeu&spage=383&sid=EBSCO:ScienceDirect&pid=%3Cauthors%3EParaginski,%20Ricardo%20Tadeu%3C/authors%3E%3Cui%3ES0733521016300753%3C/ui%3E%3Cdate%3E20160501%3C/date%3E%3Cdb%3EScienceDirect%3C/db%3E&rfr_id=info:sid/MIT.BENTO',
-      popcorn_articles['results'][1].url
+      popcorn_articles['results'][1].get_it_url
     )
   end
 


### PR DESCRIPTION
What:

* This allows for articles to have distinct links for detailed record
  view and get_it_url

Why:

* it was decided to always have the item title link to the record view
  in the source while having the get_it link go to either the record
  view or sfx depending on the type of item
* https://mitlibraries.atlassian.net/browse/DI-128

How:

* The `Result` class now supports both the required `url` as well as a
  new optional `get_it_url`. The normalizers set those as appropriate
  for the different types of resources.