### PR TITLE
Add markup to separate full record panel in analytics

### DIFF
--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <div class="gridband layout-3q1q">
-  <div class="col3q box-content">
+  <div class="col3q box-content region" data-region="Full record">
     <%# ~~~~~~~~~~~~~~~~~~~~~~~~ Basic info section ~~~~~~~~~~~~~~~~~~~~~~~~ %>
 
     <% if Flipflop.enabled?(:local_browse) %>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This adds a class and data attribute to the full record view so that interactions with that interface are recorded separately in Google Analytics.

Prior to this change, interactions with the app are broken up into several categories:
* Books and media
* Articles and journals
* Library website and guides
* Other resources
* Link (this is the catchall category, if another value is not found)

Without this PR, interactions with the record page will be recorded in the Link category, which is potentially confusing down the road.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Load a full record, inspect the markup to see the new class and data attributes.
Watch Google Analytics to see the new event classification come in when you click on a link on the record panel.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-501

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1403248/29686077-9ee06a6e-88e5-11e7-8205-434dc1a722e9.png)

![image](https://user-images.githubusercontent.com/1403248/29686082-a3ae6208-88e5-11e7-80c8-c95dd955efcd.png)


#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
