### PR TITLE
Adds preliminary github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Status
+**READY/IN DEVELOPMENT/HOLD**
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/DI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Tests
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires Database Migrations?
+YES | NO
+
+#### Includes new or updated dependencies?
+YES | NO


### PR DESCRIPTION
What:

* adds a pull request template

Why:

* standardizing the information in our pull requests will make
  reviewing code easier

Documenation: https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/