### PR TITLE
Adds get_it_label so get_it_url can be customized

### DIFF
--- a/app/models/normalize_eds_articles.rb
+++ b/app/models/normalize_eds_articles.rb
@@ -9,6 +9,7 @@ class NormalizeEdsArticles
     result.citation = numbering
     result.in = journal_title
     result.get_it_url = link(result)
+    result.get_it_label = 'Get it'
     result
   end
 

--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -11,6 +11,7 @@ class NormalizeEdsBooks
     result.location = location
     result.subjects = subjects
     result.get_it_url = @record['PLink']
+    result.get_it_label = 'Details and availability'
     result
   end
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -6,7 +6,8 @@ class Result
 
   attr_accessor :title, :year, :url, :type, :authors, :citation, :online,
                 :year, :type, :in, :publisher, :location, :blurb, :subjects,
-                :available_url, :thumbnail, :get_it_url, :db_source
+                :available_url, :thumbnail, :get_it_label, :get_it_url,
+                :db_source
 
   def initialize(title, url)
     @title = title

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -9,7 +9,7 @@
   <h3 class="result-title">
     <span class="sr">Title: </span><%= link_to(result.title, result.url, class: 'bento-link') %>
   </h3>
-  
+
   <% if result.type %>
     <p class="result-type"><span class="sr">Type: </span><%= result.type %></p>
   <% end %>
@@ -71,10 +71,10 @@
       Source DB: <%= result.db_source[0] %> (<%= result.db_source[1] %>)
     </p>
   <% end %>
-  
-  <% if result.url %>
+
+  <% if result.get_it_url.present? %>
     <div class="result-get">
-      <%= link_to('Get it', result.get_it_url, class: 'button button-primary') %>
+      <%= link_to(result.get_it_label, result.get_it_url, class: 'button button-primary') %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
What:

* adds Result.get_it_label

Why:

* a single label for all get_it_urls was not clear to users

See also:

* https://mitlibraries.atlassian.net/browse/DI-180