### PR TITLE
Di178 view more toggle

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -66,7 +66,7 @@ class SearchController < ApplicationController
     raw_results = SearchEds.new.search(
       strip_q, ENV['EDS_PROFILE'], eds_facets, page, per_page
     )
-    NormalizeEds.new.to_result(raw_results, params[:target])
+    NormalizeEds.new.to_result(raw_results, params[:target], strip_q)
   end
 
   def eds_facets
@@ -80,7 +80,7 @@ class SearchController < ApplicationController
   # Searches Google Custom Search
   def search_google
     raw_results = SearchGoogle.new.search(strip_q)
-    NormalizeGoogle.new.to_result(raw_results)
+    NormalizeGoogle.new.to_result(raw_results, strip_q)
   end
 
   # Strips trailing and leading white space in search term

--- a/app/models/normalize_google.rb
+++ b/app/models/normalize_google.rb
@@ -2,16 +2,22 @@
 #
 class NormalizeGoogle
   # Translate Google results into local result model
-  def to_result(results)
+  def to_result(results, q)
     norm = {}
     norm['total'] = results.queries['request'][0]
                            .total_results.to_i
     norm['results'] = []
+    norm['view_more_url'] = view_more(q)
     extract_results(results, norm)
     norm
   end
 
   private
+
+  def view_more(q)
+    "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}" \
+      "&ie=UTF-8&q=#{q}&sa=Search#gsc.tab=0&gsc.q=#{q}"
+  end
 
   # Extract the information we care about from the raw results and add them
   # return them as an array of {result}s

--- a/app/views/search/_view_all_link.html.erb
+++ b/app/views/search/_view_all_link.html.erb
@@ -1,17 +1,10 @@
 <% if current_page?(:controller => 'search', :action => 'search_boxed') %>
   <div class="results-more">
   <% if @results['total'] > 0 %>
-    <% if params[:target] == 'google' %>
-      <%= link_to(
-        "View all #{number_with_delimiter(@results['total'])} website results",
-        "https://cse.google.com/cse?cx=#{ENV['GOOGLE_CUSTOM_SEARCH_ID']}&ie=UTF-8&q=#{params[:q]}&sa=Search#gsc.tab=0&gsc.q=#{params[:q]}",
-        data: {count: @results['total']}) %>
-    <% elsif %w(articles books whatnot).include?(params[:target]) %>
-      <%= link_to(
-        "View all #{number_with_delimiter(@results['total'])} results like this.",
-        search_path(q: params[:q], page: 1, target: params[:target]),
-        data: {count: @results['total']}) %>
-    <% end %>
+    <%= link_to(
+      "View all #{number_with_delimiter(@results['total'])} results like this.",
+      @results['view_more_url'],
+      data: {count: @results['total']}) %>
   <% else %>
     No results found.
   <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   ENV['ENABLED_BOXES'] = 'website,books,articles,worldcat'
   ENV['MAX_AUTHORS'] = '3'
   ENV['EDS_PROFILE_URI'] = 'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3D'
+  ENV['EDS_BOOK_FACETS'] = '&facetfilter=1,SourceType:Books,SourceType:eBooks,SourceType:Audiobooks,SourceType:Dissertations,SourceType:Music+Scores,SourceType:Audio,SourceType:Videos'
+  ENV['EDS_ARTICLE_FACETS'] = '&facetfilter=1,SourceType:Academic+Journals,SourceType:Magazines,SourceType:Conference+Materials'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -4,8 +4,9 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
   def popcorn_articles
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
-      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
-      NormalizeEds.new.to_result(raw_query, 'articles')
+      raw_query = SearchEds.new.search('popcorn', 'apiwhatnot',
+                                       ENV['EDS_ARTICLE_FACETS'])
+      NormalizeEds.new.to_result(raw_query, 'articles', 'popcorn')
     end
   end
 
