### PR TITLE
Adds in-app subject and author links

### DIFF
--- a/app/models/normalize_eds_books.rb
+++ b/app/models/normalize_eds_books.rb
@@ -16,12 +16,16 @@ class NormalizeEdsBooks
 
   def subjects
     bibrecord['BibEntity']['Subjects']&.map do |s|
-      [s['SubjectFull'], subject_link(s['SubjectFull'])]
+      [subject_name(s), subject_link(s)]
     end
   end
 
+  def subject_name(subject)
+    subject['SubjectFull']
+  end
+
   def subject_link(subject)
-    ENV['EDS_PROFILE_URI'] + URI.encode_www_form_component("DE \"#{subject}\"")
+    URI.encode_www_form_component("SU \"#{subject_name(subject)}\"")
   end
 
   def location

--- a/app/models/normalize_eds_common.rb
+++ b/app/models/normalize_eds_common.rb
@@ -78,16 +78,12 @@ class NormalizeEdsCommon
 
   def authors
     contributors&.map do |author_node|
-      [author_name(author_node), author_link(author_node)]
+      [author_name(author_node), author_search_format(author_node)]
     end
   end
 
   def author_name(author_node)
     author_node.dig('PersonEntity', 'Name', 'NameFull')
-  end
-
-  def author_link(author_node)
-    ENV['EDS_PROFILE_URI'] + author_search_format(author_node)
   end
 
   def author_search_format(author_node)

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -1,4 +1,9 @@
 <div class="wrap-result">
+  <% if Flipflop.enabled?(:local_browse) %>
+    <% search_prefix = '/search/bento?q=' %>
+  <% else %>
+    <% search_prefix = ENV['EDS_PROFILE_URI'] %>
+  <% end %>
 
   <% if result.thumbnail %>
     <div class="result-image">
@@ -23,7 +28,7 @@
         <span class="sr">Authors: </span>
         <% result.truncated_authors.each do |author| %>
         <span class="result-author">
-          <%= link_to(author[0], author[1], data: {type: "Author"} ) unless author == "et al" %>
+          <%= link_to(author[0], search_prefix + author[1], data: {type: "Author"} ) unless author == "et al" %>
           <%= author if author == "et al" %>
         </span>
         <% end %>
@@ -49,7 +54,7 @@
         <ul class="list-subjects">
         <% result.truncated_subjects.each do |subject| %>
           <li class="result-subjectheading">
-            <%= link_to(subject[0], subject[1], data: {type: "Subject"} ) %>
+            <%= link_to(subject[0], search_prefix + subject[1], data: {type: "Subject"} ) %>
           </li>
         <% end %>
         </ul>

--- a/test/models/normalize_eds_articles_test.rb
+++ b/test/models/normalize_eds_articles_test.rb
@@ -42,7 +42,7 @@ class NormalizeEdsArticlesTest < ActiveSupport::TestCase
 
   test 'normalized articles have expected author links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DAU+%22Moreira+Ribeiro%2C+Rodrigo%22',
+      'AU+%22Moreira+Ribeiro%2C+Rodrigo%22',
       popcorn_articles['results'][0].authors[0][1]
     )
   end

--- a/test/models/normalize_eds_books_test.rb
+++ b/test/models/normalize_eds_books_test.rb
@@ -29,7 +29,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
 
   test 'normalized books have expected author links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DAU+%22Mulholland%2C+Garry%22',
+      'AU+%22Mulholland%2C+Garry%22',
       popcorn_books['results'][0].authors[0][1]
     )
   end
@@ -67,7 +67,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
     skip('need to determine logic to how this will work without misleading')
   end
 
-  test 'normalized books have expected subjects' do
+  test 'normalized books have expected external subjects' do
     assert_equal(
       'Rock films -- History and criticism',
       popcorn_books['results'][0].subjects[0][0]
@@ -76,7 +76,7 @@ class NormalizeEdsBooksTest < ActiveSupport::TestCase
 
   test 'normalized books have expected subject links' do
     assert_equal(
-      'http://libproxy.mit.edu/login?url=https%3A%2F%2Fsearch.ebscohost.com%2Flogin.aspx%3Fdirect%3Dtrue%26AuthType%3Dcookie%2Csso%2Cip%2Cuid%26type%3D0%26group%3Dedstest%26site%3Dedswhatnot%26profile%3Dedswhatnot%26bquery%3DDE+%22Rock+films+--+History+and+criticism%22',
+      'SU+%22Rock+films+--+History+and+criticism%22',
       popcorn_books['results'][0].subjects[0][1]
     )
   end


### PR DESCRIPTION
* local_browse feature now uses in_app links instead of external links
  to EDS UI for authors and subjects
* external links are still used when local_browse is not enabled


NOTE: I'm not sure this is actually working as intended as I don't seem to get identical results browsing locally and via the EDS UI options.

HINT: https://mit-bento-staging-pr-182.herokuapp.com/toggle?feature=local_browse