### PR TITLE
Migrates database during heroku release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rails db:migrate
 web: bundle exec puma -C config/puma.rb

--- a/db/migrate/20150101010101_devise_create_users.rb
+++ b/db/migrate/20150101010101_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       t.string :email, null: false


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
To date, the bento app has not used a database. This gets us set to use one by running the
database migrations during the release phase.

#### Helpful background context (if appropriate)
https://devcenter.heroku.com/articles/release-phase

#### How can a reviewer manually see the effects of these changes?
This is entirely a Heroku side thing. It won't be noticeable until we do a PR _after_ this is merged.

#### What are the relevant tickets?
None

#### Requires Database Migrations?
NO (ha!)

#### Includes new or updated dependencies?
NO (pg was already provisioned, we just weren't using it)