### PR TITLE
Detect and handle Aleph Course Reserve records

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -62,7 +62,11 @@ class Result
 
   # Reformat the Accession Number to match the format used in Aleph
   def clean_an
-    an.split('.').last.prepend('MIT01')
+    if aleph_record?
+      an.split('.').last.prepend('MIT01')
+    elsif aleph_cr_record?
+      an.split('.').last.prepend('MIT30')
+    end
   end
 
   # View-type method for returning a truncated list of authors.
@@ -73,6 +77,14 @@ class Result
 
   def truncated_subjects
     subjects[0..2]
+  end
+
+  def aleph_cr_record?
+    if an.present? && an.start_with?('mitcr.')
+      true
+    else
+      false
+    end
   end
 
   def aleph_record?

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -77,6 +77,13 @@
     </div>
   <% end %>
 
+  <% if result.aleph_cr_record? && params[:target] == 'books' %>
+    <div id="<%= result.clean_an %>" class='realtime_status result-local-locations' data-an="<%= result.clean_an %>">
+      Loading realtime status...
+      <i class="fa fa-spinner fa-spin"></i>
+    </div>
+  <% end %>
+
   <% if result.db_source.present? && session[:debug] %>
     <p class="result-pubinfo">
       Source DB: <%= result.db_source[0] %> (<%= result.db_source[1] %>)

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -90,10 +90,24 @@ class ResultTest < ActiveSupport::TestCase
     assert_equal(true, r.aleph_record?)
   end
 
+  test 'flags MIT Course Reserve records' do
+    r = Result.new('title', 'http://example.com')
+    assert_equal(false, r.aleph_record?)
+
+    r.an = 'mitcr.001739356'
+    assert_equal(true, r.aleph_cr_record?)
+  end
+
   test 'can reformat aleph accession number' do
     r = Result.new('title', 'http://example.com')
     r.an = 'mit.001739356'
     assert_equal('MIT01001739356', r.clean_an)
+  end
+
+  test 'can reformat aleph Course Reserve accession number' do
+    r = Result.new('title', 'http://example.com')
+    r.an = 'mitcr.001739356'
+    assert_equal('MIT30001739356', r.clean_an)
   end
 
   test 'getit_url with marc_856' do


### PR DESCRIPTION
What:

* Detects and handles aleph course reserve records

Why:

* Aleph Realtime Availability was failing due to not detecting the
  pattern used for course reserve records in EDS API results
* https://mitlibraries.atlassian.net/browse/DI-257