### PR TITLE
Remove temporary whatnot box, add box description

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,31 +2,16 @@
   "name": "bento",
   "scripts": {},
   "env": {
-    "EDS_ALEPH_PROFILE": {
+    "EDS_PROFILE": {
       "required": true
     },
-    "EDS_ALEPH_URI": {
-      "required": true
-    },
-    "EDS_NO_ALEPH_PROFILE": {
-      "required": true
-    },
-    "EDS_NO_ALEPH_URI": {
-      "required": true
-    },
-    "EDS_WHATNOT_PROFILE": {
-      "required": true
-    },
-    "EDS_WHATNOT_URI": {
+    "EDS_PROFILE_URI": {
       "required": true
     },
     "EDS_ARTICLE_FACETS": {
       "required": true
     },
     "EDS_BOOK_FACETS": {
-      "required": true
-    },
-    "EDS_WHATNOT_FACETS": {
       "required": true
     },
     "EDS_PASSWORD": {
@@ -36,9 +21,6 @@
       "required": true
     },
     "EDS_USER_ID": {
-      "required": true
-    },
-    "ENABLED_BOXES": {
       "required": true
     },
     "GLOBAL_ALERT": {
@@ -72,12 +54,6 @@
       "required": true
     },
     "SECRET_KEY_BASE": {
-      "required": true
-    },
-    "WORLDCAT_URI": {
-      "required": true
-    },
-    "WORLDCAT_API_KEY": {
       "required": true
     }
   },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,4 @@ class ApplicationController < ActionController::Base
   def new_session_path(_scope)
     root_path
   end
-
-  # Set which boxes are enabled
-  def enable_boxes
-    return if session[:boxes]
-    session[:boxes] = ENV['ENABLED_BOXES'].split(',')
-  end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -35,7 +35,7 @@ class SearchController < ApplicationController
 
   # Array of search endpoints that are supported
   def valid_targets
-    %w(articles books google whatnot)
+    %w(articles books google)
   end
 
   # Formatted date used in creating cache keys
@@ -53,13 +53,8 @@ class SearchController < ApplicationController
 
   # Seaches EDS
   def search_eds
-    raw_results = SearchEds.new.search(strip_q, eds_profile, eds_facets)
+    raw_results = SearchEds.new.search(strip_q, ENV['EDS_PROFILE'], eds_facets)
     NormalizeEds.new.to_result(raw_results, params[:target])
-  end
-
-  # Determines appropriate EDS profile
-  def eds_profile
-    ENV['EDS_WHATNOT_PROFILE']
   end
 
   def eds_facets
@@ -67,8 +62,6 @@ class SearchController < ApplicationController
       ENV['EDS_ARTICLE_FACETS']
     elsif params[:target] == 'books'
       ENV['EDS_BOOK_FACETS']
-    elsif params[:target] == 'whatnot'
-      ENV['EDS_WHATNOT_FACETS']
     end
   end
 

--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -21,7 +21,7 @@ class NormalizeEdsBooks
   end
 
   def subject_link(subject)
-    ENV['EDS_ALEPH_URI'] + URI.encode_www_form_component("DE \"#{subject}\"")
+    ENV['EDS_PROFILE_URI'] + URI.encode_www_form_component("DE \"#{subject}\"")
   end
 
   def location

--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -64,11 +64,7 @@ class NormalizeEdsCommon
   end
 
   def author_link(author_node)
-    if @type == 'books'
-      ENV['EDS_ALEPH_URI'] + author_search_format(author_node)
-    else
-      ENV['EDS_NO_ALEPH_URI'] + author_search_format(author_node)
-    end
+    ENV['EDS_PROFILE_URI'] + author_search_format(author_node)
   end
 
   def author_search_format(author_node)

--- a/app/views/search/_help.html.erb
+++ b/app/views/search/_help.html.erb
@@ -1,18 +1,11 @@
-<hr />
-
-<div class="row region" data-region="other">
-  <div class="wrap-help">
-    <h2 class="title">Not finding what you're looking for? Try these other tools:</h2>
-    <dl>
-      <dt><a href="//libraries.mit.edu/vera">Vera</a></dt>
-      <dd>Best for e-journals and databases owned or licensed by the MIT Libraries. Don’t search for individual articles here.</dd>
-      <dt><a href="//libraries.mit.edu/worldcat">WorldCat</a></dt>
-      <dd>Best for books and other items not owned by the MIT Libraries. Using this interface, you can request items from <a href="//libraries.mit.edu/borrow-direct">Borrow Direct</a> or <a href="//libraries.mit.edu/ilb">Interlibrary Borrowing (ILB)</a>.</dd>
-    </dl>
-    <h3 class="title-sub">Specialized search tools &amp; guides</h2>
-    <dl>
-      <dt><a href="http://archnet.org/">Archnet</a></dt>
-      <dd>Search for resources on architecture, urbanism, environmental and landscape design, visual culture, and conservation issues related to the Muslim world.</dd>
-    </dl>
+<div class="gridband">
+  <div class="wrap-chat inline-action">
+    <div class="message">
+      <h2 class="title">Get help from a research professional</h2>
+      <p>Our librarians are trained to find what you need.</p>
+    </div>
+    <div class="actions">
+      <a class="button button-secondary" href="https://libraries.mit.edu/ask/">AskUs: Chat with a Librarian</a>
+    </div>
   </div>
 </div>

--- a/app/views/search/_other_resources.html.erb
+++ b/app/views/search/_other_resources.html.erb
@@ -1,0 +1,48 @@
+<div class="wrap-results grid-item">
+  <h2 class="title">Other resources</h2>
+  <div class="wrap-help">
+    <p class="results-desc">Not finding what you're looking for? Try one of these tools.</p>
+
+    <dl>
+      <dt></dt>
+      <dd>
+        <a href="https://libraries.mit.edu/vera">Browse Databases by subject</a>
+      </dd>
+      <dd>
+        <a href="https://libraries.mit.edu/experts">Browse research guides</a>
+      </dd>
+      <dd>
+        <a href="https://dspace.mit.edu">Search DSpace/MIT theses</a>
+      </dd>
+      <dd>
+        <a href="http://libguides.mit.edu/reserves">Find course reserves</a>
+      </dd>
+    </dl>
+
+    <dl>
+      <dt>Popular tools</dt>
+      <dd>
+        <a href="https://scholar.google.com">Google Scholar</a>
+      </dd>
+      <dd>
+        <a href="http://libraries.mit.edu/worldcat">WorldCat: Libraries worldwide</a>
+      </dd>
+      <dd>
+        <a href="http://dome.mit.edu">DOME: MIT image repository</a>
+      </dd>
+    </dl>
+
+    <dl>
+      <dt>Tips for searching</dt>
+      <dd>
+        <a href="">Advanced search tips</a>
+      </dd>
+      <dd>
+        <a href="">More about search</a>
+      </dd>
+      <dd>
+        <a href="https://libraries.mit.edu/ask/">Other ways to get help</a>
+      </dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/search/_placeholders.html.erb
+++ b/app/views/search/_placeholders.html.erb
@@ -1,6 +1,7 @@
 <div id="box-<%= id %>" class="wrap-results grid-item">
   <h2 class="title"><%= heading %></h2>
-  <div id="<%= id %>" class="<%= id %> region" data-region="<%= id %>"> 
+  <p class="results-desc"><%= sanitize(description) %></a></p>
+  <div id="<%= id %>" class="<%= id %> region" data-region="<%= id %>">
     Loading results...
     <i class="fa fa-spinner fa-spin"></i>
   </div>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -8,22 +8,21 @@
 
     <a href="#box-articles_content"><span class="results-summary-item" data-region="books">Books and Media <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
 
-    <a href="#box-whatnot_content"><span  class="results-summary-item"data-region="whatnot">Whatnot <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
-
     <a href="#box-website_content"><span class="results-summary-item" data-region="google">Webpages <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
   </p>
 </div>
 
 <div class="gridband layout-2c">
-  <%= render partial: "placeholders", locals: { heading: 'Books and Media', id: 'books_content'} %>
+  <%= render partial: "placeholders", locals: { heading: 'Books and Media', id: 'books_content', description: 'Books, ebooks, audio books at MIT.<br />
+<a href="https://mit.worldcat.org">Expand to libraries around the world</a>' } %>
 
-  <%= render partial: "placeholders", locals: { heading: 'Articles', id: 'articles_content'} %>
+  <%= render partial: "placeholders", locals: { heading: 'Articles', id: 'articles_content', description: 'Articles from a variety of periodical publications, including journals, magazines, and newspapers from MIT. <a href="http://libraries.mit.edu/search/">More search options</a>' } %>
 </div>
 
 <div class="gridband layout-2c">
-  <%= render partial: "placeholders", locals: { heading: 'Whatnot', id: 'whatnot_content'} %>
+  <%= render partial: "placeholders", locals: { heading: 'Website and Guides', id: 'website_content', description: 'MIT Libraries website and research guides.' } %>
 
-  <%= render partial: "placeholders", locals: { heading: 'Website and Guides', id: 'website_content'} %>
+  <%= render partial: "other_resources" %>
 </div>
 
 <%= render partial: "help" %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,18 +4,14 @@ Rails.application.configure do
   ENV['EDS_URL'] = 'https://eds-api.ebscohost.com'
   ENV['EDS_USER_ID'] = 'FAKE_EDS_USER_ID'
   ENV['EDS_PASSWORD'] = 'FAKE_EDS_PASSWORD'
-  ENV['EDS_NO_ALEPH_PROFILE'] = 'apinoaleph'
-  ENV['EDS_ALEPH_PROFILE'] = 'apibarton'
-  ENV['EDS_WHATNOT_PROFILE'] = 'apiwhatnot'
+  ENV['EDS_PROFILE'] = 'apiwhatnot'
   ENV['GOOGLE_API_KEY'] = 'FAKE_GOOGLE_API_KEY'
   ENV['GOOGLE_CUSTOM_SEARCH_ID'] = 'FAKE_GOOGLE_CUSTOM_SEARCH_ID'
   ENV['WORLDCAT_URI'] = 'http://www.worldcat.org/webservices/catalog/search/worldcat/'
   ENV['WORLDCAT_API_KEY'] = 'FAKE_WORLDCAT_KEY'
   ENV['ENABLED_BOXES'] = 'website,books,articles,worldcat'
   ENV['MAX_AUTHORS'] = '3'
-  ENV['EDS_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3D'
-  ENV['EDS_NO_ALEPH_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedsnoaleph%26profile%3Dedsnoaleph%26bquery%3D'
-  ENV['EDS_WHATNOT_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3D'
+  ENV['EDS_PROFILE_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3D'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -61,17 +61,6 @@ class SearchTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'whatnot results are populated' do
-    VCR.use_cassette('popcorn whatnot',
-                     allow_playback_repeats: true) do
-      get '/search/search?q=popcorn&target=whatnot'
-      assert_response :success
-      assert_select('a.bento-link') do |value|
-        assert(value.text.include?('Sensory and nutritional evaluation'))
-      end
-    end
-  end
-
   test 'invalid target' do
     get '/search/search?q=popcorn&target=hackor'
     follow_redirect!

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -55,7 +55,7 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
 
   test 'normalized articles have expected author links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedsnoaleph%26profile%3Dedsnoaleph%26bquery%3DAU+%22Moreira+Ribeiro%2C+Rodrigo%22',
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DAU+%22Moreira+Ribeiro%2C+Rodrigo%22',
       popcorn_articles['results'][0].authors[0][1]
     )
   end

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -29,7 +29,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
 
   test 'normalized books have expected author links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3DAU+%22Mulholland%2C+Garry%22',
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DAU+%22Mulholland%2C+Garry%22',
       popcorn_books['results'][0].authors[0][1]
     )
   end
@@ -76,7 +76,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
 
   test 'normalized books have expected subject links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26profile%3Dedsbarton%26bquery%3DDE+%22Rock+films+--+History+and+criticism%22',
+      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DDE+%22Rock+films+--+History+and+criticism%22',
       popcorn_books['results'][0].subjects[0][1]
     )
   end


### PR DESCRIPTION
What:

* Removes the temporary whatnot box to move us closer to our test
target. https://mitlibraries.atlassian.net/browse/DI-144
* Adds box descriptions and creates place to put the help stuff and
the other resources links. All of those needs styles and some of it
needs markup. https://mitlibraries.atlassian.net/browse/DI-145
* removes some remnants of using multiple EDS profiles that were
confusing me