### PR TITLE
Truncate title display

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -10,6 +10,8 @@ class Result
                 :db_source, :an, :fulltext_links, :marc_856, :openurl,
                 :winner, :record_links, :uniform_title
 
+  MAX_TITLE_LENGTH = ENV['MAX_TITLE_LENGTH'] || 150
+
   def initialize(title, url)
     @title = title
     @url = url
@@ -85,6 +87,10 @@ class Result
 
   def truncated_subjects
     subjects[0..2]
+  end
+
+  def truncated_title
+    title.truncate(MAX_TITLE_LENGTH, separator: ' ')
   end
 
   def aleph_cr_record?

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <h3 class="result-title">
-    <span class="sr">Title: </span><%= link_to(result.title, result.url, class: 'bento-link', data: {type: "Title"} ) %>
+    <span class="sr">Title: </span><%= link_to(result.truncated_title, result.url, class: 'bento-link', data: {type: "Title"} ) %>
   </h3>
   <div class="result-uniform-title">
     <% if result.uniform_title %>

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -70,6 +70,17 @@ class ResultTest < ActiveSupport::TestCase
     assert_equal(r.truncated_subjects, %w[a b c])
   end
 
+  test 'long title trucated' do
+    r = Result.new('title ' * 100, 'http://example.com')
+    assert(r.title.length > 150)
+    assert(r.truncated_title.length <= 150)
+  end
+
+  test 'long title not trucated mid word' do
+    r = Result.new('title ' * 100, 'http://example.com')
+    assert_equal('title...', r.truncated_title.split(' ').last)
+  end
+
   test 'can set citation' do
     r = Result.new('title', 'http://example.com')
     r.citation = 'Journal of Stuff, vol.12, no.1, pp.2-12'


### PR DESCRIPTION
What:

* `Result#truncated_title` truncates on full words less than the
  configured value of `ENV['MAX_TITLE_LENGTH']` or 150 if unset
* `...` is appended to better identify when this is taking place in
  the UI

Why:

* some titles are way too long

See: https://mitlibraries.atlassian.net/browse/DI-306