### PR TITLE
Remove authtype=sso

### DIFF
--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -59,7 +59,7 @@ class NormalizeEdsCommon
   end
 
   def link
-    "#{@record['PLink']}#{ENV['EDS_PLINK_APPEND']}"
+    "#{@record['PLink'].gsub('&authtype=sso', '')}#{ENV['EDS_PLINK_APPEND']}"
   end
 
   def availability


### PR DESCRIPTION
EDS upstream fix to our sso access seems to have forced sso into our
EDS API result links. This is a hacky way to address that while we
consider better options