### PR TITLE
Enable flipflip feature flags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 ruby '2.3.1'
 
 gem 'devise'
+gem 'flipflop'
 gem 'google-api-client'
 gem 'http'
 gem 'http_logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     execjs (2.7.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
+    flipflop (2.3.1)
+      activesupport (>= 4.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     google-api-client (0.10.1)
@@ -340,6 +342,7 @@ DEPENDENCIES
   coveralls
   dalli
   devise
+  flipflop
   google-api-client
   http
   http_logger

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -84,7 +84,7 @@
     </div>
   <% end %>
 
-  <% if result.db_source.present? && session[:debug] %>
+  <% if result.db_source.present? && Flipflop.enabled?(:debug) %>
     <p class="result-pubinfo">
       Source DB: <%= result.db_source[0] %> (<%= result.db_source[1] %>)
     </p>
@@ -98,7 +98,7 @@
     <%= link_to("Details and requests", result.url, class: 'details button button-secondary', data: {type: "Detail"}) %>
   </div>
 
-  <% if session[:debug] %>
+  <% if Flipflop.enabled?(:debug) %>
     <%= render partial: "debug", locals: { result: result } %>
   <% end %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,10 @@ Bundler.require(*Rails.groups)
 
 module MitBento
   class Application < Rails::Application
+    # Replace with a lambda or method name defined in ApplicationController
+    # to implement access control for the Flipflop dashboard.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,8 @@
 Rails.application.configure do
+  # Replace with a lambda or method name defined in ApplicationController
+  # to implement access control for the Flipflop dashboard.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,8 @@
 Rails.application.configure do
+  # Replace with a lambda or method name defined in ApplicationController
+  # to implement access control for the Flipflop dashboard.
+  config.flipflop.dashboard_access_filter = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   ENV['EDS_URL'] = 'https://eds-api.ebscohost.com'

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,9 @@
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :session
+  strategy :default
+
+  feature :debug,
+    default: false,
+    description: 'Debug mode'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Flipflop::Engine => "/flipflop"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users, :controllers => {
     :omniauth_callbacks => 'users/omniauth_callbacks'


### PR DESCRIPTION
What:

* uses flipflip gem to allow feature toggles
* changes debug mode to check via flipflop

Why:

* as we want to roll out bigger changes, it will be easier to allow them
to merge into master before we are ready to make them public by
leaving them switched off by default so we can test them in staging
and/or in production with select users

How:

* For now, this just uses session based features but the gem supports
postgres or redis backed feature enabling which may be desirable in
some situations
* in development, you can access `/flipflop` to toggle your features
* in production, this is currently disabled so we are using the same
debug enabler to set the session key the same way we did before. If we
end up with lots of features (unlikely) that are all toggleable we may
want to implement user roles to allow staff to access the control
panel

More info:

* https://github.com/voormedia/flipflop
* https://mitlibraries.atlassian.net/browse/DI-260