### PR TITLE
451 prioritize by source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ custom hint metadata.
 - `ALEPH_HINT_SOURCE`: HTTP GET accessible marcxml source for Hints
 - `EDS_TIMEOUT`: value to override the 6 second default for EDS timeout
 - `FLIPFLOP_KEY`: set this to enable access to the flipflop dashboard
+- `GLOBAL_ALERT`: html message to display as a global header
+- `GOOGLE_ANALYTICS`: Google Analytics property ID
+- `HINT_SOURCES`: Comma-separated Hint source names, in descending order of priority. (If unset, will default to `custom`).
+  - Hints will only be displayed to the user if they are in `HINT_SOURCES`.
 - `LOG_LIKE_PROD`: uses prod-like logging in development if set
 - `LOG_LEVEL`: set log level for development, default is `:debug`
 - `RESULTS_PER_BOX`: defaults to 3
-- `GLOBAL_ALERT`: html message to display as a global header
-- `GOOGLE_ANALYTICS`: Google Analytics property ID
-- `HINT_SOURCES`: List of hint source names, in descending order of priority. (If unset, will default to `['custom']`).
-  - Hints will only be displayed to the user if they are in `HINT_SOURCES`.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,5 @@ custom hint metadata.
 - `RESULTS_PER_BOX`: defaults to 3
 - `GLOBAL_ALERT`: html message to display as a global header
 - `GOOGLE_ANALYTICS`: Google Analytics property ID
+- `HINT_SOURCES`: List of hint source names, in descending order of priority. (If unset, will default to `['custom']`).
+  - Hints will only be displayed to the user if they are in `HINT_SOURCES`.

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -20,10 +20,6 @@ class Hint < ApplicationRecord
   validates :source, presence: true
   validates :fingerprint, uniqueness: { scope: :source }
 
-  # ~~TODO~~ testing:
-  # hints are matched in order of priority
-  # if env is unset, sources defaults to custom
-  # hints in db but not in HINT_SOURCES are not returned
   def self.match(searchterm)
     searchprint = fingerprint(searchterm)
     hints = Hint.where(fingerprint: searchprint)
@@ -96,6 +92,6 @@ class Hint < ApplicationRecord
     if ENV['HINT_SOURCES'].nil?
       return ['custom']
     end
-    ENV['HINT_SOURCES']
+    ENV['HINT_SOURCES'].split(',')
   end
 end

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -25,7 +25,7 @@ class Hint < ApplicationRecord
     hints = Hint.where(fingerprint: searchprint)
     # Order matching hints by source; throw away nils; return first remaining
     # Hint. If there are none, this will return nil.
-    sources.map { |source| hints.find_by(source: source) }.compact[0]
+    sources.map { |source| hints.find_by(source: source) }.compact.first
   end
 
   # Updates a record if it exists, creates one if it does not
@@ -89,9 +89,6 @@ class Hint < ApplicationRecord
 
   def self.sources
     # Set a default value.
-    if ENV['HINT_SOURCES'].nil?
-      return ['custom']
-    end
-    ENV['HINT_SOURCES'].split(',')
+    ENV['HINT_SOURCES'].nil? ? ['custom'] : ENV['HINT_SOURCES'].split(',')
   end
 end

--- a/test/fixtures/hints.yml
+++ b/test/fixtures/hints.yml
@@ -21,22 +21,34 @@ one:
   title: 'hint value'
   url: 'http://example.com/get/stuff'
   fingerprint: 'popcorn'
-  source: 'manual'
+  source: 'custom'
 
 unido:
   title: 'UNIDO Statistics Data Portal'
   url: 'http://libraries.mit.edu/get/unido-data'
   fingerprint: 'indstat'
-  source: 'manual'
+  source: 'custom'
 
 unido2:
   title: 'UNIDO Statistics Data Portal'
   url: 'http://libraries.mit.edu/get/unido-data'
   fingerprint: 'idsb'
-  source: 'manual'
+  source: 'custom'
 
 webofscience:
   title: 'Web of Science'
   url: 'http://libraries.mit.edu/some/url/or/other'
   fingerprint: 'of science web'
-  source: 'manual'
+  source: 'custom'
+
+webofscience2:
+  title: 'Web of Science'
+  url: 'http://libraries.mit.edu/some/url/or/other'
+  fingerprint: 'of science web'
+  source: 'aleph'
+
+alephonlyhint:  # don't create a custom fixture hint with this fingerprint!
+  title: 'PubMed'
+  url: 'http://libraries.mit.edu/get/pubmed'
+  fingerprint: 'pubmed'
+  source: 'aleph'

--- a/test/helpers/hint_helper_test.rb
+++ b/test/helpers/hint_helper_test.rb
@@ -1,13 +1,24 @@
 require 'test_helper'
 
 class HintHelperTest < ActionView::TestCase
+  setup do
+    @cached_env_hint_sources = ENV['HINT_SOURCES']
+  end
+
+  teardown do
+    ENV['HINT_SOURCES'] = @cached_env_hint_sources
+  end
+
   test 'data_type' do
+    ENV['HINT_SOURCES'] = 'source1'
     Hint.create!(title: 't', url: 'u', fingerprint: 'fp', source: 'source1')
     @hint = Hint.match('fp')
     assert_equal(data_type, 'Hint_source1')
   end
 
   test 'display_types' do
+    ENV['HINT_SOURCES'] = 'custom,source1'
+
     # displays Popular result from custom source type
     Hint.create!(title: 't', url: 'u', fingerprint: 'fp1', source: 'custom')
     @hint = Hint.match('fp1')

