### PR TITLE
add not realtime words if offline

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -63,7 +63,7 @@
       <ul class="list-local-locations">
       <% result.location.each do |location| %>
         <li class="result-local-location">
-          <%= location[0] %>: <%= location[1] %>
+          <%= location[0] %>: <%= location[1] %> (not realtime)
         </li>
       <% end %>
       </ul>


### PR DESCRIPTION
If the realtime status is offline, we need to note that with the location info to prevent people from running to the stacks in excitement and being disappointed that it's checked out.