### PR TITLE
Numbers are not strings

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,7 +6,7 @@ class SearchController < ApplicationController
   def bento; end
 
   def search_boxed
-    @per_box = ENV['RESULTS_PER_BOX'] || 5
+    @per_box = (ENV['RESULTS_PER_BOX'] || 5).to_i
     @results = search_results(1, @per_box)
     return redirect_to root_url unless @results
     render layout: false


### PR DESCRIPTION
- this fixes a bug where the logic to determine whether to show a view more link
  broke if `RESULTS_PER_BOX` was set