### PR TITLE
Adds db_source display

### DIFF
--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -11,6 +11,7 @@ class NormalizeEdsCommon
     result.year = year
     result.type = type
     result.online = availability
+    result.db_source = db_source
     result
   end
 
@@ -72,6 +73,10 @@ class NormalizeEdsCommon
 
   def author_search_format(author_node)
     URI.encode_www_form_component("AU \"#{author_name(author_node)}\"")
+  end
+
+  def db_source
+    [@record.dig('Header', 'DbLabel'), @record.dig('Header', 'DbId')]
   end
 
   def contributors

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -6,7 +6,7 @@ class Result
 
   attr_accessor :title, :year, :url, :type, :authors, :citation, :online,
                 :year, :type, :in, :publisher, :location, :blurb, :subjects,
-                :available_url, :thumbnail, :get_it_url
+                :available_url, :thumbnail, :get_it_url, :db_source
 
   def initialize(title, url)
     @title = title

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -61,6 +61,12 @@
       </div>
     <% end %>
 
+    <% if result.db_source.present? %>
+      <p class="result-pubinfo">
+        Source DB: <%= result.db_source[0] %> (<%= result.db_source[1] %>)
+      </p>
+    <% end %>
+
     <% if result.url %>
       <div class="result-get">
         <%= link_to('Get it', result.get_it_url, class: 'button button-secondary') %>


### PR DESCRIPTION
What:

* adds db source label and db source id to results from EDS sources

Why:

* While we assess what data sources should feed each box in the bento,
  it will be helpful to know what data sources the specific results we
  are seeing come from
* https://mitlibraries.atlassian.net/browse/DI-130