### PR TITLE
Handle multiple colons in searchterm

### DIFF
--- a/app/models/search_eds.rb
+++ b/app/models/search_eds.rb
@@ -34,7 +34,7 @@ class SearchEds
   # Clean search term to match EDS expectations
   # Commas cause problems as they seem to be interpreted as multiple params.
   def clean_term(term)
-    URI.encode(term.strip.tr(' ', '+').delete(','))
+    URI.encode(term.strip.tr(' ', '+').tr(':', '%3A').delete(','))
   end
 
   def search_url(term, facets, page, per_page)


### PR DESCRIPTION
EDS seems to treat colons as a special character. Encoding them
explicitly seems to work okay.

https://mitlibraries.atlassian.net/browse/DI-360