### PR TITLE
Remove yewno link

### DIFF
--- a/app/views/search/_other_resources.html.erb
+++ b/app/views/search/_other_resources.html.erb
@@ -16,7 +16,6 @@
       <li><a href="https://libraries.mit.edu/vera">Vera: search e-journals and databases</a></li>
       <li><a href="https://scholar.google.com">Google Scholar</a> (<a href="http://libguides.mit.edu/google/googlescholar">Help setting preferences</a>)</li>
       <li><a href="https://libraries.mit.edu/worldcat">WorldCat: borrow from libraries worldwide</a></li>
-      <li><a href="http://yewno.com/edu">Yewno: A visual way to discover</a></li>
     </ul>
 
   </div>


### PR DESCRIPTION
Removes the link to Yewno in the other resources since we aren't currently supporting it.