### PR TITLE
Adds feature flag to local full records

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -19,6 +19,14 @@ module SearchHelper
     mit_ips.include?(request.remote_ip)
   end
 
+  def full_record_link(result)
+    if Flipflop.enabled?(:local_full_record) && params[:target] != 'google'
+      record_path(result.db_source.last, result.an)
+    else
+      result.url
+    end
+  end
+
   private
 
   # Source: http://kb.mit.edu/confluence/x/F4DCAg

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <h3 class="result-title">
-    <span class="sr">Title: </span><%= link_to(result.truncated_title.html_safe, result.url, class: 'bento-link', data: {type: "Title"} ) %>
+    <span class="sr">Title: </span><%= link_to(result.truncated_title.html_safe, full_record_link(result), class: 'bento-link', data: {type: "Title"} ) %>
   </h3>
   <div class="result-uniform-title">
     <% if result.uniform_title %>
@@ -111,7 +111,7 @@
       <% end %>
     <% end %>
 
-    <%= link_to("Details and requests", result.url, class: 'details button button-secondary', data: {type: "Detail"}) %>
+    <%= link_to("Details and requests", full_record_link(result), class: 'details button button-secondary', data: {type: "Detail"}) %>
   </div>
 
   <% if Flipflop.enabled?(:debug) %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -18,4 +18,8 @@ Flipflop.configure do
   feature :hints,
     default: true,
     description: 'Enables best bet search hint placards'
+
+  feature :local_full_record,
+    default: true,
+    description: 'Enables local full record instead of sending to EDS UI'
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Allows bento results to display links to either the EDS UI (default) or local full records.

This is accessed via the feature toggle `local_full_record`

#### How can a reviewer manually see the effects of these changes?

In the PR build, you can enable the toggle via:
https://mit-bento-staging-pr-250.herokuapp.com/toggle?feature=local_full_record

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-498

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO