### PR TITLE
451 hint source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ coverage
 
 .byebug_history
 .DS_Store
+doc/
+.yardoc/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ Search API. Appropriate credentials for both are required (see below).
 ## Bento System Overview
 ![alt text](docs/charts/bento_overview.png "Bento system overview chart")
 
+## Loading Hints
+
+Tasks exist to reload hints from supported sources.
+Example to reload Aleph hints in a development environment:
+```
+heroku local:run bin/rails reloadhints:aleph
+```
+_note_: `reloadhints:aleph` requires ENV `ALEPH_HINT_SOURCE`
+
 ## Required Environment Variables
 
 - `ALEPH_API_URI`: endpoint URI for Aleph Realtime Availability checks

--- a/app/models/aleph_hint.rb
+++ b/app/models/aleph_hint.rb
@@ -4,6 +4,7 @@ require 'open-uri'
 class AlephHint
   def initialize
     @marcxml = marcxml
+    @source = 'aleph'
   end
 
   # Load aleph hint source as XML
@@ -24,23 +25,18 @@ class AlephHint
   end
 
   # Creates Hints for each record for each title and alt title
-  # NOTE: at this time there is no detection of duplicates as that logic
-  # may better reside in the Hint object itself to handle duplicates that may
-  # originate from different loaders.
+  # @note duplicates are handled in the [Hint] model and are last one in wins
   def record_to_hints(record)
-    Hint.create(title: title(record), url: best_url(record),
-                fingerprint: Hint.fingerprint(title(record)))
-
-    fingerprint_alt_titles(246, record)
-
-    fingerprint_alt_titles(740, record)
+    fingerprint_titles(245, record)
+    fingerprint_titles(246, record)
+    fingerprint_titles(740, record)
   end
 
-  # Creates a Hint for each alternate title
-  def fingerprint_alt_titles(field, record)
+  # Creates a Hint for each title
+  def fingerprint_titles(field, record)
     alt_titles(field, record).each do |alt_title|
-      Hint.create(title: title(record), url: best_url(record),
-                  fingerprint: Hint.fingerprint(alt_title))
+      Hint.upsert(title: title(record), url: best_url(record),
+                  fingerprint: Hint.fingerprint(alt_title), source: @source)
     end
   end
 
@@ -61,7 +57,7 @@ class AlephHint
     )
   end
 
-  # For some reason, we sometimes use the standard 866$u for URLs but other
+  # For some reason, we sometimes use the standard 856$u for URLs but other
   # times use 956$u.
   def url(record)
     urls = []
@@ -71,7 +67,7 @@ class AlephHint
   end
 
   # Select the first Get URL from the array of urls
-  # NOTE: the datasource was created by selecting records that contained
+  # @note the datasource was created by selecting records that contained
   # this url pattern so we make the assumption here that at least one url
   # should indeed match. Failure to maintain that contract will result in
   # an exception error during the loading of records.

--- a/app/models/aleph_hint.rb
+++ b/app/models/aleph_hint.rb
@@ -17,6 +17,15 @@ class AlephHint
     @marcxml.xpath('//xmlns:record')
   end
 
+  # Deletes all Hints for the aleph source and reloads from the external source
+  # @note rollback if any errors occur
+  def reload
+    ActiveRecord::Base.transaction do
+      Hint.where(source: @source).delete_all
+      process_records
+    end
+  end
+
   # Loops over records and calls out to hint creation logic
   def process_records
     records.each do |record|

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -8,6 +8,7 @@
 #  fingerprint :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  source      :string           not null
 #
 
 require 'stringex/core_ext'
@@ -16,6 +17,19 @@ class Hint < ApplicationRecord
   def self.match(searchterm)
     searchprint = fingerprint(searchterm)
     Hint.find_by(fingerprint: searchprint)
+  end
+
+  # Updates a record if it exists, creates one if it does not
+  # @return [Hint]
+  def self.upsert(title:, url:, fingerprint:, source:)
+    hint = Hint.find_by(fingerprint: fingerprint, source: source)
+    if hint
+      hint.update(title: title, url: url)
+      hint.reload
+    else
+      Hint.create(title: title, url: url, fingerprint: fingerprint,
+                  source: source)
+    end
   end
 
   # This implements the OpenRefine fingerprinting algorithm. See

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -14,12 +14,20 @@
 require 'stringex/core_ext'
 
 class Hint < ApplicationRecord
+  validates :title, presence: true
+  validates :url, presence: true
+  validates :fingerprint, presence: true
+  validates :source, presence: true
+  validates :fingerprint, uniqueness: { scope: :source }
+
   def self.match(searchterm)
     searchprint = fingerprint(searchterm)
     Hint.find_by(fingerprint: searchprint)
   end
 
   # Updates a record if it exists, creates one if it does not
+  # @note an exception is thrown if validations fail to allow a loader to
+  #       rollback and sanity check data
   # @return [Hint]
   def self.upsert(title:, url:, fingerprint:, source:)
     hint = Hint.find_by(fingerprint: fingerprint, source: source)
@@ -27,8 +35,8 @@ class Hint < ApplicationRecord
       hint.update(title: title, url: url)
       hint.reload
     else
-      Hint.create(title: title, url: url, fingerprint: fingerprint,
-                  source: source)
+      Hint.create!(title: title, url: url, fingerprint: fingerprint,
+                   source: source)
     end
   end
 

--- a/db/migrate/20170727185125_add_source_to_hints.rb
+++ b/db/migrate/20170727185125_add_source_to_hints.rb
@@ -1,0 +1,12 @@
+class AddSourceToHints < ActiveRecord::Migration[5.1]
+  def change
+    # we will need to delete all existing hints before this migration
+    # or it will rollback. I don't want to add that step to the migration
+    # as I want the person running the migration to understand the consequences
+    # of deleting Hints before proceeding.
+    add_column :hints, :source, :string
+    change_column_null :hints, :source, false
+    add_index :hints, :source
+    add_index :hints, [:fingerprint, :source], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623172641) do
+ActiveRecord::Schema.define(version: 20170727185125) do
 
   create_table "hints", force: :cascade do |t|
     t.string "title", null: false
@@ -18,7 +18,10 @@ ActiveRecord::Schema.define(version: 20170623172641) do
     t.string "fingerprint", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source", null: false
+    t.index ["fingerprint", "source"], name: "index_hints_on_fingerprint_and_source", unique: true
     t.index ["fingerprint"], name: "index_hints_on_fingerprint"
+    t.index ["source"], name: "index_hints_on_source"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/reloadhints.rake
+++ b/lib/tasks/reloadhints.rake
@@ -1,0 +1,15 @@
+namespace :loadhints do
+  desc 'Drop and Reload Hints from Aleph Source'
+  task aleph: :environment do
+    Rails.logger.info('Reloading Aleph Hints')
+    Rails.logger.info(
+      "Pre-load Aleph Hint Count: #{Hint.where(source: 'aleph').count}"
+    )
+
+    AlephHint.new.reload
+
+    Rails.logger.info(
+      "Post-load Aleph Hint Count: #{Hint.where(source: 'aleph').count}"
+    )
+  end
+end

--- a/lib/tasks/reloadhints.rake
+++ b/lib/tasks/reloadhints.rake
@@ -1,4 +1,4 @@
-namespace :loadhints do
+namespace :reloadhints do
   desc 'Drop and Reload Hints from Aleph Source'
   task aleph: :environment do
     Rails.logger.info('Reloading Aleph Hints')

--- a/test/fixtures/hints.yml
+++ b/test/fixtures/hints.yml
@@ -8,6 +8,7 @@
 #  fingerprint :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  source      :string           not null
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -20,18 +21,22 @@ one:
   title: 'hint value'
   url: 'http://example.com/get/stuff'
   fingerprint: 'popcorn'
+  source: 'manual'
 
 unido:
   title: 'UNIDO Statistics Data Portal'
   url: 'http://libraries.mit.edu/get/unido-data'
   fingerprint: 'indstat'
+  source: 'manual'
 
 unido2:
   title: 'UNIDO Statistics Data Portal'
   url: 'http://libraries.mit.edu/get/unido-data'
   fingerprint: 'idsb'
+  source: 'manual'
 
 webofscience:
   title: 'Web of Science'
   url: 'http://libraries.mit.edu/some/url/or/other'
   fingerprint: 'of science web'
+  source: 'manual'

--- a/test/models/aleph_hint_test.rb
+++ b/test/models/aleph_hint_test.rb
@@ -12,7 +12,7 @@ class AlephHintTest < ActiveSupport::TestCase
     VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
       assert_equal(4, Hint.count)
       AlephHint.new.process_records
-      assert_equal(15, Hint.count)
+      assert_equal(14, Hint.count)
       assert_equal('http://libraries.mit.edu/get/ericfull',
                    Hint.match('esubscribe').url)
       assert_equal('http://libraries.mit.edu/get/encislam',

--- a/test/models/aleph_hint_test.rb
+++ b/test/models/aleph_hint_test.rb
@@ -30,7 +30,7 @@ class AlephHintTest < ActiveSupport::TestCase
 
   test 'loader throws exception when encountering a record without a get url' do
     VCR.use_cassette('aleph hint loader error', allow_playback_repeats: true) do
-      assert_raise ActiveRecord::NotNullViolation do
+      assert_raise ActiveRecord::RecordInvalid do
         AlephHint.new.process_records
       end
     end

--- a/test/models/aleph_hint_test.rb
+++ b/test/models/aleph_hint_test.rb
@@ -20,6 +20,29 @@ class AlephHintTest < ActiveSupport::TestCase
     end
   end
 
+  test 'reload hints removes existing source hints but leaves other sources' do
+    VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
+      Hint.upsert(title: 't', url: 'url', fingerprint: 'fp', source: 'aleph')
+      assert_equal(1, Hint.where(source: 'aleph').count)
+      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_equal('url', Hint.match('fp').url)
+      AlephHint.new.reload
+      assert_equal(10, Hint.where(source: 'aleph').count)
+      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_nil(Hint.match('fp'))
+    end
+  end
+
+  test 'reload hints rollsback on errors' do
+    VCR.use_cassette('aleph hint loader error', allow_playback_repeats: true) do
+      assert_equal(4, Hint.count)
+      assert_raise ActiveRecord::RecordInvalid do
+        AlephHint.new.reload
+      end
+      assert_equal(4, Hint.count)
+    end
+  end
+
   test 'get url is selected when there are multiple' do
     VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
       AlephHint.new.process_records

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -184,9 +184,9 @@ class HintTest < ActiveSupport::TestCase
   end
 
   test 'duplicates via create for a single source result in db error' do
-    Hint.create(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
-    assert_raise ActiveRecord::RecordNotUnique do
-      Hint.create(title: 't', url: 'u2', fingerprint: 'fp', source: 'source1')
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
+    assert_raise ActiveRecord::RecordInvalid do
+      Hint.create!(title: 't', url: 'u2', fingerprint: 'fp', source: 'source1')
     end
   end
 
@@ -202,8 +202,8 @@ class HintTest < ActiveSupport::TestCase
 
   test 'duplicates fingerprints for different sources are allowed' do
     initial_count = Hint.count
-    Hint.create(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
-    Hint.create(title: 't', url: 'u', fingerprint: 'fp', source: 'source2')
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp', source: 'source2')
     assert_equal(Hint.count, initial_count + 2)
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?


* adds `Hint.source` to allow for reloading of hints more easily
* adds `Hint.upsert` to allow loaders to defer duplicate logic to the   `Hint` model
* updates `AlephHint` loader to supply a `Hint.source`
* adds ActiveRecord validations to Hint
* add reload method to AlephHint to allow for one step drop / reload
* rollback on failed AlephHint loads
* adds task to easily run the AlephHint loader

#### How can a reviewer manually see the effects of these changes?

First delete any `Hints` in your local database and run the database migrations.

With a valid `ALEPH_HINT_SOURCE` set in your `.env` (ask if you need a source or grab it from Heroku), run `heroku local:run bin/rails reloadhints:aleph`

You should now have a set of non-duplicate Hints all from the aleph source.

You can manually add more records to the aleph source and re-run that task to see that your manually created records have been removed.

If you manually add Hints from a non-aleph source and rerun the task, you will see those records remain after the reload is complete.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-451
- https://mitlibraries.atlassian.net/browse/DI-453
- https://mitlibraries.atlassian.net/browse/DI-454

#### Todo:
- [x] Tests
- [x] Documentation

#### Requires Database Migrations?
YES

NOTE! We will need to drop all Hints in our databases (staging and prod) before pushing this code to those environments to allow the migration to succeed. It is not ideal, but it's a one off problem and since the data is easy to reload I don't find this to be a blocker.

#### Includes new or updated dependencies?
NO