### PR TITLE
Sets Hints feature to enabled by default

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -16,6 +16,6 @@ Flipflop.configure do
     description: 'Enables button for EDS supplied non-subscribed SFX links'
 
   feature :hints,
-    default: false,
+    default: true,
     description: 'Enables best bet search hint placards'
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

We are leaving the feature flag in place, but defaulting to enabled to
allow us to easily turn it back off if this does not go over well. We
will remove the feature flag once this is stable in production.

#### How can a reviewer manually see the effects of these changes?

I'll load the PR build with CustomHints. You should be able to search in the PR build for something that should return as a Hint and see it without manually enabling the feature.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-484

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
