### PR TITLE
Explicitly set cache expiration

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -31,7 +31,7 @@ class SearchController < ApplicationController
   # items when necessary.
   def search_results(page, per_page)
     return unless valid_target?
-    Rails.cache.fetch(cache_key(page, per_page)) do
+    Rails.cache.fetch(cache_key(page, per_page), expires_in: 1.day) do
       search_target(page, per_page)
     end
   end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

this explicitly sets the cache of search results to expire

#### Helpful background context (if appropriate)

* memcachier is supposed to purge based on LRU, but we have seen in
  production that didn't happen with our current configuration
* the intent here is to set cached items to explicitly expire so
  hopefully they will be purged appropriately as expected
* we'll need to monitor the results of this change to ensure it is
  working as intended (the cache size on staging is much smaller so
  we can use that to confirm expected results before production cache
  size gets large enough to be a concern)

#### How can a reviewer manually see the effects of these changes?

Sadly, you can't really :/

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-383 (sort of)

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO