### PR TITLE
Removes Record Links from GetIt Link

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@
 @import "bento.scss";
 @import "aleph.scss";
 @import "feedback.scss";
+@import "results.scss";

--- a/app/assets/stylesheets/bento.scss
+++ b/app/assets/stylesheets/bento.scss
@@ -244,7 +244,7 @@ $z-depth-way-front:     1000;
   border-bottom: 1px solid $gray-l3;
   border-right: 1px solid $white-t;
   border-left: 1px solid $white-t;
-  padding: 2rem 1rem 1rem 1rem;
+  padding: 2rem 1rem 2rem 1rem;
 
   &:first-child {
     border-top: 1px solid $gray-l3;

--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -1,0 +1,3 @@
+.result-get a.button.button-primary.green {
+  float: left;
+}

--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -13,13 +13,18 @@ class NormalizeEdsCommon
     result.online = availability
     result.db_source = db_source
     result.an = @record.dig('Header', 'An')
-    result.custom_link = custom_link
+    result.fulltext_links = fulltext_links
+    result.record_links = record_links
     result.marc_856 = marc_856
     result
   end
 
-  def custom_link
+  def fulltext_links
     @record.dig('FullText', 'CustomLinks')
+  end
+
+  def record_links
+    @record.dig('CustomLinks')
   end
 
   def marc_856

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -7,8 +7,8 @@ class Result
   attr_accessor :title, :year, :url, :type, :authors, :citation, :online,
                 :year, :type, :in, :publisher, :location, :blurb, :subjects,
                 :available_url, :thumbnail, :get_it_label,
-                :db_source, :an, :custom_link, :marc_856, :openurl,
-                :winner
+                :db_source, :an, :fulltext_links, :marc_856, :openurl,
+                :winner, :record_links
 
   def initialize(title, url)
     @title = title
@@ -19,12 +19,8 @@ class Result
   def getit_url
     if marc_856 && relevant_marc_856?
       best_link(marc_856, 'marc_856')
-    elsif custom_link && relevant_custom_link?
-      best_link(custom_link_picker, 'custom_link')
-    elsif openurl
-      best_link(openurl, 'openurl')
-    else
-      best_link(url, 'url')
+    elsif fulltext_links && relevant_fulltext_links?
+      best_link(fulltext_links_picker, 'eds fulltext')
     end
   end
 
@@ -42,9 +38,9 @@ class Result
     ['library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu']
   end
 
-  # Check custom link for specific parameters to allow for prioritization
-  def relevant_custom_link?
-    custom_link.map do |link|
+  # Check fulltext_links for specific parameters to allow for prioritization
+  def relevant_fulltext_links?
+    fulltext_links.map do |link|
       relevant_links.map { |x| link['Url'].include?(x) }.any?
     end.include?(true)
   end
@@ -53,11 +49,11 @@ class Result
   # may be to less useful things (like t.o.c.) or direct to publishers, which
   # while useful on campus, would not be useful off campus without adding
   # additional features to bento that are currently out of scope.
-  def custom_link_picker
-    c_link = custom_link.map do |link|
-      relevant_links.map { |x| link if link['Url'].include?(x) }
+  def fulltext_links_picker
+    link = fulltext_links.map do |l|
+      relevant_links.map { |x| l if l['Url'].include?(x) }
     end
-    c_link.flatten.compact.first['Url'] if c_link
+    link.flatten.compact.first['Url'] if link
   end
 
   # Reformat the Accession Number to match the format used in Aleph

--- a/app/views/search/_debug.html.erb
+++ b/app/views/search/_debug.html.erb
@@ -1,0 +1,51 @@
+<p class="result-debug">
+  <ul>
+    <li>EDS Supplied FullText Links</li>
+      <ul>
+      <% if result.fulltext_links %>
+        <% result.fulltext_links&.each do |cl| %>
+          <li><%= link_to(cl["Name"], cl["Url"], class: 'bento-link') %></li>
+        <% end %>
+      <% else %>
+        <li>None</li>
+      <% end %>
+      </ul>
+  </ul>
+
+  <ul>
+    <li>EDS Supplied Record Links</li>
+      <ul>
+      <% if result.record_links %>
+        <% result.record_links&.each do |cl| %>
+          <li><%= link_to(cl["Name"], cl["Url"], class: 'bento-link') %></li>
+        <% end %>
+      <% else %>
+        <li>None</li>
+      <% end %>
+      </ul>
+  </ul>
+
+  <ul><li><%= link_to('EDS UI Detail Link', result.url, class: 'bento-link') %></li></ul>
+
+  <ul>
+    <% if result.openurl %>
+    <li>
+      <%= link_to('SFX Constructed from metadata', result.openurl, class: 'bento-link') %>
+    </li>
+    <% else %>
+      <li>No SFX Constructed from metadata available</li>
+    <% end %>
+  </ul>
+
+  <ul>
+    <% if result.marc_856 %>
+    <li>
+      <%= link_to("MARC 856", result.marc_856, class: 'bento-link') %>
+    </li>
+    <% else %>
+      <li>No MARC 856</li>
+    <% end %>
+  </ul>
+
+  <ul><li>Winner: <%= result.winner || 'no fulltext link found' %></li></ul>
+<p>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -91,48 +91,14 @@
   <% end %>
 
   <div class="result-get">
-    <%= link_to(result.get_it_label, result.getit_url, class: 'button button-primary', data: {type: "Get"}) %>
+    <% if result.getit_url.present? %>
+      <%= link_to("Online", result.getit_url, class: 'button button-primary green', data: {type: "Get"}) %>
+    <% end %>
+
+    <%= link_to("Details and requests", result.url, class: 'button button-secondary', data: {type: "Detail"}) %>
   </div>
 
   <% if session[:debug] %>
-    <p class="result-debug">
-
-      <ul>
-        <li>EDS Supplied CustomLinks</li>
-          <ul>
-          <% if result.custom_link %>
-            <% result.custom_link&.each do |cl| %>
-              <li><%= link_to(cl["Name"], cl["Url"], class: 'bento-link') %></li>
-            <% end %>
-          <% else %>
-            <li>None</li>
-          <% end %>
-          </ul>
-      </ul>
-
-      <ul><li><%= link_to('EDS UI Detail Link', result.url, class: 'bento-link') %></li></ul>
-
-      <ul>
-        <% if result.openurl %>
-        <li>
-          <%= link_to('SFX Constructed from metadata', result.openurl, class: 'bento-link') %>
-        </li>
-        <% else %>
-          <li>No SFX Constructed from metadata available</li>
-        <% end %>
-      </ul>
-
-      <ul>
-        <% if result.marc_856 %>
-        <li>
-          <%= link_to("MARC 856", result.marc_856, class: 'bento-link') %>
-        </li>
-        <% else %>
-          <li>No MARC 856</li>
-        <% end %>
-      </ul>
-
-      <ul><li>Winner: <%= result.winner %></li></ul>
-    <p>
+    <%= render partial: "debug", locals: { result: result } %>
   <% end %>
 </div>

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -28,13 +28,6 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
     )
   end
 
-  test 'normalized articles have expected url eds provided sfx link' do
-    assert_equal(
-      'https://sfx.mit.edu/sfx_local?rfr_id=info%3Asid%2FMIT.BENTO&rft.au=Moreira+Ribeiro%2C+Rodrigo%3Bdo+Amaral+J%C3%BAnior%2C+Ant%C3%B4nio+Teixeira%3BFerreira+Pena%2C+Guilherme%3BVivas%2C+Marcelo%3BNascimento+Kurosawa%2C+Railan%3BAzeredo+Gon%C3%A7alves%2C+Leandro+Sim%C3%B5es&rft.eissn=&rft.issn=16799275&rft.issue=4&rft.jtitle=Acta+Scientiarum%3A+Agronomy&rft.volume=38&rft.year=2016&rft_id=info%3Adoi%2F10.4025%2Factasciagron.v38i4.30573',
-      popcorn_articles['results'][0].getit_url
-    )
-  end
-
   test 'normalized articles have expected type' do
     assert_equal('Academic Journal', popcorn_articles['results'][0].type)
   end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -4,8 +4,10 @@ class ResultTest < ActiveSupport::TestCase
   def record_with_all_url_possibilities
     r = Result.new('title', 'http://example.org')
     r.marc_856 = 'http://sfx.mit.edu/marc856_example'
