### PR TITLE
Pass profile info with detail links

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,9 @@
     "EDS_PASSWORD": {
       "required": true
     },
+    "EDS_PLINK_APPEND": {
+      "required": true
+    },
     "EDS_URL": {
       "required": true
     },

--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -10,9 +10,13 @@ class NormalizeEdsBooks
     result.publisher = publisher
     result.location = location
     result.subjects = subjects
-    result.get_it_url = @record['PLink']
+    result.get_it_url = getit_url
     result.get_it_label = 'Details and availability'
     result
+  end
+
+  def getit_url
+    "#{@record['PLink']}#{ENV['EDS_PLINK_APPEND']}"
   end
 
   def subjects


### PR DESCRIPTION
What:

* To ensure we send users consistently to the expected detail page
  in EDS, we need to pass some additional information to the link
  we extract from the EDS record.

Why:

* Not passing in the profile information sent users sometimes to an
  unexpected profile.

How:

* ENV `EDS_PLINK_APPEND` will now append parameters to the extracted URL
  to allow for targeting specific profiles.