### PR TITLE
Adds access control to flipflop controller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.3.1
 sudo: false
+script: bin/rails test

--- a/app.json
+++ b/app.json
@@ -35,6 +35,9 @@
     "FEEDBACK_MAIL_TO": {
       "required": true
     },
+    "FLIPFLOP_KEY": {
+      "required": true
+    },
     "GLOBAL_ALERT": {
       "required": true
     },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,20 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  def flipflop_access_control
+    return if session[:flipflop_user]
+    head :forbidden unless valid_flipflop_key?
+    session[:flipflop_user] = true
+  end
+
   def new_session_path(_scope)
     root_path
+  end
+
+  private
+
+  def valid_flipflop_key?
+    return if params[:flipflop_key].blank?
+    params[:flipflop_key] == ENV['FLIPFLOP_KEY']
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module MitBento
   class Application < Rails::Application
     # Replace with a lambda or method name defined in ApplicationController
     # to implement access control for the Flipflop dashboard.
-    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+    config.flipflop.dashboard_access_filter = :flipflop_access_control
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,4 @@
 Rails.application.configure do
-  # Replace with a lambda or method name defined in ApplicationController
-  # to implement access control for the Flipflop dashboard.
-  config.flipflop.dashboard_access_filter = nil
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,8 +1,4 @@
 Rails.application.configure do
-  # Replace with a lambda or method name defined in ApplicationController
-  # to implement access control for the Flipflop dashboard.
-  config.flipflop.dashboard_access_filter = nil
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   ENV['EDS_URL'] = 'https://eds-api.ebscohost.com'
@@ -22,6 +18,7 @@ Rails.application.configure do
   ENV['ALEPH_API_URI'] = 'https://fake_server.example.com/rest-dlf/'
   ENV['ALEPH_KEY'] = 'FAKE_KEY'
   ENV['PER_PAGE'] = '10'
+  ENV['FLIPFLOP_KEY'] = 'yoyo'  
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/features/flipflop_dashboard_test.rb
+++ b/test/features/flipflop_dashboard_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+feature 'FlipflopDashboard' do
+  before do
+    Capybara.current_session.driver.browser.clear_cookies
+  end
+
+  after do
+    Capybara.current_session.driver.browser.clear_cookies
+  end
+
+  test 'can toggle a feature from the dashboard' do
+    visit "/flipflop?flipflop_key=#{ENV['FLIPFLOP_KEY']}"
+
+    within('tr[data-feature=debug] td[data-strategy=session]') do
+      click_on 'on'
+    end
+
+    within('tr[data-feature=debug]') do
+      assert_equal('on', first('td.status').text)
+      assert_equal('on', first('td[data-strategy=session] button.active').text)
+    end
+  end
+end

--- a/test/integration/flipflop_test.rb
+++ b/test/integration/flipflop_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class FlipflopTest < ActionDispatch::IntegrationTest
+  test 'can access dashboard with secret key' do
+    get '/flipflop', params: { flipflop_key: ENV['FLIPFLOP_KEY'] }
+    assert_response :success
+  end
+
+  test 'cannot acess dashboard without secret key' do
+    get '/flipflop'
+    assert_response :forbidden
+  end
+
+  test 'cannot access dashboard with wrong secret key' do
+    get '/flipflop', params: { flipflop_key: 'not_the_key' }
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
What:

* adds shared secret key access to flipflop controller in all
  environments (dev / test were previously always accessible)
* travis defaults to running `rake`, new way is `bin/rails test`

Why:

* the ability to easily toggle features for staff in PR and staging
  builds where they can confirm their current settings requires some
  form of dashboard and flipflop comes with one so why not use it

How:

* setting `ENV['FLIPFLOP_KEY']` and passing that value like
  `/flipflop?flipflop_key=thatthingyouset` will provide access to the
  dashboard where you can see all possible toggles and easily toggle
  features for your session
* if you don't set `ENV['FLIPFLOP_KEY']` all access is denied to the
  dashboard but you can still toggle features via the
  `/toggle?feature=yourfeature` route