### PR TITLE
288 nomethod error

### DIFF
--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -60,7 +60,7 @@ class NormalizeEdsCommon
   end
 
   def year
-    return unless bibentity['Dates']
+    return unless bibentity && bibentity['Dates']
     bibentity['Dates'][0]['Y']
   end
 
@@ -103,6 +103,7 @@ class NormalizeEdsCommon
   end
 
   def bibentity
+    return unless relationships['IsPartOfRelationships']
     relationships['IsPartOfRelationships'][0]['BibEntity']
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,13 +49,27 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV['LOG_LEVEL'] || :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  if ENV['LOG_LIKE_PROD'].present?
+    config.lograge.enabled = true
+    config.lograge.custom_options = lambda do |event|
+      exceptions = %w(controller action format id)
+      {
+        params: event.payload[:params].except(*exceptions)
+      }
+    end
+
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
   ENV['ALEPH_API_URI'] = 'https://fake_server.example.com/rest-dlf/'
   ENV['ALEPH_KEY'] = 'FAKE_KEY'
   ENV['PER_PAGE'] = '10'
-  ENV['FLIPFLOP_KEY'] = 'yoyo'  
+  ENV['FLIPFLOP_KEY'] = 'yoyo'
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/test/models/normalize_eds_test.rb
+++ b/test/models/normalize_eds_test.rb
@@ -66,8 +66,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   end
 
   test 'can handle missing title titlefull with item title' do
