### PR TITLE
Add Recaptcha to Feedback Form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'omniauth-mit-oauth2'
 gem 'omniauth-oauth2'
 gem 'puma'
 gem 'rails', '5.0.1'
+gem 'recaptcha', require: 'recaptcha/rails'
 gem 'rollbar'
 gem 'sass-rails'
 gem 'therubyracer', platforms: :ruby
@@ -42,6 +43,7 @@ group :test do
   gem 'minitest-rails'
   gem 'minitest-rails-capybara'
   gem 'minitest-reporters'
+  gem 'mocha'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
       mime-types (>= 1.16, < 4)
     memcachier (0.0.2)
     memoist (0.15.0)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -175,6 +176,8 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -238,6 +241,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.1)
     rake (11.3.0)
+    recaptcha (4.0.1)
+      json
     ref (2.0.0)
     representable (2.3.0)
       uber (~> 0.0.7)
@@ -336,6 +341,7 @@ DEPENDENCIES
   minitest-rails
   minitest-rails-capybara
   minitest-reporters
+  mocha
   newrelic_rpm
   omniauth-mit-oauth2
   omniauth-oauth2
@@ -343,6 +349,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (= 5.0.1)
+  recaptcha
   rollbar
   rubocop
   sass-rails

--- a/app.json
+++ b/app.json
@@ -56,6 +56,8 @@
     "RAILS_SERVE_STATIC_FILES": {
       "required": true
     },
+    "RECAPTCHA_SECRET_KEY": "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe",
+    "RECAPTCHA_SITE_KEY": "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI",
     "ROLLBAR_ACCESS_TOKEN": {
       "required": true
     },

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,5 +1,6 @@
 class FeedbackController < ApplicationController
   before_action :validate_message!, only: [:submit]
+  before_action :recaptcha!, only: [:submit]
 
   def index; end
 
@@ -11,6 +12,12 @@ class FeedbackController < ApplicationController
   end
 
   private
+
+  def recaptcha!
+    return if verify_recaptcha
+    flash[:error] = 'Please confirm you are not a robot.'
+    redirect_to feedback_url
+  end
 
   def validate_message!
     return if params[:feedback_message].present?

--- a/app/views/feedback/index.html.erb
+++ b/app/views/feedback/index.html.erb
@@ -12,6 +12,10 @@
     </div>
 
     <div class="form-group">
+      <%= recaptcha_tags unless Rails.env.test? %>
+    </div>
+
+    <div class="form-group">
       <%= submit_tag "Submit Feedback", class: 'btn button-primary' %>
     </div>
   </div>

--- a/test/integration/feedback_test.rb
+++ b/test/integration/feedback_test.rb
@@ -39,4 +39,19 @@ class FeedbackTest < ActionDispatch::IntegrationTest
       assert_select('p', 'Feedback Submitted')
     end
   end
+
+  test 'feedback with no recaptcha redirects to feedback_url' do
+    FeedbackController.any_instance.stubs(:verify_recaptcha).returns(false)
+    assert_difference('ActionMailer::Base.deliveries.size', 0) do
+      post feedback_submit_url, params: {
+        feedback_message: 'Popcorn is cool.',
+        contact_email: 'yo@example.com',
+        previous_page: 'http://example.com/hi'
+      }
+      follow_redirect!
+      assert_select('.alert') do |value|
+        assert(value.text.include?('Please confirm you are not a robot.'))
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/rails/capybara'
 require 'minitest/reporters'
+require 'mocha/mini_test'
 Minitest::Reporters.use!
 
 VCR.configure do |config|


### PR DESCRIPTION
What
- adds recaptcha to feedback form
- uses test keys in pr build

Why
- to prevent spam