### PR TITLE
Change name to generic or quick search

### DIFF
--- a/app/views/layouts/_about-bento.html.erb
+++ b/app/views/layouts/_about-bento.html.erb
@@ -1,5 +1,5 @@
 <div class="about-bento bit" role="complementary">
-  <h3 class="title">About this beta discovery search</h3>
-  <p>Beta discovery at the MIT Libraries is a new way to find books, movies, music, articles, journals, and other great stuff we have at the library. You will find results sorted into categories: books and media, articles and journals, and library website, as well as links to more specific search tools and resources. <a href="https://libraries.mit.edu/beta-search/">Learn more</p>
+  <h3 class="title">About this search app</h3>
+  <p>Quick search at the MIT Libraries is a new way to find books, movies, music, articles, journals, and other great stuff we have at the library. You will find results sorted into categories: books and media, articles and journals, and library website, as well as links to more specific search tools and resources. <a href="https://libraries.mit.edu/beta-search/">Learn more</p>
   <p><%= link_to('Let us know what you think of this new tool', feedback_path) %></p>
 </div>

--- a/app/views/layouts/_breadcrumbs.html
+++ b/app/views/layouts/_breadcrumbs.html
@@ -1,7 +1,7 @@
 <div class="wrap-outer-breadcrumb layout-band">
   <div class="wrap-breadcrumb" role="navigation" aria-label="breadcrumbs">
     <div class="breadcrumbs">
-      <a href="https://libraries.mit.edu" title="MIT Libraries">Home</a>  &raquo;  <a href="/">Discovery</a>
+      <a href="https://libraries.mit.edu" title="MIT Libraries">Home</a>  &raquo;  <a href="/">Search</a>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title><%= content_for?(:title) ? yield(:title) : " Discovery search | MIT Libraries" %></title>
+<title><%= content_for?(:title) ? yield(:title) : " Search | MIT Libraries" %></title>
 <%= csrf_meta_tags %>
 
 <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->

--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -17,7 +17,7 @@
 <div class="wrap-outer-header-local layout-band">
   <div class="wrap-header-local">
     <div class="local-identity">
-      <h2 class="title title-site"><a href="/">Discovery Search at MIT Libraries</a></h2>
+      <h2 class="title title-site"><a href="/">Quick Search at MIT Libraries</a></h2>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR changes references to "Discovery" to "Quick search" or just generic "search" since we don't want to name this app (yet).