### PR TITLE
Records existance of hint in google analytics via staccato gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'recaptcha', require: 'recaptcha/rails'
 gem 'rollbar'
 gem 'sass-rails'
 gem 'skylight'
+gem 'staccato'
 gem 'stringex'
 gem 'therubyracer', platforms: :ruby
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    staccato (0.5.1)
     stringex (2.7.1)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
@@ -425,6 +426,7 @@ DEPENDENCIES
   simplecov
   skylight
   sqlite3
+  staccato
   stringex
   therubyracer
   uglifier

--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -2,6 +2,10 @@ class HintController < ApplicationController
   def hint
     return if params[:q].blank?
     @hint = Hint.match(params[:q])
+    if (@hint && ENV['GOOGLE_ANALYTICS'])
+      tracker = Staccato.tracker(ENV['GOOGLE_ANALYTICS'], nil, ssl: true)
+      tracker.event(category: 'Bento', action: 'Hint', label: 'Show', value: 1)
+    end
     render layout: false
   end
 end

--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -2,7 +2,7 @@ class HintController < ApplicationController
   def hint
     return if params[:q].blank?
     @hint = Hint.match(params[:q])
-    if (@hint && ENV['GOOGLE_ANALYTICS'])
+    if @hint && ENV['GOOGLE_ANALYTICS']
       tracker = Staccato.tracker(ENV['GOOGLE_ANALYTICS'], nil, ssl: true)
       tracker.event(category: 'Bento', action: 'Hint', label: 'Show', value: 1)
     end

--- a/app/controllers/hint_controller.rb
+++ b/app/controllers/hint_controller.rb
@@ -2,7 +2,7 @@ class HintController < ApplicationController
   def hint
     return if params[:q].blank?
     @hint = Hint.match(params[:q])
-    if @hint && ENV['GOOGLE_ANALYTICS']
+    if @hint && ENV['GOOGLE_ANALYTICS'] && Flipflop.enabled?(:hint_tracker)
       tracker = Staccato.tracker(ENV['GOOGLE_ANALYTICS'], nil, ssl: true)
       tracker.event(category: 'Bento', action: 'Hint', label: 'Show', value: 1)
     end

--- a/app/views/hint/hint.html.erb
+++ b/app/views/hint/hint.html.erb
@@ -1,5 +1,5 @@
 <% if @hint %>
-  <div class="wrap-hint-box">
+  <div class="wrap-hint-box" data-region="Hint">
     <div class="hint-box">
       <p class="type"><%= display_type %></p>
       <h3 class="title"><%= hint_link(@hint.title) %></h3>

--- a/config/features.rb
+++ b/config/features.rb
@@ -22,4 +22,8 @@ Flipflop.configure do
   feature :local_full_record,
     default: ENV['LOCAL_FULL_RECORD'],
     description: 'Enables local full record instead of sending to EDS UI'
+
+  feature :hint_tracker,
+    default: ENV['HINT_TRACKER'],
+    description: 'Sends hint display to GA'
 end

--- a/test/controllers/hint_controller_test.rb
+++ b/test/controllers/hint_controller_test.rb
@@ -17,4 +17,17 @@ class HintControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes(@response.body, 'UNIDO Statistics Data Portal')
   end
+
+  test 'ga tracking' do
+    cached_ga_key = ENV['GOOGLE_ANALYTICS']
+    ENV['GOOGLE_ANALYTICS'] = 'UA-FAKE-KEY'
+
+    # the test
+    VCR.use_cassette('ga hint tracking', allow_playback_repeats: true) do
+      get '/hint?q=INDSTAT'
+      assert_response :success
+    end
+
+    ENV['GOOGLE_ANALYTICS'] = cached_ga_key
+  end
 end

--- a/test/controllers/hint_controller_test.rb
+++ b/test/controllers/hint_controller_test.rb
@@ -1,19 +1,19 @@
 require 'test_helper'
 
-class HintControllerTest < ActionDispatch::IntegrationTest
+class HintControllerTest < ActionController::TestCase
   test 'hint with no query' do
-    get '/hint'
+    get :hint
     assert_response :success
   end
 
   test 'hint with query and no match' do
-    get '/hint?q=purple+stuff'
+    get :hint, params: { q: 'purple+stuff' }
     assert_response :success
     assert_empty(@response.body)
   end
 
   test 'hint with query and match' do
-    get '/hint?q=INDSTAT'
+    get :hint, params: { q: 'INDSTAT' }
     assert_response :success
     assert_includes(@response.body, 'UNIDO Statistics Data Portal')
   end
@@ -21,13 +21,14 @@ class HintControllerTest < ActionDispatch::IntegrationTest
   test 'ga tracking' do
     cached_ga_key = ENV['GOOGLE_ANALYTICS']
     ENV['GOOGLE_ANALYTICS'] = 'UA-FAKE-KEY'
+    session[:hint_tracker] = true
 
-    # the test
     VCR.use_cassette('ga hint tracking', allow_playback_repeats: true) do
-      get '/hint?q=INDSTAT'
+      get :hint, params: { q: 'INDSTAT' }
       assert_response :success
     end
 
     ENV['GOOGLE_ANALYTICS'] = cached_ga_key
+    session[:hint_tracker] = false
   end
 end

--- a/test/vcr_cassettes/ga_hint_tracking.yml
+++ b/test/vcr_cassettes/ga_hint_tracking.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ssl.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&tid=UA-FAKE-KEY&cid=f1211898-3907-4f5c-92d2-226efe3d9789&t=event&ec=Bento&ea=Hint&el=Show&ev=1
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ssl.google-analytics.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Thu, 07 Sep 2017 15:57:20 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="39,38,37,35"
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version:
+  recorded_at: Thu, 07 Sep 2017 15:57:20 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This improves our analytics capabilities around hints. Specifically, it:
- records interactions with hints in their own action, instead of alongside other branding elements.
- uses the staccato gem to record the _display_ of hints, in addition to just when users click on them.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
- Inspect the markup around a displayed hint to see a data attribute for the container.
- Watch the real time events panel in Google Analytics to see server-side analytics when they are displayed.
- Watch the real time events panel in Google Analytics to see how interactions with hints are now re-classified in the `Bento / Hints` category / action, rather than `Bento / Link`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-474

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