@@ -64,7 +65,7 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
     VCR.use_cassette('no article authors',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('orange', 'apinoaleph', '')
-      query = NormalizeEds.new.to_result(raw_query, 'articles')
+      query = NormalizeEds.new.to_result(raw_query, 'articles', 'orange')
       assert_nil(query['results'][0].authors)
     end
   end

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -5,7 +5,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn books',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
-      NormalizeEds.new.to_result(raw_query, 'books')
+      NormalizeEds.new.to_result(raw_query, 'books', 'popcorn books')
     end
   end
 
@@ -38,7 +38,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('multiple book authors',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('vonnegut', 'apibarton', '')
-      query = NormalizeEds.new.to_result(raw_query, 'books')
+      query = NormalizeEds.new.to_result(raw_query, 'books', 'vonnegut')
       assert_equal(
         ['Vonnegut, Kurt', 'Wakefield, Dan'],
         query['results'][0].authors.map { |a| a[0] }
@@ -50,7 +50,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('no book authors',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('orange', 'apibarton', '')
-      query = NormalizeEds.new.to_result(raw_query, 'books')
+      query = NormalizeEds.new.to_result(raw_query, 'books', 'orange')
       assert_nil(query['results'][0].authors)
     end
   end
@@ -89,7 +89,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('multiple book subjects',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('orange', 'apibarton', '')
-      query = NormalizeEds.new.to_result(raw_query, 'books')
+      query = NormalizeEds.new.to_result(raw_query, 'books', 'orange')
       assert_equal(4, query['results'][1].subjects.count)
     end
   end
@@ -109,7 +109,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('multiple book subjects',
                      allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('orange', 'apibarton', '')
-      query = NormalizeEds.new.to_result(raw_query, 'books')
+      query = NormalizeEds.new.to_result(raw_query, 'books', 'orange')
       assert_nil(query['results'][1].location)
     end
   end

--- a/test/models/normalize_google_test.rb
+++ b/test/models/normalize_google_test.rb
@@ -5,7 +5,7 @@ class NormalizeGoogleTest < ActiveSupport::TestCase
   test 'normalized results have expected title' do
     VCR.use_cassette('valid google search and credentials') do
       raw_query = SearchGoogle.new.search('endnote')
-      query = NormalizeGoogle.new.to_result(raw_query)
+      query = NormalizeGoogle.new.to_result(raw_query, 'endnote')
       assert_equal(
         'EndNote with LaTeX & BibTeX - EndNote at MIT',
         query['results'].first.title.split[0...9].join(' ')
@@ -16,7 +16,7 @@ class NormalizeGoogleTest < ActiveSupport::TestCase
   test 'normalized articles have expected url' do
     VCR.use_cassette('valid google search and credentials') do
       raw_query = SearchGoogle.new.search('endnote')
-      query = NormalizeGoogle.new.to_result(raw_query)
+      query = NormalizeGoogle.new.to_result(raw_query, 'endnote')
       assert_equal(
         'http://libguides.mit.edu/c.php?g=176170&p=1158648',
         query['results'].first.url
@@ -27,7 +27,7 @@ class NormalizeGoogleTest < ActiveSupport::TestCase
   test 'normalized articles have expected snippet' do
     VCR.use_cassette('valid google search and credentials') do
       raw_query = SearchGoogle.new.search('endnote')
-      query = NormalizeGoogle.new.to_result(raw_query)
+      query = NormalizeGoogle.new.to_result(raw_query, 'endnote')
       assert_includes(query['results'].first.blurb, 'with LaTeX and BibTeX')
     end
   end
@@ -35,7 +35,7 @@ class NormalizeGoogleTest < ActiveSupport::TestCase
   test 'searches with no results do not error' do
     VCR.use_cassette('google no results') do
       raw_query = SearchGoogle.new.search('asdffdsaasdffdsa')
-      query = NormalizeGoogle.new.to_result(raw_query)
+      query = NormalizeGoogle.new.to_result(raw_query, 'asdffdsaasdffdsa')
       assert_equal(0, query['total'])
     end
   end
@@ -43,7 +43,7 @@ class NormalizeGoogleTest < ActiveSupport::TestCase
   test 'handles pages with no metadata' do
     VCR.use_cassette('google no metadata') do
       raw_query = SearchGoogle.new.search('weather patterns')
-      query = NormalizeGoogle.new.to_result(raw_query)
+      query = NormalizeGoogle.new.to_result(raw_query, 'weather patterns')
       assert_equal(88, query['total'])
     end
   end

--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -4,7 +4,8 @@ class SearchEdsTest < ActiveSupport::TestCase
   test 'can search articles' do
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
+      query = SearchEds.new.search('popcorn', 'apiwhatnot',
+                                   ENV['EDS_ARTICLE_FACETS'])
       assert_equal(Hash, query.class)
     end
   end
@@ -12,7 +13,8 @@ class SearchEdsTest < ActiveSupport::TestCase
   test 'can search books' do
     VCR.use_cassette('popcorn non articles',
                      allow_playback_repeats: true) do
-      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
+      query = SearchEds.new.search('popcorn', 'apiwhatnot',
+                                   ENV['EDS_BOOK_FACETS'])
       assert_equal(Hash, query.class)
     end
   end

--- a/test/vcr_cassettes/popcorn_articles.yml
+++ b/test/vcr_cassettes/popcorn_articles.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=5&searchmode=all&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&facetfilter=1,SourceType:Academic%20Journals,SourceType:Magazines,SourceType:Conference%20Materials&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=5&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_books_paginated.yml
+++ b/test/vcr_cassettes/popcorn_books_paginated.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:06:17 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=10&searchmode=all&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&facetfilter=1,SourceType:Books,SourceType:eBooks,SourceType:Audiobooks,SourceType:Dissertations,SourceType:Music%20Scores,SourceType:Audio,SourceType:Videos&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=10&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/popcorn_non_articles.yml
+++ b/test/vcr_cassettes/popcorn_non_articles.yml
@@ -94,7 +94,7 @@ http_interactions:
   recorded_at: Thu, 27 Oct 2016 19:06:17 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=5&searchmode=all&sort=relevance&view=detailed
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&facetfilter=1,SourceType:Books,SourceType:eBooks,SourceType:Audiobooks,SourceType:Dissertations,SourceType:Music%20Scores,SourceType:Audio,SourceType:Videos&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=5&searchmode=all&sort=relevance&view=detailed
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
What:
* Allows a toggle between viewing local paginated results and results
  in EDS UI
* The default is EDS UI
* This is a global setting
* To enable local paginated results, set Environment Variable
  `LOCAL_RESULTS=true`

Why:
* It is still not clear whether we want to send people to EDS UI or use a
  local solution for this feature
* This feature toggle will allow us to test both options to make an
  informed decision on what is best
* See https://mitlibraries.atlassian.net/browse/DI-178
