### PR TITLE
Uses proxied links and prefers them over sfx links

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -35,7 +35,7 @@ class Result
   end
 
   def relevant_links
-    ['library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu']
+    ['libproxy.mit.edu', 'library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu']
   end
 
   # Check fulltext_links for specific parameters to allow for prioritization
@@ -53,7 +53,19 @@ class Result
     link = fulltext_links.map do |l|
       relevant_links.map { |x| l if l['Url'].include?(x) }
     end
-    link.flatten.compact.first['Url'] if link
+    fulltext_link_sorter(link).first if link
+  end
+
+  # prioritizes proxied links
+  def fulltext_link_sorter(link)
+    urls = link.flatten.compact.map { |x| x['Url'] }
+    urls.sort do |x|
+      if x.include?(relevant_links[0])
+        -1
+      else
+        1
+      end
+    end
   end
 
   # Reformat the Accession Number to match the format used in Aleph

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -166,4 +166,23 @@ class ResultTest < ActiveSupport::TestCase
     r.openurl = nil
     assert_nil(r.getit_url)
   end
+
+  test 'getit_url with sfx and proxied sd links uses sd' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = nil
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example' },
+      { 'Url' => 'http://libproxy.mit.edu/somestuff' }
+    ]
+    r.openurl = nil
+    assert_equal('http://libproxy.mit.edu/somestuff', r.getit_url)
+
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example' },
+      { 'Url' => 'http://example.com/example' },
+      { 'Url' => 'http://libproxy.mit.edu/somestuff' },
+      { 'Url' => 'http://sfx.mit.edu/example' }
+    ]
+    assert_equal('http://libproxy.mit.edu/somestuff', r.getit_url)
+  end
 end


### PR DESCRIPTION
What:

* consider proxied links relevant
* if custom_links have both sfx and proxied links, prefer proxied

Why:

* the proxied links have been determined to be more reliable

How:

* the sort currently only prioritizes proxied links. If we need to sort
  in a more complex way, say by the order in `relevant_links`, more work
  will need to be done to ensure the sort always works as intended. This
  is entirely fine for our current use case.

See https://mitlibraries.atlassian.net/browse/DI-296