### PR TITLE
add app global notice/alert

### DIFF
--- a/app/assets/stylesheets/libraries-global.css
+++ b/app/assets/stylesheets/libraries-global.css
@@ -219,6 +219,7 @@ hr {
 }
 
 .wrap-gridband,
+.wrap-notice,
 .wrap-header,
 .wrap-header-local,
 .wrap-breadcrumb,
@@ -230,6 +231,7 @@ hr {
   padding: 10px 4%;
 }
 .wrap-gridband:after,
+.wrap-notice:after,
 .wrap-header:after,
 .wrap-header-local:after,
 .wrap-breadcrumb:after,
@@ -639,6 +641,9 @@ form .disabled {
 .alert p {
   margin-bottom: .2rem;
 }
+.alert.info {
+  color: #111;
+}
 .alert.success {
   color: #43926a;
 }
@@ -647,6 +652,25 @@ form .disabled {
 }
 .alert.error {
   color: #AC1D22;
+}
+
+/* global app style alerts and notices */
+.wrap-notices {
+  background-color: #f3f3f3;
+  color: #111;
+  font-size: 1.2rem;
+}
+.wrap-notices.info {
+  border-top: 2px solid #ccc;
+}
+.wrap-notices.success {
+  border-top: 2px solid #43926a;
+}
+.wrap-notices.warning {
+  border-top: 2px solid #faa933;
+}
+.wrap-notices.error {
+  border-top: 2px solid #AC1D22;
 }
 
 .alert-banner {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,14 @@
 
     <div class="wrap-page">
 
+    <div class="wrap-notices info layout-band">
+      <div class="wrap-notice">
+        <div class="alert alert-global" role="alert">
+          <p>This is a beta service. Try it out or <a href="http://libraries.mit.edu">return to our main site</a>.</p>
+        </div>
+      </div>
+    </div>
+
       <%= render partial: "layouts/site_header" %>
 
       <div class="wrap-outer-content layout-band">


### PR DESCRIPTION
This PR adds a static beta banner to the bento app - that can also be used to wire in app-level/global-level notifications at some point. 