### PR TITLE
adjust hint on mobile to prevent text overlap

### DIFF
--- a/app/assets/stylesheets/_hint.scss
+++ b/app/assets/stylesheets/_hint.scss
@@ -15,6 +15,7 @@
 
   .title {
     margin-bottom: .2em;
+    margin-right: 10rem;
     font-size: $fs-small;
     font-weight: $fw-bold;
   }


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Fixes a text overlap in hints UI when on a small screen.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-487

#### Screenshots (if appropriate)
Before:
<img width="386" alt="before" src="https://user-images.githubusercontent.com/4327102/29475217-b84e433a-842c-11e7-962b-d51a3fe94b6d.png">

After:
<img width="387" alt="after" src="https://user-images.githubusercontent.com/4327102/29475222-bd449b50-842c-11e7-8018-b36c5a338727.png">
