### PR TITLE
Hints

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -1,0 +1,7 @@
+class HintController < ApplicationController
+  def hint
+    return unless params[:q].present?
+    @hint = Hint.match(params[:q])
+    render layout: false
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -1,0 +1,10 @@
+class Hint < ApplicationRecord
+  has_many :matches
+
+  def self.match(searchterm)
+    Match.all.map do |m|
+      next unless searchterm.include?(m.match)
+      m.hint
+    end.compact.first
+  end
+end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,0 +1,3 @@
+class Match < ApplicationRecord
+  belongs_to :hint
+end

--- a/app/views/hint/hint.html.erb
+++ b/app/views/hint/hint.html.erb
@@ -1,0 +1,9 @@
+<% if @hint %>
+  <div class="wrap-hint-box">
+    <div class="hint-box">
+      <p class="type">Popular result</p>
+      <h3 class="title"><%= @hint.title %></h3>
+      <p class="desc"><%= link_to(@hint.url, @hint.url, data: {type: "Hint"} ) %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/search/_trigger_hint.html.erb
+++ b/app/views/search/_trigger_hint.html.erb
@@ -1,0 +1,9 @@
+$.ajax({
+  url: "/hint?q=<%= URI.encode_www_form_component(params[:q]) %>"
+}).done(function( msg ) {
+  console.log(msg);
+  $('#hint').html( msg );
+  TrackLinks( $('#hint').find( 'a' ) );
+}).fail(function( xhr, textStatus ) {
+  console.log(xhr);
+});

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -17,6 +17,8 @@
   <p>Was this search useful? <%= link_to('Send feedback', feedback_path) %>
 </div>
 
+<div id="hint"></div>
+
 <div class="gridband layout-2c">
   <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand search to libraries around the world</a>" } %>
 
@@ -37,4 +39,7 @@
   <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
 
   <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
+
+  <%= render partial: "trigger_hint" %>
+
 </script>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -17,7 +17,9 @@
   <p>Was this search useful? <%= link_to('Send feedback', feedback_path) %>
 </div>
 
-<div id="hint"></div>
+<% if Flipflop.enabled?(:hints) %>
+  <div id="hint"></div>
+<% end %>
 
 <div class="gridband layout-2c">
   <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand search to libraries around the world</a>" } %>
@@ -40,6 +42,8 @@
 
   <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
 
-  <%= render partial: "trigger_hint" %>
+  <% if Flipflop.enabled?(:hints) %>
+    <%= render partial: "trigger_hint" %>
+  <% end %>
 
 </script>

--- a/config/features.rb
+++ b/config/features.rb
@@ -14,4 +14,8 @@ Flipflop.configure do
   feature :check_online,
     default: false,
     description: 'Enables button for EDS supplied non-subscribed SFX links'
+
+  feature :hints,
+    default: false,
+    description: 'Enables best bet search hint placards'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   post 'feedback', to: 'feedback#submit', as: :feedback_submit
 
   get 'item_status', to: 'aleph#item_status'
+  get 'hint', to: 'hint#hint'
   get 'toggle', to: 'feature#toggle'
 
   get '*path', to: 'catch_all#catch_all'

--- a/db/migrate/20170623172641_create_hints.rb
+++ b/db/migrate/20170623172641_create_hints.rb
@@ -1,0 +1,10 @@
+class CreateHints < ActiveRecord::Migration[5.1]
+  def change
+    create_table :hints do |t|
+      t.string :title, null: false
+      t.string :url, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170626140311_create_matches.rb
+++ b/db/migrate/20170626140311_create_matches.rb
@@ -1,0 +1,10 @@
+class CreateMatches < ActiveRecord::Migration[5.1]
+  def change
+    create_table :matches do |t|
+      t.belongs_to :hint, index: true
+      t.string :match
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150101010101) do
+ActiveRecord::Schema.define(version: 20170626140311) do
+
+  create_table "hints", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "matches", force: :cascade do |t|
+    t.integer "hint_id"
+    t.string "match"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hint_id"], name: "index_matches_on_hint_id"
+  end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",      null: false
-    t.string   "uid",        null: false
+    t.string "email", null: false
+    t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_users_on_uid", unique: true