-    VCR.use_cassette('popcorn books',
-                     allow_playback_repeats: true) do
+    VCR.use_cassette('popcorn books', allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books', 'popcorn')
       assert_equal('Popcorn handbook', query['results'][3].title)
@@ -75,8 +74,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   end
 
   test 'can handle missing title titlefull and no item title' do
-    VCR.use_cassette('popcorn books',
-                     allow_playback_repeats: true) do
+    VCR.use_cassette('popcorn books', allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books', 'popcorn')
       assert_equal('unknown title', query['results'][4].title)
@@ -85,8 +83,7 @@ class NormalizeEdsTest < ActiveSupport::TestCase
 
   test 'can generate a local pagination link' do
     ENV['LOCAL_RESULTS'] = 'true'
-    VCR.use_cassette('popcorn books',
-                     allow_playback_repeats: true) do
+    VCR.use_cassette('popcorn books', allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books', 'popcorn')
       assert_equal(
@@ -97,14 +94,25 @@ class NormalizeEdsTest < ActiveSupport::TestCase
   end
 
   test 'can generate an EDS UI paginaltion link' do
-    VCR.use_cassette('popcorn books',
-                     allow_playback_repeats: true) do
+    VCR.use_cassette('popcorn books', allow_playback_repeats: true) do
       raw_query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       query = NormalizeEds.new.to_result(raw_query, 'books', 'popcorn')
       assert_equal(
         'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3Dpopcorn&facet=Books,eBooks,Audiobooks,Dissertations,MusicScores,Audio,Videos',
         query['eds_ui_view_more']
       )
+    end
+  end
+
+  test 'handle missing no dates and no IsPartOfRelationships' do
+    VCR.use_cassette('turn of the screw', allow_playback_repeats: true) do
+      raw_query = SearchEds.new.search(
+        'turn of the screw', 'apiwhatnot', ENV['EDS_BOOK_FACETS'], 4, 1
+      )
+      query = NormalizeEds.new.to_result(
+        raw_query, 'books', 'turn of the screw'
+      )
+      assert_nil(query['results'].first.year)
     end
   end
 end

--- a/test/vcr_cassettes/turn_of_the_screw.yml
+++ b/test/vcr_cassettes/turn_of_the_screw.yml
@@ -1,0 +1,325 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.2.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2017 15:05:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Tue, 04 Apr 2017 15:05:24 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.2.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2017 15:05:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 1a506fcc-353a-4c0a-896a-35eb0dda4cf9
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '1874290137'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '100'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version: 
+  recorded_at: Tue, 04 Apr 2017 15:05:24 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&facetfilter=1,SourceType:Books,SourceType:eBooks,SourceType:Audiobooks,SourceType:Dissertations,SourceType:Music%20Scores,SourceType:Audio,SourceType:Videos&highlight=n&includefacets=n&pagenumber=4&query=turn%20of%20the%20screw&resultsperpage=1&searchmode=all&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.2.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2017 15:05:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 5d232b42-d584-4d10-9c5a-ce4c12f7ab4c
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '1874290137'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '14927'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SearchRequestGet":{"QueryString":"query-1=AND,turn+of+the+screw&facetfilter=1,SourceType:Books,SourceType:eBooks,SourceType:Audiobooks,SourceType:Dissertations,SourceType:Music+Scores,SourceType:Audio,SourceType:Videos&expander=fulltext&sort=relevance&includefacets=n&searchmode=all&autosuggest=n&view=detailed&resultsperpage=1&pagenumber=4&highlight=n","SearchCriteriaWithActions":{"QueriesWithAction":[{"Query":{"BooleanOperator":"AND","Term":"turn
+        of the screw"},"RemoveAction":"removequery(1)"}],"FacetFiltersWithAction":[{"FilterId":1,"FacetValuesWithAction":[{"FacetValue":{"Id":"SourceType","Value":"Books"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Books)"},{"FacetValue":{"Id":"SourceType","Value":"eBooks"},"RemoveAction":"removefacetfiltervalue(1,SourceType:eBooks)"},{"FacetValue":{"Id":"SourceType","Value":"Audiobooks"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Audiobooks)"},{"FacetValue":{"Id":"SourceType","Value":"Dissertations"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Dissertations)"},{"FacetValue":{"Id":"SourceType","Value":"Music
+        Scores"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Music Scores)"},{"FacetValue":{"Id":"SourceType","Value":"Audio"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Audio)"},{"FacetValue":{"Id":"SourceType","Value":"Videos"},"RemoveAction":"removefacetfiltervalue(1,SourceType:Videos)"}],"RemoveAction":"removefacetfilter(1)"}],"ExpandersWithAction":[{"Id":"fulltext","RemoveAction":"removeexpander(fulltext)"}]}},"SearchResult":{"Statistics":{"TotalHits":1470626,"TotalSearchTime":386,"Databases":[{"Id":"eric","Label":"ERIC","Status":"0","Hits":2},{"Id":"rih","Label":"RILM
+        Abstracts of Music Literature (1967 to Present only)","Status":"0","Hits":55},{"Id":"agr","Label":"Agricola","Status":"0","Hits":0},{"Id":"lah","Label":"CAB
+        Abstracts","Status":"0","Hits":0},{"Id":"egh","Label":"Environment Index","Status":"0","Hits":0},{"Id":"inh","Label":"Inspec","Status":"0","Hits":1},{"Id":"ecn","Label":"EconLit","Status":"0","Hits":2},{"Id":"ufh","Label":"Communication
+        & Mass Media Complete","Status":"0","Hits":6},{"Id":"qth","Label":"LGBT Life
+        with Full Text","Status":"0","Hits":21},{"Id":"fyh","Label":"Women''s Studies
+        International","Status":"0","Hits":1},{"Id":"fmh","Label":"Gender Studies
+        Database","Status":"0","Hits":12},{"Id":"ibh","Label":"International Bibliography
+        of Theatre & Dance with Full Text","Status":"0","Hits":52},{"Id":"bth","Label":"Business
+        Source Complete","Status":"0","Hits":114},{"Id":"lxh","Label":"Library, Information
+        Science & Technology Abstracts","Status":"0","Hits":1},{"Id":"mah","Label":"Music
+        Index","Status":"0","Hits":0},{"Id":"a9h","Label":"","Status":"0","Hits":29},{"Id":"ich","Label":"Index
+        Islamicus","Status":"0","Hits":0},{"Id":"ahl","Label":"America: History &
+        Life","Status":"0","Hits":2},{"Id":"hia","Label":"Historical Abstracts","Status":"0","Hits":1},{"Id":"poh","Label":"Political
+        Science Complete","Status":"0","Hits":10},{"Id":"phl","Label":"Philosopher''s
+        Index","Status":"0","Hits":2},{"Id":"8gh","Label":"GreenFILE","Status":"0","Hits":0},{"Id":"edswah","Label":"Arts
+        & Humanities Citation Index","Status":"0","Hits":0},{"Id":"edswsc","Label":"Science
+        Citation Index","Status":"0","Hits":2},{"Id":"edswss","Label":"Social Sciences
+        Citation Index","Status":"0","Hits":0},{"Id":"edselp","Label":"ScienceDirect","Status":"0","Hits":9116},{"Id":"pix","Label":"Play
+        Index (H.W. Wilson)","Status":"0","Hits":8},{"Id":"edsoso","Label":"Oxford
+        Scholarship Online","Status":"0","Hits":2},{"Id":"nlabk","Label":"Audiobook
+        Collection (EBSCOhost)","Status":"0","Hits":0},{"Id":"nlebk","Label":"eBook
+        Collection (EBSCOhost)","Status":"0","Hits":1562},{"Id":"hma","Label":"Humanities
+        Abstracts (H.W. Wilson)","Status":"0","Hits":0},{"Id":"rga","Label":"Readers''
+        Guide Abstracts (H.W. Wilson)","Status":"0","Hits":0},{"Id":"edscrc","Label":"Credo
+        Reference","Status":"0","Hits":0},{"Id":"cat00916a","Label":"MIT Barton Catalog","Status":"0","Hits":87},{"Id":"edsasp","Label":"Alexander
+        Street Press","Status":"0","Hits":67},{"Id":"edo","Label":"","Status":"0","Hits":27},{"Id":"edb","Label":"","Status":"0","Hits":9537},{"Id":"edsoao","Label":"Grove
+        Art Online","Status":"0","Hits":0},{"Id":"edsoad","Label":"American National
+        Biography Online","Status":"0","Hits":0},{"Id":"edsodb","Label":"Oxford Dictionary
+        of National Biography","Status":"0","Hits":0},{"Id":"edsoro","Label":"Oxford
+        Reference","Status":"0","Hits":0},{"Id":"edsomo","Label":"Grove Music Online","Status":"0","Hits":1},{"Id":"edsebo","Label":"Britannica
+        Online","Status":"0","Hits":12},{"Id":"ant","Label":"Anthropology Plus","Status":"0","Hits":0},{"Id":"edsssb","Label":"Books24x7","Status":"0","Hits":0},{"Id":"eue","Label":"Education
+        Source","Status":"0","Hits":57},{"Id":"hus","Label":"Humanities Source","Status":"0","Hits":97},{"Id":"aci","Label":"Applied
+        Science & Technology Source","Status":"0","Hits":55},{"Id":"cat01763a","Label":"MIT
+        Course Reserves","Status":"0","Hits":0},{"Id":"asu","Label":"Art & Architecture
+        Source","Status":"0","Hits":51},{"Id":"edsnmj","Label":"Naxos Music Library
+        Jazz","Status":"0","Hits":0},{"Id":"edsnol","Label":"Naxos Music Library","Status":"0","Hits":86},{"Id":"edssmt","Label":"SpringerMaterials","Status":"0","Hits":0},{"Id":"htm","Label":"History
+        of Science, Technology & Medicine","Status":"0","Hits":3},{"Id":"edshtl","Label":"HathiTrust","Status":"0","Hits":1449448},{"Id":"edsecd","Label":"Energy
+        Citations Database","Status":"0","Hits":1},{"Id":"ers","Label":"Research Starters","Status":"0","Hits":75},{"Id":"edsvec","Label":"CQ
+        Press Voting & Elections Collection","Status":"0","Hits":0},{"Id":"edscoc","Label":"CQ
+        Press Congress Collection","Status":"0","Hits":0},{"Id":"edsspo","Label":"SpringerProtocols","Status":"0","Hits":0},{"Id":"edsoec","Label":"OECD
+        iLibrary","Status":"0","Hits":0},{"Id":"edsstc","Label":"SciTech Connect","Status":"0","Hits":1},{"Id":"edswbe","Label":"World
+        Bank eLibrary","Status":"0","Hits":12},{"Id":"msn","Label":"MathSciNet via
+        EBSCOhost","Status":"0","Hits":4},{"Id":"edseee","Label":"IEEE Xplore Digital
+        Library","Status":"0","Hits":1},{"Id":"edskan","Label":"Kanopy","Status":"0","Hits":3},{"Id":"bvh","Label":"Avery
+        Index to Architectural Periodicals","Status":"0","Hits":0},{"Id":"fjh","Label":"The
+        New Republic Archive","Status":"0","Hits":0},{"Id":"nih","Label":"The Nation
+        Archive","Status":"0","Hits":0},{"Id":"hev","Label":"European Views of the
+        Americas: 1493 to 1750","Status":"0","Hits":0},{"Id":"apn","Label":"Alternative
+        Press Index","Status":"0","Hits":0},{"Id":"edspdh","Label":"PsycARTICLES","Status":"0","Hits":0},{"Id":"edsmbo","Label":"Marquis
+        Biographies Online","Status":"0","Hits":0},{"Id":"edsarx","Label":"arXiv","Status":"0","Hits":0},{"Id":"hsr","Label":"Humanities
+        & Social Sciences Index Retrospective: 1907-1984 (H.W. Wilson)","Status":"0","Hits":0},{"Id":"air","Label":"Art
+        Index Retrospective (H.W. Wilson)","Status":"0","Hits":0},{"Id":"rgr","Label":"Readers''
+        Guide Retrospective: 1890-1982 (H.W. Wilson)","Status":"0","Hits":0},{"Id":"bpr","Label":"Business
+        Periodicals Index Retrospective: 1913-1982 (H.W. Wilson)","Status":"0","Hits":0},{"Id":"mdc","Label":"MEDLINE
+        Complete","Status":"0","Hits":0},{"Id":"edslex","Label":"LexisNexis Academic:
+        Law Reviews","Status":"0","Hits":0},{"Id":"edsjst","Label":"J-STAGE","Status":"0","Hits":0},{"Id":"edsdoj","Label":"Directory
+        of Open Access Journals","Status":"0","Hits":0},{"Id":"edsper","Label":"Persée","Status":"0","Hits":0},{"Id":"edshol","Label":"HeinOnline","Status":"0","Hits":0},{"Id":"edshst","Label":"Henry
+        Stewart Talks","Status":"0","Hits":0},{"Id":"edsjsr","Label":"JSTOR Journals","Status":"0","Hits":0},{"Id":"edscao","Label":"CQ
+        Almanac Online Edition","Status":"0","Hits":0},{"Id":"edsmmd","Label":"ASM
+        Medical Materials Database","Status":"0","Hits":0},{"Id":"edsonp","Label":"OnePetro","Status":"0","Hits":0}]},"Data":{"RecordFormat":"EP
+        Display","Records":[{"ResultId":4,"Header":{"DbId":"rih","DbLabel":"RILM Abstracts
+        of Music Literature (1967 to Present only)","An":"A615659","RelevancyScore":"1968","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&scope=site&db=rih&AN=A615659&authtype=sso&custid=s8978330","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=book&atitle=&title=Denying%20and%20admitting%3A%20The%20turn%20of%20the%20screw%20in%20the%20light%20of%20the%20%27will%20to%20know%27&isbn=&volume=&issue=&date=&aulast=Weidringer,
+        Walter&spage=&pages=&sid=EBSCO:RILM%20Abstracts%20of%20Music%20Literature%20%281967%20to%20Present%20only%29:A615659","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability."}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Leugnen
+        und Gestehen: The turn of the screw im Lichte des &#39;Willens zum Wissen&#39;"},{"Name":"TitleEng","Label":"English
+        Title","Group":"TiAlt","Data":"Denying and admitting: The turn of the screw
+        in the light of the &#39;will to know&#39;"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Weidringer%2C+Walter%22&quot;&gt;Weidringer,
+        Walter&lt;\/searchLink&gt; (Author)"},{"Name":"Subject","Label":"Subjects","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22Britten%2C+Benjamin%22&quot;&gt;Britten,
+        Benjamin&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22Britten%2C+Benjamin+--+works%22&quot;&gt;
+        -- works&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22Britten%2C+Benjamin+--+works+--+The+turn+of+the+screw%22&quot;&gt;
+        -- The turn of the screw&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot;
+        term=&quot;%22Britten%2C+Benjamin+--+works+--+The+turn+of+the+screw+--+relation+to+James+story%22&quot;&gt;
+        -- relation to James story&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22James%2C+Henry%22&quot;&gt;James, Henry&lt;\/searchLink&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22James%2C+Henry+--+writings%22&quot;&gt;
+        -- writings&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22James%2C+Henry+--+writings+--+The+turn+of+the+screw+%281898%29%22&quot;&gt;
+        -- The turn of the screw (1898)&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot;
+        term=&quot;%22James%2C+Henry+--+writings+--+The+turn+of+the+screw+%281898%29+--+basis+of+Britten+opera%22&quot;&gt;
+        -- basis of Britten opera&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;SW&quot;
+        term=&quot;%22sexuality+and+gender%22&quot;&gt;sexuality and gender&lt;\/searchLink&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22sexuality+and+gender+--+Britten%2C+Benjamin%22&quot;&gt;
+        -- Britten, Benjamin&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot;
+        term=&quot;%22sexuality+and+gender+--+Britten%2C+Benjamin+--+The+turn+of+the+screw%22&quot;&gt;
+        -- The turn of the screw&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;SW&quot;
+        term=&quot;%22Piper%2C+Myfanwy%22&quot;&gt;Piper, Myfanwy&lt;\/searchLink&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22Piper%2C+Myfanwy+--+writings%22&quot;&gt;
+        -- writings&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22Piper%2C+Myfanwy+--+writings+--+libretto+for+Britten+The+turn+of+the+screw%22&quot;&gt;
+        -- libretto for Britten The turn of the screw&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22libretto--by+librettist%22&quot;&gt;libretto--by
+        librettist&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22libretto--by+librettist+--+Piper%2C+M%2E%22&quot;&gt;
+        -- Piper, M.&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22libretto--by+librettist+--+Piper%2C+M%2E+--+The+turn+of+the+screw+by+Britten%22&quot;&gt;
+        -- The turn of the screw by Britten&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;SW&quot; term=&quot;%22Foucault%2C+Michel%22&quot;&gt;Foucault,
+        Michel&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22Foucault%2C+Michel+--+writings%22&quot;&gt;
+        -- writings&lt;\/searchLink&gt;&lt;searchLink fieldCode=&quot;SW&quot; term=&quot;%22Foucault%2C+Michel+--+writings+--+La+volont&#233;+de+savoir%22&quot;&gt;
+        -- La volont&#233; de savoir&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"English:
+        Henry James&#39;s novella The turn of the screw is one of the most complex
+        and most frequently received works of world literature. Benjamin Britten&#39;s
+        opera of the same name, on a libretto by Myfanwy Piper, is of particular interest
+        in this context. Michel Foucault&#39;s La volont&#233; de savoir offers exceptionally
+        good assistance in interpreting it: in the novella, as in the opera, there
+        are various focal points in which power and knowledge with respect to sexuality
+        have combined since the 18th c.&lt;br \/&gt;German: [unedited non–English
+        abstract received by RILM] Henry James&#39; Novelle &#39;The turn of the screw&#39;
+        ist eines der vielschichtigsten und am h&#228;ufigsten rezipierten Werke der
+        Weltliteratur. Von besonderem Interesse ist hier die gleichnamige Oper Benjamin
+        Brittens auf das Libretto von Myfanwy Piper. Michel Foucaults &#39;La volont&#233;
+        de savoir&#39; bietet eine au&#223;erordentlich gute Handreichung zur Interpretation:
+        In der Novelle wie in der Oper finden sich jene Brennpunkte, in denen sich
+        seit dem 18. Jahrhundert Macht und Wissen in Bezug auf Sexualit&#228;t b&#252;ndeln."},{"Name":"AbstractInfo","Label":"Abstractor
+        Name","Group":"Ab","Data":"Sch&#246;ner, Oliver"},{"Name":"TitleSourceBook","Label":"Collected
+        Work","Group":"Src","Data":"Musik-Wissenschaft an ihren Grenzen. Published
+        by: Frankfurt am Main, Germany: Peter Lang, 2004. ISBN: 978-3-631-51955-4;
+        3-631-51955-9. Pages: 321-341., (&lt;searchLink fieldCode=&quot;AN&quot; term=&quot;%222004-04895%22&quot;&gt;Link
+        to This Item&lt;\/searchLink&gt;)  (&lt;searchLink fieldCode=&quot;JN&quot;
+        term=&quot;%22Musik-Wissenschaft+an+ihren+Grenzen%22&quot;&gt;Link to All
+        Related Parts&lt;\/searchLink&gt;)"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Britten,
+        Benjamin","Type":"general"},{"SubjectFull":"James, Henry","Type":"general"},{"SubjectFull":"sexuality
+        and gender","Type":"general"},{"SubjectFull":"Piper, Myfanwy","Type":"general"},{"SubjectFull":"libretto--by
+        librettist","Type":"general"},{"SubjectFull":"Foucault, Michel","Type":"general"}],"Titles":[{"TitleFull":"Denying
+        and admitting: The turn of the screw in the light of the ''will to know''","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Weidringer,
+        Walter"}}}]}}}}]}}}'
+    http_version: 
+  recorded_at: Tue, 04 Apr 2017 15:05:25 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.2.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2017 15:05:18 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - d94ef2be-9a3c-428c-ac03-4101adcdf99d
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '20'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version: 
+  recorded_at: Tue, 04 Apr 2017 15:05:25 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Metadata with no relationships when reading year
* metadata that came back from EDS that did not contain
  `IsPartOfRelationships` would fail when trying to extract the year
  from that section
* this handles that case by confirming the expected sections exist
  before trying to access them

See https://mitlibraries.atlassian.net/browse/DI-288

This also adds an option to log like production during local development.