### PR TITLE
Frances/location wrap

### DIFF
--- a/app/assets/stylesheets/_aleph.scss
+++ b/app/assets/stylesheets/_aleph.scss
@@ -3,9 +3,11 @@
 // ------------------------------
 
 .fa-check {
-  color: $success
+  color: $success;
 }
 
 .fa-times {
- color: $error
+  margin-left: .2rem;
+  margin-right: .1rem;
+ color: $error;
 }

--- a/app/assets/stylesheets/_results.scss
+++ b/app/assets/stylesheets/_results.scss
@@ -96,9 +96,11 @@
   .list-local-locations {
     @extend .list-unbulleted;
     margin-bottom: 0;
+    margin-left: 2rem;
   }
 
   .result-local-location {
+    text-indent: -1rem;
     color: $gray;
     font-size: $fs-smallish;
   }


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
The location list items now wrap so the icons hang to the left, and the text aligns left whether the item is available or not.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-469

#### Screenshots (if appropriate)
Before:
<img width="356" alt="icon-before" src="https://user-images.githubusercontent.com/4327102/29476294-5df239dc-8431-11e7-93cc-ff4b6ebcd4b6.png">
<img width="333" alt="item-indent-before" src="https://user-images.githubusercontent.com/4327102/29476295-621f748e-8431-11e7-89cb-7adfd07670df.png">

After:
<img width="495" alt="icon-after" src="https://user-images.githubusercontent.com/4327102/29476303-630b7492-8431-11e7-99be-3115ac278496.png">
<img width="327" alt="item-indent-after" src="https://user-images.githubusercontent.com/4327102/29476304-630dac3a-8431-11e7-91d8-bebea35571c7.png">