--- a/test/controllers/hint_controller_test.rb
+++ b/test/controllers/hint_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class HintControllerTest < ActionDispatch::IntegrationTest
+  test 'hint with no query' do
+    get '/hint'
+    assert_response :success
+  end
+
+  test 'hint with query and no match' do
+    get '/hint?q=purple+stuff'
+    assert_response :success
+    assert_empty(@response.body)
+  end
+
+  test 'hint with query and match' do
+    get '/hint?q=INDSTAT'
+    assert_response :success
+    assert_includes(@response.body, 'UNIDO Statistics Data Portal')
+  end
+end

--- a/test/fixtures/hints.yml
+++ b/test/fixtures/hints.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  title: 'hint value'
+  url: 'http://example.com/get/stuff'
+
+unido:
+  title: 'UNIDO Statistics Data Portal'
+  url: 'http://libraries.mit.edu/get/unido-data'

--- a/test/fixtures/matches.yml
+++ b/test/fixtures/matches.yml
@@ -1,0 +1,29 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  match: popcorn
+  hint: one
+
+unido_1:
+  match: 'UNIDO Statistics Data Portal'
+  hint: unido
+
+unido_2:
+  match: IDSB
+  hint: unido
+
+unido_4:
+  match: INDSTAT4
+  hint: unido
+
+unido_5:
+  match: INDSTAT2
+  hint: unido
+
+unido_5:
+  match: INDSTAT
+  hint: unido

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class HintTest < ActiveSupport::TestCase
+  test 'simple exact match' do
+    searchterm = 'popcorn'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:one), match)
+  end
+
+  test 'simple non match' do
+    searchterm = 'grapes'
+    match = Hint.match(searchterm)
+    assert_nil(match)
+  end
+
+  test 'match on one of multiple terms' do
+    searchterm = 'INDSTAT'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:unido), match)
+  end
+
+  test 'match anywhere in the searchterm' do
+    searchterm = 'I want INDSTAT to be found'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:unido), match)
+  end
+
+  test 'phrase match within longer string if enabled' do
+    searchterm = 'popcorn soup is good for you'
+    # match on 'popcorn soup is good for you'
+    # match on 'soup is good for you' ?
+    # match on 'popcorn soup' ?
+    match = Hint.match(searchterm)
+    assert_equal(hints(:one), match)
+  end
+
+  # The intent of this test is to prove we can disable matching
+  # of the phrase if it is not left truncated. Right now we
+  # cannot do that though so we skip it. The feature seems
+  # useful but has not gotten stakeholder support yet.
+  test 'no phrase match mid string if not enabled' do
+    skip 'not yet implemented'
+    searchterm =  'soup is good popcorn'
+    match = Hint.match(searchterm)
+    assert_nil(match)
+  end
+
+  test 'phrase left justified in longer string when not enabled' do
+    searchterm =  'blah blah UNIDO Statistics Data Portal'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:unido), match)
+  end
+end

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MatchTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This is an initial system to store local search hints or best bets and match them fairly naively to search terms a user supplies. Please see individual commit messages for further details on limitations and features.

#### Helpful background context (if appropriate)

Users are having difficulty locating some items. As the search engine is vended, we cannot adjust the upstream settings directly (we are working with them to address immediate concerns). This system will allow us to intervene in such cases that the search engine predictably does not return expected results.

#### How can a reviewer manually see the effects of these changes?

You first have to populate a Hint and associated Match phrases in the database. Example staring at a Rails console:

```ruby
h = Hint.create(title: 'da title', url: 'http://example.com/get/stuff')
Match.create(hint: h, match: 'popcorn soup')
```

Then run a search that should match and you'll see a placard displayed.

Running a search that should not match should not show any placard.
#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-411

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES

`bin/rails db:migrate` will need to be run locally to update the schema

#### Includes new or updated dependencies?
NO