### PR TITLE
Only use relevant marc856 links

### DIFF
--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ResultTest < ActiveSupport::TestCase
   def record_with_all_url_possibilities
     r = Result.new('title', 'http://example.org')
-    r.marc_856 = 'http://example.org/this_is_a_marc856_link'
+    r.marc_856 = 'http://sfx.mit.edu/marc856_example'
     r.custom_link = [{ 'Url' => 'http://sfx.mit.edu/example' },
                      { 'Url' => 'http://example.org/irrelevant_custom_link' }]
     r.openurl = 'http://example.org/constructed_open_url'
@@ -114,6 +114,13 @@ class ResultTest < ActiveSupport::TestCase
     assert_equal('http://library.mit.edu/F/example', r.getit_url)
   end
 
+  test 'getit_url with owens custom_link' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = nil
+    r.custom_link = [{ 'Url' => 'http://owens.mit.edu/stuff' }]
+    assert_equal('http://owens.mit.edu/stuff', r.getit_url)
+  end
+
   test 'getit_url with non sfx non library custom_link' do
     r = record_with_all_url_possibilities
     r.marc_856 = nil
@@ -132,6 +139,20 @@ class ResultTest < ActiveSupport::TestCase
   test 'getit_url with only url' do
     r = record_with_all_url_possibilities
     r.marc_856 = nil
+    r.custom_link = nil
+    r.openurl = nil
+    assert_equal('http://example.org', r.getit_url)
+  end
+
+  test 'getit_url with library.mit.edu url' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = 'http://library.mit.edu/F/this_is_a_marc856_link'
+    assert_equal('http://library.mit.edu/F/this_is_a_marc856_link', r.getit_url)
+  end
+
+  test 'getit_url with irrelevant marc_856 url' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = 'http://example.org/this_is_a_marc856_link'
     r.custom_link = nil
     r.openurl = nil
     assert_equal('http://example.org', r.getit_url)


### PR DESCRIPTION
What:

* This only uses marc856 links we know to be useful

Why:

* We store a lot of not-so-useful for this purpose links in our
  MARC 856