### PR TITLE
small a11y fixes

### DIFF
--- a/app/assets/stylesheets/bento.scss
+++ b/app/assets/stylesheets/bento.scss
@@ -117,6 +117,10 @@ $z-depth-way-front:     1000;
 // #BENTO-SPECIFIC - BEGIN
 // ----------------------------
 
+.wrap-notices .title {
+  font-size: 1.2rem;
+}
+
 .wrap-outer-header-local {
   display: none;
 }

--- a/app/views/layouts/_global_alert.html.erb
+++ b/app/views/layouts/_global_alert.html.erb
@@ -2,7 +2,7 @@
   <div class="wrap-notices info layout-band">
     <div class="wrap-notice">
       <div class="alert alert-global">
-        <p><%= sanitize(ENV['GLOBAL_ALERT']) %></p>
+        <h1 class="title"><%= sanitize(ENV['GLOBAL_ALERT']) %></h1>
       </div>
     </div>
   </div>

--- a/app/views/layouts/_site_footer.html.erb
+++ b/app/views/layouts/_site_footer.html.erb
@@ -10,7 +10,7 @@
         </div>
       </div><!-- end div.identity -->
       <div class="wrap-sitemap">
-        <nav class="sitemap-libraries-abbrev" aria-label="MIT Libraries site menu">
+        <nav class="sitemap-libraries-abbrev">
           <h2 class="sr">MIT Libraries navigation</h2>
           <a class="item" href="https://libraries.mit.edu/">Home</a>
           <a class="item" href="https://libraries.mit.edu/search">Search</a>


### PR DESCRIPTION
I realized that there were 2 small fixes that ATIC recommended outside issues which are in this PR: make the alert a little more findable since it's outside the main area, and remove the redundant aria label on the nav since the header is doing the same thing.