### PR TITLE
Update Hint Placard UI

### DIFF
--- a/app/helpers/feature_helper.rb
+++ b/app/helpers/feature_helper.rb
@@ -1,2 +1,0 @@
-module FeatureHelper
-end

--- a/app/helpers/hint_helper.rb
+++ b/app/helpers/hint_helper.rb
@@ -1,0 +1,20 @@
+module HintHelper
+  # generates a link with appropriate data type for our analytics
+  def hint_link(link_text)
+    link_to(link_text, @hint.url, data: { type: data_type })
+  end
+
+  # display a user friendly distinction between Hint sources
+  def display_type
+    if @hint.source == 'custom'
+      'Popular result'
+    else
+      'Were you looking for...'
+    end
+  end
+
+  # Allows analytics tracking to distinguish clicked Hint sources
+  def data_type
+    "Hint_#{@hint.source}"
+  end
+end

--- a/app/views/hint/hint.html.erb
+++ b/app/views/hint/hint.html.erb
@@ -1,9 +1,14 @@
 <% if @hint %>
   <div class="wrap-hint-box">
     <div class="hint-box">
-      <p class="type">Popular result</p>
-      <h3 class="title"><%= @hint.title %></h3>
-      <p class="desc"><%= link_to(@hint.url, @hint.url, data: {type: "Hint"} ) %></p>
+      <p class="type"><%= display_type %></p>
+      <h3 class="title"><%= hint_link(@hint.title) %></h3>
+
+      <% if @hint.url.include?('libraries.mit.edu/get') %>
+        <p class="desc">
+          <%= hint_link(@hint.url) %>
+        </p>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/test/helpers/hint_helper_test.rb
+++ b/test/helpers/hint_helper_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class HintHelperTest < ActionView::TestCase
+  test 'data_type' do
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
+    @hint = Hint.match('fp')
+    assert_equal(data_type, 'Hint_source1')
+  end
+
+  test 'display_types' do
+    # displays Popular result from custom source type
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp1', source: 'custom')
+    @hint = Hint.match('fp1')
+    assert_equal(display_type, 'Popular result')
+
+    # displays other text from non-custom source type
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp2', source: 'source1')
+    @hint = Hint.match('fp2')
+    assert_equal(display_type, 'Were you looking for...')
+  end
+
+  test 'hint_link' do
+    Hint.create!(title: 't', url: 'u', fingerprint: 'fp1', source: 'custom')
+    @hint = Hint.match('fp1')
+
+    # can display a link using the hint.title as link_text
+    assert_equal(hint_link(@hint.title),
+                 '<a data-type="Hint_custom" href="u">t</a>')
+
+    # can display a link using the hint url as link_text
+    assert_equal(hint_link(@hint.url),
+                 '<a data-type="Hint_custom" href="u">u</a>')
+  end
+end

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -26,31 +26,6 @@ class HintTest < ActiveSupport::TestCase
     assert_nil(match)
   end
 
-  test 'phrase match within longer string' do
-    skip 'not yet implemented'
-    searchterm = 'popcorn soup is good for you'
-    match = Hint.match(searchterm)
-    assert_equal(hints(:one), match)
-  end
-
-  # The intent of this test is to prove we can disable matching
-  # of the phrase if it is not left truncated. Right now we
-  # cannot do that though so we skip it. The feature seems
-  # useful but has not gotten stakeholder support yet.
-  test 'no phrase match mid string if not enabled' do
-    skip 'not yet implemented'
-    searchterm =  'soup is good popcorn'
-    match = Hint.match(searchterm)
-    assert_nil(match)
-  end
-
-  test 'phrase left justified in longer string when not enabled' do
-    skip 'not yet implemented'
-    searchterm =  'blah blah UNIDO Statistics Data Portal'
-    match = Hint.match(searchterm)
-    assert_equal(hints(:unido), match)
-  end
-
   # --- Tests of fingerprinting ---
   test 'fingerprinting distinguishes types of C' do
     # We actually want C, C++, and C# to be distinguished, even though


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This updates our Hint placards as follows:
- uses `Hint.title` as the link text for the main link
- displays and links the `Hint.url` on a separate line only if it is a "get" URL
- makes a distinction in the UI between a 'custom' `Hint.source` and any other `Hint.source`

Misc
- removes some skipped Hint tests for a feature we’ll likely never implement
- removes an unused Helper file

#### How can a reviewer manually see the effects of these changes?

After enabling the feature on the PR build via https://mit-bento-staging-pr-235.herokuapp.com/toggle?feature=hints

Searching for:
- `pubmed` will show the logic for a custom link and get url logic
- `popcorn` will show the non-custom link, non-get url logic
- `42` will show the non-custom link with get-url logic

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-465

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO