### PR TITLE
update about link to point to prod version

### DIFF
--- a/app/views/layouts/_about-bento.html.erb
+++ b/app/views/layouts/_about-bento.html.erb
@@ -1,5 +1,5 @@
 <div class="about-bento bit" role="complementary">
   <h3 class="title">About this search app</h3>
-  <p>Quick search at the MIT Libraries is a new way to find books, movies, music, articles, journals, and other great stuff we have at the library. You will find results sorted into categories: books and media, articles and journals, and library website, as well as links to more specific search tools and resources. <a href="https://libraries.mit.edu/beta-search/">Learn more</a></p>
+  <p>Quick search at the MIT Libraries is a new way to find books, movies, music, articles, journals, and other great stuff we have at the library. You will find results sorted into categories: books and media, articles and journals, and library website, as well as links to more specific search tools and resources. <a href="https://libraries.mit.edu/about-quick-search/">Learn more</a></p>
   <p><%= link_to('Let us know what you think of this new tool', feedback_path) %></p>
 </div>


### PR DESCRIPTION
The about link should now point to the non-beta about page link. 