### PR TITLE
Split EDS supplied sfx links by subscribed bucket

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -105,6 +105,12 @@
       <%= link_to("View online", result.getit_url, class: 'online button button-primary green', data: {type: "Get"}) %>
     <% end %>
 
+    <% if Flipflop.enabled?(:check_online) %>
+      <% if result.getit_url.blank? && result.check_sfx_url.present? %>
+        <%= link_to("Check for online access", result.check_sfx_url, class: 'online button-secondary', data: {type: "Check"}) %>
+      <% end %>
+    <% end %>
+
     <%= link_to("Details and requests", result.url, class: 'details button button-secondary', data: {type: "Detail"}) %>
   </div>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -10,4 +10,8 @@ Flipflop.configure do
   feature :local_browse,
     default: false,
     description: 'Enables local browsing of paginated results'
+
+  feature :check_online,
+    default: false,
+    description: 'Enables button for EDS supplied non-subscribed SFX links'
 end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -196,4 +196,39 @@ class ResultTest < ActiveSupport::TestCase
     ]
     assert_equal('http://libproxy.mit.edu/somestuff', r.getit_url)
   end
+
+  test 'getit_url with only non-subscribed sfx link' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = nil
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example',
+        'Name' => 'SFX link (not subscribed resources)' }
+    ]
+    r.openurl = nil
+    assert_nil(r.getit_url)
+  end
+
+  test 'getit_url with subscribed and non-subscribed sfx links' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = nil
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example',
+        'Name' => 'SFX link (not subscribed resources)' },
+      { 'Url' => 'http://sfx.mit.edu/hi_mom' }
+    ]
+    r.openurl = nil
+    assert_equal('http://sfx.mit.edu/hi_mom', r.getit_url)
+  end
+
+  test 'check_sfx_url with non-subscribed link' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = nil
+    r.fulltext_links = [
+      { 'Url' => 'http://sfx.mit.edu/example',
+        'Name' => 'SFX link (not subscribed resources)' }
+    ]
+    r.openurl = nil
+    assert_nil(r.getit_url)
+    assert_equal('http://sfx.mit.edu/example', r.check_sfx_url)
+  end
 end


### PR DESCRIPTION
What:

* detects sfx links from EDS that are in our not-subscribed bucket and
  prevents them from being used in the View Online button
* adds non-subscribed sfx links to a new button with a feature flag

Why:

* having the view online button lead to an sfx page that only allowed
  ILL was not desired
* non-subscribed sfx however remain useful, so feature flagging the new
  button for testing allows us to assess our next steps

https://mitlibraries.atlassian.net/browse/DI-371