### PR TITLE
Di59 result error handling

### DIFF
--- a/app/models/search_eds.rb
+++ b/app/models/search_eds.rb
@@ -46,9 +46,13 @@ class SearchEds
   end
 
   def search_filtered(term, facets, page, per_page)
+    Rails.logger.debug(
+      "EDS Search URL: #{search_url(term, facets, page, per_page)}"
+    )
     result = HTTP.headers(accept: 'application/json',
                           'x-authenticationToken': @auth_token,
                           'x-sessionToken': @session_key)
+                 .timeout(:global, write: 2, connect: 2, read: 2)
                  .get(search_url(term, facets, page, per_page).to_s).to_s
     JSON.parse(result)
   end

--- a/app/views/search/_trigger_search.html.erb
+++ b/app/views/search/_trigger_search.html.erb
@@ -1,4 +1,11 @@
-$('#<%= id %>').load("/search/search_boxed?q=<%= URI.encode_www_form_component(params[:q]) %>&target=<%= target %>", function() {
+$.ajax({
+  url: "/search/search_boxed?q=<%= URI.encode_www_form_component(params[:q]) %>&target=<%= target %>",
+  context: $('#<%= id %>')
+}).done(function( msg ) {
+  $('#<%= id %>').html( msg );
   TrackLinks( $( this ).find( 'a' ) );
   ReportSummary( '<%= target %>', $( this ).find('[data-count]').data('count') );
+}).fail(function( xhr, textStatus ) {
+  console.log(xhr);
+  $('#<%= id %>').html( 'An error has occured loading results. Sorry.' ).addClass('alert error');
 });

--- a/app/views/search/_trigger_search.html.erb
+++ b/app/views/search/_trigger_search.html.erb
@@ -7,5 +7,5 @@ $.ajax({
   ReportSummary( '<%= target %>', $( this ).find('[data-count]').data('count') );
 }).fail(function( xhr, textStatus ) {
   console.log(xhr);
-  $('#<%= id %>').html( 'An error has occured loading results. Sorry.' ).addClass('alert error');
+  $('#<%= id %>').html( 'Sorry, an error has occurred loading results at this time.' ).addClass('alert error');
 });

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,13 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -5,7 +5,7 @@ Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
 
   # Here we'll disable in 'test':
-  if Rails.env.test?
+  if Rails.env.test? || Rails.env.development?
     config.enabled = false
   end
 


### PR DESCRIPTION
What:

* This presents an error message to users when things go awry during the
  XHR requests
* This does not try to get fancy and report errors from the client side,
  but instead assumes the errors would have been logged during the rails
  server side processing (which is probably true)
* It does log to the end user's JavaScript console the xhr response when
  this is triggered so in theory we could work with tech savvy users to
  get a copy of the request if necessary (probably not)
* This also adds a timeout of 6 seconds to the EDS API calls and logs
  all URLs to EDS for debug purposes
* Disables rollbar and enables more logging in dev environment

Why:

* The previous fail state was an infinitely spinning loader image which
  was obviously not too helpful

Note:
* see also https://mitlibraries.atlassian.net/browse/DI-59
