### PR TITLE
Adds global alert system

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,6 +41,9 @@
     "ENABLED_BOXES": {
       "required": true
     },
+    "GLOBAL_ALERT": {
+      "required": true
+    },
     "GOOGLE_API_KEY": {
       "required": true
     },

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,8 @@
-<% if flash[:error] %>
-  <div class="alert alert-banner alert-danger" role="alert">
-    <%= flash[:error] %>
-  </div>
+<% if flash %>
+  <% flash.each do |msg_type, message| %>
+    <% next if msg_type == 'global' %>
+    <div class="alert alert-banner <%= msg_type %>" role="alert">
+      <%= sanitize(message) %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/layouts/_global_alert.html.erb
+++ b/app/views/layouts/_global_alert.html.erb
@@ -1,0 +1,9 @@
+<% if ENV['GLOBAL_ALERT'] %>
+  <div class="wrap-notices info layout-band">
+    <div class="wrap-notice">
+      <div class="alert alert-global" role="alert">
+        <p><%= sanitize(ENV['GLOBAL_ALERT']) %></p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,13 +8,7 @@
 
     <div class="wrap-page">
 
-    <div class="wrap-notices info layout-band">
-      <div class="wrap-notice">
-        <div class="alert alert-global" role="alert">
-          <p>This is a beta service. Try it out or <a href="http://libraries.mit.edu">return to our main site</a>.</p>
-        </div>
-      </div>
-    </div>
+      <%= render partial: "layouts/global_alert" %>
 
       <%= render partial: "layouts/site_header" %>
 

--- a/test/integration/alerts_test.rb
+++ b/test/integration/alerts_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class AlertsTest < ActionDispatch::IntegrationTest
+  def setup
+    ENV['GLOBAL_ALERT'] = nil
+  end
+
+  def after
+    ENV['GLOBAL_ALERT'] = nil
+  end
+
+  test 'no alert set does not display an alert' do
+    get '/'
+    assert_response :success
+    assert_select('.alert', false)
+  end
+
+  test 'alert set display an alert' do
+    ENV['GLOBAL_ALERT'] = 'This is an alert!!!'
+    get '/'
+    assert_response :success
+    assert_select('.alert', true)
+    assert_select('.alert') do |value|
+      assert(value.text.include?('This is an alert!!!'))
+    end
+  end
+end


### PR DESCRIPTION
What:

* Adds an ENV based global alert system

Why:

* Initially, this will be used to signify test and beta instances of our
application. Eventually, this may be used to signify other globally
relevant application level information (such as known planned API
outages, etc)
* See: https://mitlibraries.atlassian.net/browse/DI-141

How:

* ENV['GLOBAL_ALERT'] can be set like 'This is a beta site. You may be
interested in our
<a href="/some_url">production discovery environment.</a>'
* By using ENV['GLOBAL_ALERT'] we can always set our test ENVs to link
back to Prod versions, etc