### PR TITLE
bugfix: return from extract_by_name

### DIFF
--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -44,6 +44,7 @@ class NormalizeEdsCommon
   end
 
   def extract_by_name(name)
+    return unless @record['Items'].try(:select) { |x| x['Name'] == name }
     @record['Items'].try(:select) { |x| x['Name'] == name }.map do |x|
       x['Data']
     end.first


### PR DESCRIPTION
This returns from the method if the name we are trying to select
doesn’t exist in the returned data. Ooops.