### PR TITLE
491 Enables Google Analytics linker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ custom hint metadata.
 - `FLIPFLOP_KEY`: set this to enable access to the flipflop dashboard
 - `GLOBAL_ALERT`: html message to display as a global header
 - `GOOGLE_ANALYTICS`: Google Analytics property ID
+- `GOOGLE_ANALYTICS_LINKED_DOMAINS`: List of related domains, if your implementation uses cross-domain linking. Use syntax: `foo.com,bar.com`
 - `HINT_SOURCES`: Comma-separated Hint source names, in descending order of priority. (If unset, will default to `custom`).
   - Hints will only be displayed to the user if they are in `HINT_SOURCES`.
 - `LOG_LIKE_PROD`: uses prod-like logging in development if set

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -35,7 +35,11 @@
 
   }(window,document,'script','https://www.google-analytics.com/analytics.js','ga'));
 
-  ga('create', '<%= ENV['GOOGLE_ANALYTICS'] %>', 'auto');
+  ga('create', '<%= ENV['GOOGLE_ANALYTICS'] %>', 'auto', {allowLinker: true});
+  <% if (ENV['GOOGLE_ANALYTICS_LINKED_DOMAINS']) %>
+  ga('require', 'linker');
+  ga('linker:autoLink', <%= raw ENV['GOOGLE_ANALYTICS_LINKED_DOMAINS'].split(',') %>);
+  <% end %>
   ga('send', 'pageview');
 
   // Interaction tracking


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This enables the [Linker plugin](https://developers.google.com/analytics/devguides/collection/analyticsjs/linker) as part of our Google Analytics infrastructure. This is part of our attempt to work toward seamless reporting on the functioning of our discovery environment.

#### Helpful background context (if appropriate)
Traditionally, separate web applications each have a separate GA profile. However, when multiple web applications are functionally one environment, this approach breaks down. The discovery environment is one such case, where users start in one location (typically the public homepage) and then proceed through multiple tools (Bento, EDS, SFX, etc) on their way to complete their task.

Through the Linker plugin and cross-domain referral exclusion lists, Google Analytics makes it possible to get information about these systems in total, rather than as isolated tools.

#### How can a reviewer manually see the effects of these changes?
Look at the source code of the `head` element. Before this PR, the GA implementation will be:

```
ga('create', 'UA-XXXX-Y', 'auto');
ga('send', 'pageview');
```

After the PR, with the proper environment value set, this becomes:
```
ga('create', 'UA-XXXX-Y', 'auto', {allowLinker: true});
ga('require', 'linker');
ga('linker:autoLink', ["foo.com", "bar.net", "baz.org"]);
ga('send', 'pageview');
```

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-491

#### Screenshots (if appropriate)
none applicable - check the `head` element source code to see the effect of this PR.

#### Todo:
- [ ] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
