### PR TITLE
Refactor from EDS profiles to EDS Facets

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,6 +20,15 @@
     "EDS_WHATNOT_URI": {
       "required": true
     },
+    "EDS_ARTICLE_FACETS": {
+      "required": true
+    },
+    "EDS_BOOK_FACETS": {
+      "required": true
+    },
+    "EDS_WHATNOT_FACETS": {
+      "required": true
+    },
     "EDS_PASSWORD": {
       "required": true
     },

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -53,18 +53,22 @@ class SearchController < ApplicationController
 
   # Seaches EDS
   def search_eds
-    raw_results = SearchEds.new.search(strip_q, eds_profile)
+    raw_results = SearchEds.new.search(strip_q, eds_profile, eds_facets)
     NormalizeEds.new.to_result(raw_results, params[:target])
   end
 
   # Determines appropriate EDS profile
   def eds_profile
+    ENV['EDS_WHATNOT_PROFILE']
+  end
+
+  def eds_facets
     if params[:target] == 'articles'
-      ENV['EDS_NO_ALEPH_PROFILE']
+      ENV['EDS_ARTICLE_FACETS']
+    elsif params[:target] == 'books'
+      ENV['EDS_BOOK_FACETS']
     elsif params[:target] == 'whatnot'
-      ENV['EDS_WHATNOT_PROFILE']
-    else
-      ENV['EDS_ALEPH_PROFILE']
+      ENV['EDS_WHATNOT_FACETS']
     end
   end
 

--- a/app/models/normalize_eds_articles.rb
+++ b/app/models/normalize_eds_articles.rb
@@ -54,7 +54,7 @@ class NormalizeEdsArticles
   end
 
   def journal_title
-    return unless bibentity['Titles']
+    return [] unless bibentity['Titles']
     [bibentity['Titles'][0]['TitleFull'],
      'https://sfx.mit.edu/sfx_local?' + 'rft.jtitle=' +
        URI.encode_www_form_component(

--- a/app/models/search_eds.rb
+++ b/app/models/search_eds.rb
@@ -21,10 +21,10 @@ class SearchEds
     @results = {}
   end
 
-  def search(term, profile)
+  def search(term, profile, facets)
     return 'invalid credentials' unless @auth_token
     @session_key = create_session(profile) if @auth_token
-    raw_results = search_filtered(term)
+    raw_results = search_filtered(term, facets)
     end_session
     raw_results
   end
@@ -37,18 +37,19 @@ class SearchEds
     URI.encode(term.strip.tr(' ', '+').delete(','))
   end
 
-  def search_url(term)
+  def search_url(term, facets)
     [EDS_URL, '/edsapi/rest/Search?query=', clean_term(term),
      '&searchmode=all', "&resultsperpage=#{RESULTS_PER_BOX}",
      '&pagenumber=1', '&sort=relevance', '&highlight=n', '&includefacets=n',
-     '&view=detailed', '&autosuggest=n', '&expander=fulltext'].join('')
+     '&view=detailed', '&autosuggest=n', '&expander=fulltext',
+     facets].join('')
   end
 
-  def search_filtered(term)
+  def search_filtered(term, facets)
     result = HTTP.headers(accept: 'application/json',
                           'x-authenticationToken': @auth_token,
                           'x-sessionToken': @session_key)
-                 .get(search_url(term).to_s).to_s
+                 .get(search_url(term, facets).to_s).to_s
     JSON.parse(result)
   end
 

--- a/app/views/search/search.html.erb
+++ b/app/views/search/search.html.erb
@@ -9,21 +9,8 @@
       "View all #{number_with_delimiter(@results['total'])} website results",
       "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}",
       data: {count: @results['total']}) %>
-  <% elsif params[:target] == 'articles' %>
-    <%= link_to(
-      "View all #{number_with_delimiter(@results['total'])} articles",
-      "#{ENV['EDS_NO_ALEPH_URI']}#{params[:q]}",
-      data: {count: @results['total']}) %>
-  <% elsif params[:target] == 'books' %>
-    <%= link_to(
-      "View all #{number_with_delimiter(@results['total'])} books and media",
-      "#{ENV['EDS_ALEPH_URI']}#{params[:q]}",
-      data: {count: @results['total']}) %>
-  <% elsif params[:target] == 'whatnot' %>
-    <%= link_to(
-      "View all #{number_with_delimiter(@results['total'])} like this",
-      "#{ENV['EDS_WHATNOT_URI']}#{params[:q]}",
-      data: {count: @results['total']}) %>
+  <% elsif %w(articles books whatnot).include?(params[:target]) %>
+    View all <%= number_with_delimiter(@results['total']) %> like this link returning soon(ish)!
   <% end %>
 <% else %>
   No results found.

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -4,7 +4,7 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
   def popcorn_articles
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apinoaleph')
+      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       NormalizeEds.new.to_result(raw_query, 'articles')
     end
   end
