### PR TITLE
Flag title values as html_safe because they are

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -12,11 +12,11 @@
   <% end %>
 
   <h3 class="result-title">
-    <span class="sr">Title: </span><%= link_to(result.truncated_title, result.url, class: 'bento-link', data: {type: "Title"} ) %>
+    <span class="sr">Title: </span><%= link_to(result.truncated_title.html_safe, result.url, class: 'bento-link', data: {type: "Title"} ) %>
   </h3>
   <div class="result-uniform-title">
     <% if result.uniform_title %>
-      <span class="sr">Alternate Title: </span><%= result.uniform_title %>
+      <span class="sr">Alternate Title: </span><%= result.uniform_title.html_safe %>
     <% end %>
   </div>
   <p>


### PR DESCRIPTION
What:

* flag title values as html_safe so they won't be escaped and thus
  display properly.

Why:

* nobody wants to see `&amp;`

See: https://mitlibraries.atlassian.net/browse/DI-329