### PR TITLE
Keep view more link in dom when not displaying

### DIFF
--- a/app/assets/stylesheets/_bento.scss
+++ b/app/assets/stylesheets/_bento.scss
@@ -62,6 +62,10 @@
     display: block;
     text-align: center;
   }
+
+  .hidden {
+    @extend .is-hidden;
+  }
 }
 
 /* other bits */

--- a/app/views/search/_view_all_link.html.erb
+++ b/app/views/search/_view_all_link.html.erb
@@ -1,7 +1,6 @@
 <% if current_page?(:controller => 'search', :action => 'search_boxed') %>
   <div class="results-more">
   <% if @results['total'] > 0 %>
-    <% return unless @results['total'] > @per_box %>
     <% if Flipflop.enabled?(:local_browse) && @results['local_view_more'] %>
       <% view_more_url = @results['local_view_more'] %>
     <% else %>
@@ -10,7 +9,7 @@
     <%= link_to(
       "View all #{number_with_delimiter(@results['total'])} results",
       view_more_url,
-      data: {count: number_with_delimiter(@results['total']), type: 'view all results'}, class: 'button button-secondary') %>
+      data: {count: number_with_delimiter(@results['total']), type: 'view all results'}, class: "button button-secondary #{ 'hidden' if @results['total'] <= @per_box }") %>
   <% else %>
     No results found.
   <% end %>


### PR DESCRIPTION
* we were not adding the view more link when we had fewer results in
  the box than the per_box max which prevented the data elements from
  being present for the javascript to use to populate the summary bar
* this adds the view more link back to the dom and adds an `hidden`
  css class
* one day, Frances promises she will make that class something useful

https://mitlibraries.atlassian.net/browse/DI-302