### PR TITLE
Include libraries.mit.edu domain in relevant_links

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -43,7 +43,8 @@ class Result
 
   # domains we consider relevant when evaluating links
   def relevant_links
-    ['libproxy.mit.edu', 'library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu']
+    ['libproxy.mit.edu', 'library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu',
+     'libraries.mit.edu']
   end
 
   # Check fulltext_links for specific parameters to allow for prioritization

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -170,6 +170,12 @@ class ResultTest < ActiveSupport::TestCase
     assert_equal('http://library.mit.edu/F/this_is_a_marc856_link', r.getit_url)
   end
 
+  test 'getit_url with libraries.mit.edu url' do
+    r = record_with_all_url_possibilities
+    r.marc_856 = 'http://libraries.mit.edu/get/stuff'
+    assert_equal('http://libraries.mit.edu/get/stuff', r.getit_url)
+  end
+
   test 'getit_url with irrelevant marc_856 url' do
     r = record_with_all_url_possibilities
     r.marc_856 = 'http://example.org/this_is_a_marc856_link'


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

a change to how we handle "get URLs" necessitates we include the
libraries.mit.edu domain in our `relevant_links`

#### Helpful background context (if appropriate)

In order to not use irrelevant links to t.o.c or publisher sites that we include in our MARC records, we only count links to "relevant" domains as links for our `View Online` links.

#### How can a reviewer manually see the effects of these changes?

Once the data is loaded from our test barton catalog into the test EDS profile, searching for records with get urls should provide that URL directly as the "View Online" url rather than as a passed parameter in a SFX url.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-436

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO