### PR TITLE
Defaults to 20 per page for paginated results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -13,7 +13,7 @@ class SearchController < ApplicationController
 
   def search
     page = params[:page] || 1
-    per_page = params[:per_page] || 10
+    per_page = params[:per_page] || ENV['PER_PAGE'] || 20
     @results = search_results(page, per_page)
     return redirect_to root_url unless @results
     render 'search_boxed'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,6 +17,7 @@ Rails.application.configure do
   ENV['FEEDBACK_MAIL_TO'] = 'test@example.com'
   ENV['ALEPH_API_URI'] = 'https://fake_server.example.com/rest-dlf/'
   ENV['ALEPH_KEY'] = 'FAKE_KEY'
+  ENV['PER_PAGE'] = '10'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that


### PR DESCRIPTION
* The new default is 20 per page for paginated results
* `ENV[‘PER_PAGE’]` is available to change that
* passing in a `per_page` URL parameter remains an option as well