-    r.custom_link = [{ 'Url' => 'http://sfx.mit.edu/example' },
-                     { 'Url' => 'http://example.org/irrelevant_custom_link' }]
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example' },
+      { 'Url' => 'http://example.org/irrelevant_custom_link' }
+    ]
     r.openurl = 'http://example.org/constructed_open_url'
     r
   end
@@ -124,14 +126,14 @@ class ResultTest < ActiveSupport::TestCase
   test 'getit_url with library custom_link' do
     r = record_with_all_url_possibilities
     r.marc_856 = nil
-    r.custom_link = [{ 'Url' => 'http://library.mit.edu/F/example' }]
+    r.fulltext_links = [{ 'Url' => 'http://library.mit.edu/F/example' }]
     assert_equal('http://library.mit.edu/F/example', r.getit_url)
   end
 
   test 'getit_url with owens custom_link' do
     r = record_with_all_url_possibilities
     r.marc_856 = nil
-    r.custom_link = [{ 'Url' => 'http://owens.mit.edu/stuff' }]
+    r.fulltext_links = [{ 'Url' => 'http://owens.mit.edu/stuff' }]
     assert_equal('http://owens.mit.edu/stuff', r.getit_url)
   end
 
@@ -139,23 +141,16 @@ class ResultTest < ActiveSupport::TestCase
     r = record_with_all_url_possibilities
     r.marc_856 = nil
     r.openurl = nil
-    r.custom_link = [{ 'Url' => 'http://example.org/irrelevant_custom_link' }]
-    assert_equal('http://example.org', r.getit_url)
-  end
-
-  test 'getit_url with openurl' do
-    r = record_with_all_url_possibilities
-    r.marc_856 = nil
-    r.custom_link = nil
-    assert_equal('http://example.org/constructed_open_url', r.getit_url)
+    r.fulltext_links = [{ 'Url' => 'http://example.org/irrelevant_customlink' }]
+    assert_nil(r.getit_url)
   end
 
   test 'getit_url with only url' do
     r = record_with_all_url_possibilities
     r.marc_856 = nil
-    r.custom_link = nil
+    r.fulltext_links = nil
     r.openurl = nil
-    assert_equal('http://example.org', r.getit_url)
+    assert_nil(r.getit_url)
   end
 
   test 'getit_url with library.mit.edu url' do
@@ -167,8 +162,8 @@ class ResultTest < ActiveSupport::TestCase
   test 'getit_url with irrelevant marc_856 url' do
     r = record_with_all_url_possibilities
     r.marc_856 = 'http://example.org/this_is_a_marc856_link'
-    r.custom_link = nil
+    r.fulltext_links = nil
     r.openurl = nil
-    assert_equal('http://example.org', r.getit_url)
+    assert_nil(r.getit_url)
   end
 end


### PR DESCRIPTION
What:

* Removes record links (eds ui detail view) from GetIt link
* Removes constructed openurls from GetIt link
* Extracts both fulltext and record links from EDS
* Adds record link as a button (only using EDS UI link for now)
* Renames GetIt Link to reflect it should lead towards online
  full text links
* Splits record debug to a partial to make it easier to scan the main
  record view

Why:

* The single button doing so much was potentially leading to confusion
for end users