--- a/test/models/aleph_hint_test.rb
+++ b/test/models/aleph_hint_test.rb
@@ -1,6 +1,15 @@
 require 'test_helper'
 
 class AlephHintTest < ActiveSupport::TestCase
+  setup do
+    @cached_env_hint_sources = ENV['HINT_SOURCES']
+    ENV['HINT_SOURCES'] = 'aleph'
+  end
+
+  teardown do
+    ENV['HINT_SOURCES'] = @cached_env_hint_sources
+  end
+
   test 'loads and parses xml' do
     VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
       xml = AlephHint.new
@@ -10,9 +19,9 @@ class AlephHintTest < ActiveSupport::TestCase
 
   test 'load hints' do
     VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
-      assert_equal(4, Hint.count)
+      assert_equal(6, Hint.count)
       AlephHint.new.process_records
-      assert_equal(15, Hint.count)
+      assert_equal(17, Hint.count)
       assert_equal('http://libraries.mit.edu/get/ericfull',
                    Hint.match('esubscribe').url)
       assert_equal('http://libraries.mit.edu/get/encislam',
@@ -23,23 +32,23 @@ class AlephHintTest < ActiveSupport::TestCase
   test 'reload hints removes existing source hints but leaves other sources' do
     VCR.use_cassette('aleph hint', allow_playback_repeats: true) do
       Hint.upsert(title: 't', url: 'url', fingerprint: 'fp', source: 'aleph')
-      assert_equal(1, Hint.where(source: 'aleph').count)
-      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_equal(3, Hint.where(source: 'aleph').count)
+      assert_equal(4, Hint.where(source: 'custom').count)
       assert_equal('url', Hint.match('fp').url)
       AlephHint.new.reload
       assert_equal(11, Hint.where(source: 'aleph').count)
-      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_equal(4, Hint.where(source: 'custom').count)
       assert_nil(Hint.match('fp'))
     end
   end
 
   test 'reload hints rollsback on errors' do
     VCR.use_cassette('aleph hint loader error', allow_playback_repeats: true) do
-      assert_equal(4, Hint.count)
+      assert_equal(6, Hint.count)
       assert_raise ActiveRecord::RecordInvalid do
         AlephHint.new.reload
       end
-      assert_equal(4, Hint.count)
+      assert_equal(6, Hint.count)
     end
   end
 

--- a/test/models/custom_hint_test.rb
+++ b/test/models/custom_hint_test.rb
@@ -69,9 +69,9 @@ class CustomHintTest < ActiveSupport::TestCase
 
   test 'load hints' do
     VCR.use_cassette('custom hint', allow_playback_repeats: true) do
-      assert_equal(4, Hint.count)
+      assert_equal(6, Hint.count)
       CustomHint.new(@url).process_records
-      assert_equal(126, Hint.count)
+      assert_equal(127, Hint.count)
       assert_equal('http://libraries.mit.edu/get/ieee',
                    Hint.match('ieee xplore').url)
     end
@@ -83,7 +83,7 @@ class CustomHintTest < ActiveSupport::TestCase
                   url: 'http://libraries.mit.edu/get/snoxboops',
                   fingerprint: 'snoxboops',
                   source: 'custom')
-      assert_equal(1, Hint.where(source: 'custom').count)
+      assert_equal(5, Hint.where(source: 'custom').count)
       assert_equal('http://libraries.mit.edu/get/snoxboops',
                    Hint.match('snoxboops').url)
 
@@ -95,12 +95,12 @@ class CustomHintTest < ActiveSupport::TestCase
 
   test 'reload hints leaves hints from other sources' do
     VCR.use_cassette('custom hint', allow_playback_repeats: true) do
-      assert_equal(0, Hint.where(source: 'custom').count)
-      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_equal(4, Hint.where(source: 'custom').count)
+      assert_equal(2, Hint.where(source: 'aleph').count)
 
       CustomHint.new(@url).reload
       assert_equal(122, Hint.where(source: 'custom').count)
-      assert_equal(4, Hint.where(source: 'manual').count)
+      assert_equal(2, Hint.where(source: 'aleph').count)
     end
   end
 
@@ -116,7 +116,7 @@ class CustomHintTest < ActiveSupport::TestCase
   test 'skips rows with neither fingerprint nor search' do
     VCR.use_cassette('custom hint blank fingerprints', allow_playback_repeats: true) do
       url = 'https://www.dropbox.com/s/3dgxge8b14ht0c3/custom%20hint%20for%20test%20suite.csv?dl=0'
-      assert_equal(4, Hint.count)
+      assert_equal(6, Hint.count)
       CustomHint.new(url).process_records
       assert_nil(Hint.find_by(title: 'No search here'))
       # Make sure it did create all the other hints, though, and not just skip


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Allows us to set an environment variable listing the Hint sources we display to the user, in order of priority.

#### Helpful background context (if appropriate)
We may have hints with the same fingerprint from multiple sources (e.g. one automatically generated from aleph and one manually entered by staff on the spreadsheet); we need a tiebreaker mechanism.

#### How can a reviewer manually see the effects of these changes?
* In your console, create Hints that both have a fingerprint of `pubmed`, one whose source is `custom` and one whose source is `aleph`
* `Hint.match('pubmed')` and observe that you get the custom-sourced one
* Set `ENV['HINT_SOURCES'] = 'custom,aleph'`; note that `Hint.match('pubmed')` returns the custom-sourced hint
* Set `ENV['HINT_SOURCES'] = 'aleph,custom'`; note that `Hint.match('pubmed')` returns the aleph-sourced hint
* Set `ENV['HINT_SOURCES'] = 'fake'`; note that `Hint.match('pubmed')` returns `nil` as neither matching source is in your `HINT_SOURCES`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-452

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
