### PR TITLE
Removes unnecessary info from feedback email

### DIFF
--- a/app/views/feedback_mailer/feedback_email.html.erb
+++ b/app/views/feedback_mailer/feedback_email.html.erb
@@ -1,6 +1,4 @@
-<p>The following feedback was submitted.</p>
-
-  <p><%= @msg %></p>
+<p><%= @msg %></p>
 
   <p>Contact Name: <%= @contact_name %></p>
 

--- a/test/controllers/feedback_controller_test.rb
+++ b/test/controllers/feedback_controller_test.rb
@@ -19,8 +19,6 @@ class FeedbackControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal('MIT Bento Feedback', feedback_email.subject)
     assert_equal('test@example.com', feedback_email.to[0])
-    assert_match(/The following feedback was submitted/,
-                 feedback_email.body.to_s)
     assert_match(/Popcorn is cool./,
                  feedback_email.body.to_s)
     assert_match(/Client IP: 127.0.0.1/,

--- a/test/fixtures/feedback_mailer/feedback_email
+++ b/test/fixtures/feedback_mailer/feedback_email
@@ -8,9 +8,7 @@
   </head>
 
   <body>
-    <p>The following feedback was submitted.</p>
-
-  <p>This is an important message!</p>
+    <p>This is an important message!</p>
 
   <p>Contact Name: Firsty Lastoson</p>
 


### PR DESCRIPTION
What:

* removes a line from the feedback email

Why:

* to allow easier quick scanning when previewing email

See: https://mitlibraries.atlassian.net/browse/DI-244