### PR TITLE
Initial system to store local search hints

### DIFF
--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -1,0 +1,7 @@
+class HintController < ApplicationController
+  def hint
+    return if params[:q].blank?
+    @hint = Hint.match(params[:q])
+    render layout: false
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -1,0 +1,5 @@
+class Hint < ApplicationRecord
+  def self.match(searchterm)
+    Hint.find_by(fingerprint: searchterm)
+  end
+end

--- a/app/views/hint/hint.html.erb
+++ b/app/views/hint/hint.html.erb
@@ -1,0 +1,9 @@
+<% if @hint %>
+  <div class="wrap-hint-box">
+    <div class="hint-box">
+      <p class="type">Popular result</p>
+      <h3 class="title"><%= @hint.title %></h3>
+      <p class="desc"><%= link_to(@hint.url, @hint.url, data: {type: "Hint"} ) %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/search/_trigger_hint.html.erb
+++ b/app/views/search/_trigger_hint.html.erb
@@ -1,0 +1,9 @@
+$.ajax({
+  url: "/hint?q=<%= URI.encode_www_form_component(params[:q]) %>"
+}).done(function( msg ) {
+  console.log(msg);
+  $('#hint').html( msg );
+  TrackLinks( $('#hint').find( 'a' ) );
+}).fail(function( xhr, textStatus ) {
+  console.log(xhr);
+});

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -17,6 +17,10 @@
   <p>Was this search useful? <%= link_to('Send feedback', feedback_path) %>
 </div>
 
+<% if Flipflop.enabled?(:hints) %>
+  <div id="hint"></div>
+<% end %>
+
 <div class="gridband layout-2c">
   <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand search to libraries around the world</a>" } %>
 
@@ -37,4 +41,9 @@
   <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
 
   <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
+
+  <% if Flipflop.enabled?(:hints) %>
+    <%= render partial: "trigger_hint" %>
+  <% end %>
+
 </script>

--- a/config/features.rb
+++ b/config/features.rb
@@ -14,4 +14,8 @@ Flipflop.configure do
   feature :check_online,
     default: false,
     description: 'Enables button for EDS supplied non-subscribed SFX links'
+
+  feature :hints,
+    default: false,
+    description: 'Enables best bet search hint placards'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   post 'feedback', to: 'feedback#submit', as: :feedback_submit
 
   get 'item_status', to: 'aleph#item_status'
+  get 'hint', to: 'hint#hint'
   get 'toggle', to: 'feature#toggle'
 
   get '*path', to: 'catch_all#catch_all'

--- a/db/migrate/20170623172641_create_hints.rb
+++ b/db/migrate/20170623172641_create_hints.rb
@@ -1,0 +1,12 @@
+class CreateHints < ActiveRecord::Migration[5.1]
+  def change
+    create_table :hints do |t|
+      t.string :title, null: false
+      t.string :url, null: false
+      t.string :fingerprint, null: false
+      t.timestamps
+    end
+
+    add_index :hints, :fingerprint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150101010101) do
+ActiveRecord::Schema.define(version: 20170623172641) do
+
+  create_table "hints", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "url", null: false
+    t.string "fingerprint", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fingerprint"], name: "index_hints_on_fingerprint"
+  end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",      null: false
-    t.string   "uid",        null: false
+    t.string "email", null: false
+    t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["uid"], name: "index_users_on_uid", unique: true

--- a/test/controllers/hint_controller_test.rb
+++ b/test/controllers/hint_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class HintControllerTest < ActionDispatch::IntegrationTest
+  test 'hint with no query' do
+    get '/hint'
+    assert_response :success
+  end
+
+  test 'hint with query and no match' do
+    get '/hint?q=purple+stuff'
+    assert_response :success
+    assert_empty(@response.body)
+  end
+
+  test 'hint with query and match' do
+    get '/hint?q=INDSTAT'
+    assert_response :success
+    assert_includes(@response.body, 'UNIDO Statistics Data Portal')
+  end
+end

--- a/test/fixtures/hints.yml
+++ b/test/fixtures/hints.yml
@@ -1,0 +1,20 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one:
+  title: 'hint value'
+  url: 'http://example.com/get/stuff'
+  fingerprint: 'popcorn'
+
+unido:
+  title: 'UNIDO Statistics Data Portal'
+  url: 'http://libraries.mit.edu/get/unido-data'
+  fingerprint: 'INDSTAT'
+
+unido2:
+  title: 'UNIDO Statistics Data Portal'
+  url: 'http://libraries.mit.edu/get/unido-data'
+  fingerprint: 'IDSB'

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class HintTest < ActiveSupport::TestCase
+  test 'simple exact match' do
+    searchterm = 'popcorn'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:one), match)
+  end
+
+  test 'simple non match' do
+    searchterm = 'grapes'
+    match = Hint.match(searchterm)
+    assert_nil(match)
+  end
+
+  test 'phrase match within longer string' do
+    skip 'not yet implemented'
+    searchterm = 'popcorn soup is good for you'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:one), match)
+  end
+
+  # The intent of this test is to prove we can disable matching
+  # of the phrase if it is not left truncated. Right now we
+  # cannot do that though so we skip it. The feature seems
+  # useful but has not gotten stakeholder support yet.
+  test 'no phrase match mid string if not enabled' do
+    skip 'not yet implemented'
+    searchterm =  'soup is good popcorn'
+    match = Hint.match(searchterm)
+    assert_nil(match)
+  end
+
+  test 'phrase left justified in longer string when not enabled' do
+    skip 'not yet implemented'
+    searchterm =  'blah blah UNIDO Statistics Data Portal'
+    match = Hint.match(searchterm)
+    assert_equal(hints(:unido), match)
+  end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This allows for phrase matching of search queries to suggested
  'best bets' to display in a placard system.

#### Helpful background context (if appropriate)
Users are having difficulty locating some items. As the search engine is vended, we cannot adjust the upstream settings directly (we are working with them to address immediate concerns). This system will allow us to intervene in such cases that the search engine predictably does not return expected results.

This is preliminary work currently behind a feature flag. Additional work will be done
before we make this a public facing feature.

#### How can a reviewer manually see the effects of these changes?
- migrate your db to get the latest schema (see below)
- create a Hint using a rails console: `heroku local:run rails console`
- in the rails console:
  `Hint.create(title: 'yo title', url: 'http://example.com/get/stuff', fingerprint: 'popcorn')`
- enable the feature in your browser sessions: `/toggle?feature=hints`
- search for `popcorn` and see a placard!

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-411

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES
`bin/rails db:migrate` in your dev environment. This normally also updates your test db, but
if you run into issues, `bin/rails db:test:prepare` is your friend.

#### Includes new or updated dependencies?
NO