### PR TITLE
Wrap 404s in site template

### DIFF
--- a/app/controllers/catch_all_controller.rb
+++ b/app/controllers/catch_all_controller.rb
@@ -1,0 +1,5 @@
+class CatchAllController < ApplicationController
+  def catch_all
+    render status: 404
+  end
+end

--- a/app/views/catch_all/catch_all.html.erb
+++ b/app/views/catch_all/catch_all.html.erb
@@ -1,0 +1,3 @@
+<h2 class="title title-page">Ooops! The requested page was not found.</h2>
+
+<p><%= link_to('Starting over', root_path) %> may help. If it does not, please <%= link_to('let us know', feedback_path) %>!</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,4 +22,6 @@ Rails.application.routes.draw do
 
   get 'item_status', to: 'aleph#item_status'
   get 'debug', to: 'application#debug'
+
+  get '*path', to: 'catch_all#catch_all'
 end

--- a/test/integration/catch_all_test.rb
+++ b/test/integration/catch_all_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class CatchAllTest < ActionDispatch::IntegrationTest
+  test 'handle 404s' do
+    get '/blargh'
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This just puts the 404s in our site template for now.

5xx is less simple due to the nature of 5xx meaning it's best to use static pages so we need to do more work.