@@ -63,7 +63,7 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
   test 'normalized articles can handle no authors' do
     VCR.use_cassette('no article authors',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('orange', 'apinoaleph')
+      raw_query = SearchEds.new.search('orange', 'apinoaleph', '')
       query = NormalizeEds.new.to_result(raw_query, 'articles')
       assert_nil(query['results'][0].authors)
     end

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -4,7 +4,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   def popcorn_books
     VCR.use_cassette('popcorn books',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apibarton')
+      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       NormalizeEds.new.to_result(raw_query, 'books')
     end
   end
@@ -37,7 +37,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   test 'normalized books have expected multiple authors' do
     VCR.use_cassette('multiple book authors',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('vonnegut', 'apibarton')
+      raw_query = SearchEds.new.search('vonnegut', 'apibarton', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal(
         ['Vonnegut, Kurt', 'Wakefield, Dan'],
@@ -49,7 +49,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   test 'normalized books can handle no authors' do
     VCR.use_cassette('no book authors',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('orange', 'apibarton')
+      raw_query = SearchEds.new.search('orange', 'apibarton', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_nil(query['results'][0].authors)
     end
@@ -88,7 +88,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   test 'normalized books can handle multiple subjects' do
     VCR.use_cassette('multiple book subjects',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('orange', 'apibarton')
+      raw_query = SearchEds.new.search('orange', 'apibarton', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal(4, query['results'][1].subjects.count)
     end
@@ -108,7 +108,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
   test 'normalized books can have no locations' do
     VCR.use_cassette('multiple book subjects',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('orange', 'apibarton')
+      raw_query = SearchEds.new.search('orange', 'apibarton', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_nil(query['results'][1].location)
     end

--- a/test/models/normalize_eds_test.rb
+++ b/test/models/normalize_eds_test.rb
@@ -4,7 +4,8 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   test 'searches with no results do not error' do
     VCR.use_cassette('no results',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcornandorangejuice', 'apinoaleph')
+      raw_query = SearchEds.new.search('popcornandorangejuice',
+                                       'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'articles')
       assert_equal(0, query['total'])
     end
@@ -16,7 +17,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('rollbar4') do
       searchterm = 'R. F. Harrington, Field computation by moment methods. '\
                    'Macmillan, 1968'
-      raw_query = SearchEds.new.search(searchterm, 'apinoaleph')
+      raw_query = SearchEds.new.search(searchterm, 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'articles')
       assert_equal(77_612_346, query['total'])
     end
@@ -28,7 +29,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('rollbar4a') do
       searchterm = 'R. F. Harrington, Field computation by moment methods. '\
                    'Macmillan, 1968'
-      raw_query = SearchEds.new.search(searchterm, 'apibarton')
+      raw_query = SearchEds.new.search(searchterm, 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal(1_268_662, query['total'])
     end
@@ -48,7 +49,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   test 'can handle missing years' do
     VCR.use_cassette('rollbar8') do
       searchterm = 'web of science'
-      raw_query = SearchEds.new.search(searchterm, 'apinoaleph')
+      raw_query = SearchEds.new.search(searchterm, 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'articles')
       assert_equal(37_667_909, query['total'])
       assert_nil(query['results'][0].year)
@@ -58,7 +59,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   test 'can handle missing title titlefull with item title' do
     VCR.use_cassette('popcorn books',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apibarton')
+      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal('Popcorn handbook', query['results'][3].title)
     end
@@ -67,7 +68,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   test 'can handle missing title titlefull and no item title' do
     VCR.use_cassette('popcorn books',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apibarton')
+      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books')
       assert_equal('unknown title', query['results'][4].title)
     end

--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -4,7 +4,7 @@ class SearchEdsTest < ActiveSupport::TestCase
   test 'can search articles' do
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apinoaleph')
+      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       assert_equal(Hash, query.class)
     end
   end
@@ -12,14 +12,14 @@ class SearchEdsTest < ActiveSupport::TestCase
   test 'can search books' do
     VCR.use_cassette('popcorn non articles',
                      allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apibarton')
+      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       assert_equal(Hash, query.class)
     end
   end
 
   test 'invalid credentials' do
     VCR.use_cassette('invalid credentials') do
-      query = SearchEds.new.search('popcorn', 'apibarton')
+      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       assert_equal('invalid credentials', query)
     end
   end

--- a/test/vcr_cassettes/no_results.yml
+++ b/test/vcr_cassettes/no_results.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:20:47 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apinoaleph
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_articles.yml
+++ b/test/vcr_cassettes/popcorn_articles.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apinoaleph
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_books.yml
+++ b/test/vcr_cassettes/popcorn_books.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Thu, 17 Nov 2016 21:21:11 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_non_articles.yml
+++ b/test/vcr_cassettes/popcorn_non_articles.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:06:17 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/rollbar4.yml
+++ b/test/vcr_cassettes/rollbar4.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Wed, 14 Sep 2016 17:13:13 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apinoaleph
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/rollbar4a.yml
+++ b/test/vcr_cassettes/rollbar4a.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Wed, 14 Sep 2016 17:09:07 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apibarton
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/rollbar8.yml
+++ b/test/vcr_cassettes/rollbar8.yml
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Tue, 27 Sep 2016 19:01:19 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apinoaleph
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
What:

* Moves from multiple EDS Admin configured profiles to a faceted
  approach that uses the source facet to segregate content into
  appropriate boxes

Why:

* EDS profiles would never allow us to create the boxes we were asked
  to create because we were basing the boxes on format of the material
  and profiles can't be created effective that way.
* https://mitlibraries.atlassian.net/browse/DI-136

How:

* Facets for the (currently 3) boxes are configured via the ENV settings.
  EDS_ARTICLE_FACETS, EDS_BOOK_FACETS, EDS_WHATNOT_FACETS

Note:

* The link to more like this is temporarily disabled as we look into how to
  deep link into pre-faceted result sets in EDS UI. That issue is tracked
  via https://mitlibraries.atlassian.net/browse/DI-143
