### PR TITLE
add about bento block

### DIFF
--- a/app/assets/stylesheets/bento.scss
+++ b/app/assets/stylesheets/bento.scss
@@ -344,3 +344,7 @@ $z-depth-way-front:     1000;
     margin-bottom: .2em;
   }
 }
+
+.about-bento {
+  margin: 4rem 0;
+}

--- a/app/assets/stylesheets/libraries-global.css
+++ b/app/assets/stylesheets/libraries-global.css
@@ -675,6 +675,7 @@ form .disabled {
 }
 
 .alert p {
+  margin-top: .2rem;
   margin-bottom: .2rem;
 }
 .alert.info {

--- a/app/views/layouts/_about-bento.html.erb
+++ b/app/views/layouts/_about-bento.html.erb
@@ -1,0 +1,5 @@
+<div class="about-bento bit">
+  <h3 class="title">About Discovery search</h3>
+  <p>Discovery at the MIT Libraries is a new way to find books, movies, music, articles, journals, and other great stuff we have at the library. You will find results sorted into categories: Books and media, Articles and journals, and Library website, as well as links to more specific search tools and resources. If you need assistance, you can click to chat with one of the library staff. </p>
+  <p><a href="">Let us know what you think of this new tool</a></p>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
           <main id="content-main" class="content-main" role="main">
             <%= render partial: "layouts/flash" %>
             <%= yield %>
+
+            <%= render partial: "layouts/about-bento" %>
+
           </main>
           <!-- close content-main -->
         </div>


### PR DESCRIPTION
This PR adds an "About bento" informational block to the bottom of the bento pages. 
NOTE: Copy is still TBD but shippable.