### PR TITLE
Handle bad EDS Session Tokens

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,8 +16,8 @@ class SearchController < ApplicationController
     page = params[:page] || 1
     per_page = params[:per_page] || ENV['PER_PAGE'] || 20
     @results = search_results(page, per_page)
-    @pageable_results = paginate_results(page, per_page)
     return redirect_to root_url unless @results
+    @pageable_results = paginate_results(page, per_page)
     render 'search_boxed'
   end
 

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -86,4 +86,13 @@ class SearchTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'only retries once on bad EDS session' do
+    VCR.use_cassette('bad eds session', allow_playback_repeats: true) do
+      error = assert_raise RuntimeError do
+        get '/search?q=popcorn&target=articles&per_page=5'
+      end
+      assert_match(/Consecutive Session Token/, error.message)
+    end
+  end
 end

--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -49,4 +49,22 @@ class SearchEdsTest < ActiveSupport::TestCase
       assert_equal(1, SearchEds.new.send(:http_timeout))
     end
   end
+
+  # creating an appropriate cassette for this is difficult as we need to
+  # first show the failure state and then show the success state when issuing
+  # the exact same call to EDS. Showing that it does not loop infinitely in
+  # a related test is successful and thus is probably good enough for now.
+  test 'retries on bad EDS session' do
+    skip 'unable to create a cassette to replicate failure then success'
+  end
+
+  test 'only retries once on bad EDS session' do
+    error = assert_raise RuntimeError do
+      VCR.use_cassette('bad eds session', allow_playback_repeats: true) do
+        SearchEds.new.search('popcorn', 'apiwhatnot',
+                             ENV['EDS_ARTICLE_FACETS'])
+      end
+    end
+    assert_match(/Consecutive Session Token/, error.message)
+  end
 end

--- a/test/vcr_cassettes/bad_eds_session.yml
+++ b/test/vcr_cassettes/bad_eds_session.yml
@@ -1,0 +1,195 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/UIDAuth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD"}'
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '128'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 28 Oct 2016 13:54:13 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?guest=n&profile=apiwhatnot
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '101'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 7cacf1a6-76c7-41bb-b781-3f4ca997da28
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 28 Oct 2016 13:54:14 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version:
+  recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Search?autosuggest=n&expander=fulltext&facetfilter=1,SourceType:Academic%20Journals,SourceType:Magazines,SourceType:Conference%20Materials&highlight=n&includefacets=n&pagenumber=1&query=popcorn&resultsperpage=5&searchmode=all&sort=relevance&view=detailed
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '24748'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 8acb55d8-6dd4-4dfc-8cac-8f93fc555d4b
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 28 Oct 2016 13:54:14 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"DetailedErrorDescription":"Invalid Session Token. Please generate a new one.", "ErrorDescription":"Session Token Invalid", "ErrorNumber":"109"}'
+    http_version:
+  recorded_at: Fri, 28 Oct 2016 13:54:14 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/endsession?sessiontoken=FakeSessiontoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Connection:
+      - close
+      Host:
+      - eds-api.ebscohost.com
+      User-Agent:
+      - http.rb/2.0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '20'
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - Microsoft-IIS/7.5
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - b0607fd7-c86d-4e48-81cb-bb9306648a0d
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Fri, 28 Oct 2016 13:54:14 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"IsSuccessful":"y"}'
+    http_version:
+  recorded_at: Wed, 14 Sep 2016 17:10:32 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

* EDS sometimes does not accept session tokens they have created
* detect and log when that happens
* attempt to create a new session token, but only once, when detected
  to hopefully provide end users with a reliable experience even when
  our upstream source is being flakey
* throw an exception if the bad token is detected on two consecutive attempts during a single  
  request

#### How can a reviewer manually see the effects of these changes?

Sadly, there is no great way without changing the code. However, this is how to change the code to see what should happen.

In `search_eds.rb` model, change line 70 from `return unless eds_session_invalid?(result)` to `return if @attempts == 1`. When running a local search, your logs should now show the detection of a bad token, a retry, and then your search should succeed (unless you somehow manage to do this at the same time as EDS is for real having problems in which case you'll get the exception message).

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-493

#### Todo:
- [x] Tests
- [x] Documentation

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO