### PR TITLE
Allow SpecReporter format and enable on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: ruby
 rvm:
   - 2.4.1
 sudo: false
+env:
+  - SPEC_REPORTER=true
 script: bin/rails test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,12 @@ require 'rails/test_help'
 require 'minitest/rails/capybara'
 require 'minitest/reporters'
 require 'mocha/mini_test'
-Minitest::Reporters.use!
+
+if ENV['SPEC_REPORTER'] == 'true'
+  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
+else
+  Minitest::Reporters.use!
+end
 
 VCR.configure do |config|
   config.ignore_localhost = true


### PR DESCRIPTION
What:

* allows optional, via ENV['SPEC_REPORTER'], more detailed test
  output

Why:

* in CI, and sometimes locally, it's nice to see the SpecReporter
  test output