### PR TITLE
Allows ENV configurable http_timeout in EDS Search

### DIFF
--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 class SearchEdsTest < ActiveSupport::TestCase
+  def setup
+    ENV['EDS_TIMEOUT'] = nil
+  end
+
+  def after
+    ENV['EDS_TIMEOUT'] = nil
+  end
+
   test 'can search articles' do
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
@@ -23,6 +31,22 @@ class SearchEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('invalid credentials') do
       query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
       assert_equal('invalid credentials', query)
+    end
+  end
+
+  test 'can change timeout value' do
+    VCR.use_cassette('custom timeout') do
+      assert_equal(2, SearchEds.new.send(:http_timeout))
+    end
+
+    ENV['EDS_TIMEOUT'] = '0.1'
+    VCR.use_cassette('custom timeout') do
+      assert_equal(0.03333333333333333, SearchEds.new.send(:http_timeout))
+    end
+
+    ENV['EDS_TIMEOUT'] = '3'
+    VCR.use_cassette('custom timeout') do
+      assert_equal(1, SearchEds.new.send(:http_timeout))
     end
   end
 end

--- a/test/vcr_cassettes/custom_timeout.yml
+++ b/test/vcr_cassettes/custom_timeout.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.2.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 10 Apr 2017 17:36:01 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version: 
+  recorded_at: Mon, 10 Apr 2017 17:36:26 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
What:

* it is now possible to control the timeout via an Environment
  setting for EDS API calls

Why:

* there are times with EDS doesn't seem to be responding in an
  acceptable amount of time
* while we feel EDS should fix this, it is likely there will be
  times when we want to bump our timeout a bit higher just to allow
  users to search even if it takes way too long