### PR TITLE
Books record link fix

### DIFF
--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -10,13 +10,9 @@ class NormalizeEdsBooks
     result.publisher = publisher
     result.location = location
     result.subjects = subjects
-    result.get_it_url = getit_url
+    result.get_it_url = result.url
     result.get_it_label = 'Details and availability'
     result
-  end
-
-  def getit_url
-    "#{@record['PLink']}#{ENV['EDS_PLINK_APPEND']}"
   end
 
   def subjects

--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -42,7 +42,7 @@ class NormalizeEdsCommon
   end
 
   def link
-    @record['PLink']
+    "#{@record['PLink']}#{ENV['EDS_PLINK_APPEND']}"
   end
 
   def availability


### PR DESCRIPTION
When we added profile information to get_it_urls for books, we didn’t
update the title link which for books also links to the same profile
page.

This change ensures they use the same code to set both links.