### PR TITLE
Initial full record realtime availability

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -15,3 +15,15 @@ function RealtimeStatus( id ) {
     });
   });
 }
+
+function RealtimeItem( an ) {
+  $.ajax({
+    url: "/full_item_status?id=" + an
+  }).done(function( msg ) {
+    $("#full-avail").html( msg );
+  }).fail(function( xhr, textStatus ) {
+    console.log('realtime item error');
+    console.log(xhr);
+    $("#full-avail").html( 'Sorry, an error has occurred loading realtime availability information.' ).addClass('alert error');
+  });
+}

--- a/app/controllers/aleph_controller.rb
+++ b/app/controllers/aleph_controller.rb
@@ -3,4 +3,9 @@ class AlephController < ApplicationController
     @status = AlephItem.new.items(params[:id])
     render layout: false
   end
+
+  def full_item_status
+    @status = AlephItem.new.items(params[:id])
+    render layout: false
+  end
 end

--- a/app/helpers/aleph_helper.rb
+++ b/app/helpers/aleph_helper.rb
@@ -1,0 +1,39 @@
+module AlephHelper
+  # detect media call number prefixes. can be used to exclude some types of
+  # material from receiving UI features. i.e. DVD does not get photocopy button
+  def media?(call_number)
+    call_number.start_with?('AUDIO', 'AUDTAPE', 'CD', 'CDROM', 'DSKETTE',
+                            'DVD', 'DVDROM', 'USB DRIVE', 'VDISC', 'VIDEO')
+  end
+
+  def reserve?(collection)
+    collection == 'Reserve Stacks'
+  end
+
+  def archives?(library)
+    library == 'Institute Archives'
+  end
+
+  # generates a link to an map for each library on campus
+  def map_link(library)
+    if library == 'Barker Library'
+      map_link_to('https://libraries.mit.edu/barker/')
+    elsif library == 'Dewey Library'
+      map_link_to('https://libraries.mit.edu/dewey/')
+    elsif library == 'Hayden Library'
+      map_link_to('https://libraries.mit.edu/hayden/')
+    elsif library == 'Institute Archives'
+      map_link_to('https://libraries.mit.edu/archives/')
+    elsif library == 'Lewis Music Library'
+      map_link_to('https://libraries.mit.edu/music/')
+    elsif library == 'Rotch Library'
+      map_link_to('https://libraries.mit.edu/rotch/')
+    end
+  end
+
+  private
+
+  def map_link_to(url)
+    link_to('', url, class: 'fa fa-map-marker', aria: { hidden: true })
+  end
+end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -1,0 +1,60 @@
+module RecordHelper
+  def local_record?
+    aleph_record? || aleph_cr_record?
+  end
+
+  # determines if an item is serial-ish or monograph-ish to help us determine
+  # if we should use holdings records or item records for realtime status
+  def non_serial?
+    if book_like.include?(@record.eds_publication_type)
+      true
+    else
+      false
+    end
+  end
+
+  # Publication types that we want to treat like books
+  def book_like
+    ['Book', 'Audio', 'Video Recording']
+  end
+
+  # Link to local source record
+  def local_record_source_url
+    if aleph_record?
+      'https://library.mit.edu/item/' \
+        "#{@record.eds_accession_number.split('.').last}"
+    elsif aleph_cr_record?
+      'https://library.mit.edu/res/' \
+        "#{@record.eds_accession_number.split('.').last}"
+    end
+  end
+
+  # Reformat the Accession Number to match the format used in Aleph
+  def clean_an
+    if aleph_record?
+      @record.eds_accession_number.split('.').last.prepend('MIT01')
+    elsif aleph_cr_record?
+      @record.eds_accession_number.split('.').last.prepend('MIT30')
+    end
+  end
+
+  # Detects local aleph course reserve records
+  def aleph_cr_record?
+    if @record.eds_accession_number.present? &&
+       @record.eds_accession_number.start_with?('mitcr.')
+      true
+    else
+      false
+    end
+  end
+
+  # Detects local aleph records
+  def aleph_record?
+    if @record.eds_accession_number.present? &&
+       @record.eds_accession_number.start_with?('mit.')
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/views/aleph/full_item_status.html.erb
+++ b/app/views/aleph/full_item_status.html.erb
@@ -1,0 +1,50 @@
+<p class="sr">Library locations: </p>
+<ul class="list-local-locations">
+<% @status.each do |s| %>
+  <li class="result-local-location">
+    <%= s[:library] %> <%= s[:collection] %>: <%= s[:call_number] %>
+    <% if s[:description].present? %> <%= s[:description] %> <% end %>
+    <span class="sr"><%= s[:label] %></span>
+
+    <br />
+
+    <% if s[:available?] %>
+      <i class="fa fa-check" aria-hidden="true"></i>
+
+      <% if archives?(s[:library]) %>
+
+        <a class="btn button-secondary" href="https://libraries.mit.edu/archives/">Contact Us</a>
+
+        <%= map_link(s[:library]) %>
+
+      <% elsif reserve?(s[:collection]) %>
+
+        <a class="btn button-secondary" href="">Place Hold</a>
+
+        <%= map_link(s[:library]) %>
+
+      <% elsif media?(s[:call_number]) %>
+
+        <a class="btn button-secondary" href="">Place Hold</a>
+
+        <%= map_link(s[:library]) %>
+
+      <% else %>
+
+        <a class="btn button-secondary" href="">Place Hold</a>
+
+        <a class="btn button-secondary" href="">Request Scan</a>
+
+        <%= map_link(s[:library]) %>
+
+      <% end %>
+
+    <% else %>
+      <i class="fa fa-times" aria-hidden="true"></i>
+      Not available at MIT
+      <a class="btn button-secondary" href="">Get it with ILL (3-4 days)</a>
+    <% end %>
+
+  </li>
+<% end %>
+</ul>

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -1,0 +1,2 @@
+<h3 class="subtitle3">Availability</h3>
+<%= @record.eds_publication_type %>

--- a/app/views/record/_basic_info.html.erb
+++ b/app/views/record/_basic_info.html.erb
@@ -1,0 +1,33 @@
+<% if Flipflop.enabled?(:local_browse) %>
+  <% search_prefix = '/search/bento?q=' %>
+<% else %>
+  <% search_prefix = ENV['EDS_PROFILE_URI'] %>
+<% end %>
+
+<% if @record.eds_cover_thumb_url.present? %>
+  <img src='<%= @record.eds_cover_thumb_url %>' />
+<% end %>
+
+<h2><%= @record.title %></h2>
+<% if @record.eds_publication_type == 'Periodical' %>
+  Periodical | Published <%= @record.eds_publication_year %>
+<% elsif @record.eds_publication_type == 'Academic Journal' %>
+  In <%= link_to(@record.eds_source_title, search_prefix + "JN+\"#{@record.eds_source_title}\"", data: {type: "Journal"} ) %>
+  volume <%= @record.eds_volume %>
+  issue <%= @record.eds_issue %>
+  (<%= @record.eds_publication_year %>)
+<%# Includes Books; is catchall for other types not specified in wireframes %>
+<% else %>
+  <%= @record.eds_publication_type %> | Published <%= @record.eds_publication_year %>
+<% end %>
+
+<br />
+<%# If there are no authors (as with periodicals) this section will be
+    blank, corresponding to the wireframe. %>
+<% @record.eds_authors.each do |author| %>
+  <% if author == "et al" %>
+    <%= author %>
+  <% else %>
+    <%= link_to(author, search_prefix + "AU+\"#{author}\"", data: {type: "Author"} ) unless author == "et al" %><% if author != @record.eds_authors.last %>; <% end %>
+  <% end %>
+<% end %>

--- a/app/views/record/_extended_info.html.erb
+++ b/app/views/record/_extended_info.html.erb
@@ -1,0 +1,3 @@
+<h3 class="subtitle3">More information</h3>
+
+coming soon!!!

--- a/app/views/record/_links.html.erb
+++ b/app/views/record/_links.html.erb
@@ -1,0 +1,8 @@
+Full text links
+
+<%# hint @record.eds_fulltext_links %>
+
+<br />
+
+Non-full text links (if no full text link)
+<%# hint @record.eds_non_fulltext_links %>

--- a/app/views/record/_sidebar.html.erb
+++ b/app/views/record/_sidebar.html.erb
@@ -1,0 +1,12 @@
+<h4>Sidebar</h4>
+
+<ul>
+  <li>Advanced Search</li>
+  <li>Save to...</li>
+
+  <% if local_record? %>
+    <%= link_to('Source Record', local_record_source_url) %>
+  <% else %>
+    Link to EDS UI Full record
+  <% end %>
+</ul>

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -5,45 +5,35 @@
 
 <div class="gridband layout-3q1q">
   <div class="col3q box-content region" data-region="Full record">
-    <%# ~~~~~~~~~~~~~~~~~~~~~~~~ Basic info section ~~~~~~~~~~~~~~~~~~~~~~~~ %>
 
-    <% if Flipflop.enabled?(:local_browse) %>
-      <% search_prefix = '/search/bento?q=' %>
-    <% else %>
-      <% search_prefix = ENV['EDS_PROFILE_URI'] %>
-    <% end %>
-
-    <% if @record.eds_cover_thumb_url.present? %>
-      <img src='<%= @record.eds_cover_thumb_url %>' />
-    <% end %>
-
-    <h1><%= @record.title %></h1>
-    <% if @record.eds_publication_type == 'Periodical' %>
-      Periodical | Published <%= @record.eds_publication_year %>
-    <% elsif @record.eds_publication_type == 'Academic Journal' %>
-      In <%= link_to(@record.eds_source_title, search_prefix + "JN+\"#{@record.eds_source_title}\"", data: {type: "Journal"} ) %>
-      volume <%= @record.eds_volume %>
-      issue <%= @record.eds_issue %>
-      (<%= @record.eds_publication_year %>)
-    <%# Includes Books; is catchall for other types not specified in wireframes %>
-    <% else %>
-      <%= @record.eds_publication_type %> | Published <%= @record.eds_publication_year %>
-    <% end %>
+    <div class="discovery-full-record-basic-info">
+      <%= render partial: "basic_info" %>
+    </div>
 
     <br />
-    <%# If there are no authors (as with periodicals) this section will be
-        blank, corresponding to the wireframe. %>
-    <% @record.eds_authors.each do |author| %>
-      <% if author == "et al" %>
-        <%= author %>
+
+    <%= render partial: 'links' %>
+
+    <% if local_record? %>
+      <div id="full-avail" class="discovery-full-record-availability-info">
+        <%= render partial: "availability" %>
+      </div>
+
+      <br />
+
+      <% if non_serial? %>
+        <script>RealtimeItem( "<%= clean_an %>" );</script>
       <% else %>
-        <%= link_to(author, search_prefix + "AU+\"#{author}\"", data: {type: "Author"} ) unless author == "et al" %><% if author != @record.eds_authors.last %>; <% end %>
+        Call for realtime holdings instead of items. (coming soon!)
       <% end %>
     <% end %>
 
-    <%# ~~~~~~~~~~~~~~~~~~~ Other sections to be written ~~~~~~~~~~~~~~~~~~~ %>
+    <div class="discovery-full-record-basic-info">
+      <%= render partial: "extended_info" %>
+    </div>
+
   </div>
   <div class="col1q-r">
-    <%# Sidebar will go here. %>
+    <%= render partial: "sidebar" %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
   post 'feedback', to: 'feedback#submit', as: :feedback_submit
 
   get 'item_status', to: 'aleph#item_status'
+  get 'full_item_status', to: 'aleph#full_item_status'
+
   get 'hint', to: 'hint#hint'
   get 'toggle', to: 'feature#toggle'
 

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -14,7 +14,8 @@ class RecordControllerTest < ActionController::TestCase
   end
 
   test 'should handle invalid parameters' do
-    VCR.use_cassette('record: no such database', allow_playback_repeats: true) do
+    VCR.use_cassette('record: no such database',
+                     allow_playback_repeats: true) do
       assert_raises ActionController::RoutingError do
         get :record, params: { db_source: 'dog00916a', an: 'mit.001492509' }
       end

--- a/test/helpers/aleph_helper_test.rb
+++ b/test/helpers/aleph_helper_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+include AlephHelper
+
+class AlephHelperTest < ActionView::TestCase
+  test 'media?' do
+    refute(controller.media?('POPCORN'))
+    assert(controller.media?('DVD'))
+  end
+
+  test 'reserve?' do
+    refute(controller.reserve?('POPCORN'))
+    assert(controller.reserve?('Reserve Stacks'))
+  end
+
+  test 'archives?' do
+    refute(controller.archives?('POPCORN'))
+    assert(controller.archives?('Institute Archives'))
+  end
+end

--- a/test/integration/aleph_test.rb
+++ b/test/integration/aleph_test.rb
@@ -1,0 +1,73 @@
+require 'test_helper'
+
+class AlephTest < ActionDispatch::IntegrationTest
+  test 'map_link barker' do
+    VCR.use_cassette('record status barker', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01001251550' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/barker/'))
+      end
+    end
+  end
+
+  test 'map_link dewey' do
+    VCR.use_cassette('record status dewey', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01002519066' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/dewey/'))
+      end
+    end
+  end
+
+  test 'map_link hayden' do
+    VCR.use_cassette('record status hayden', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01001739356' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/hayden/'))
+      end
+    end
+  end
+
+  test 'map_link archives' do
+    VCR.use_cassette('record status archives', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01001975671' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.last[:href].include?('libraries.mit.edu/archives/'))
+      end
+    end
+  end
+
+  test 'map_link music' do
+    VCR.use_cassette('record status music', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01001528789' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/music/'))
+      end
+    end
+  end
+
+  test 'map_link rotch' do
+    VCR.use_cassette('record status rotch', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01002403936' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/rotch/'))
+      end
+    end
+  end
+
+  test 'local course reserve record' do
+    VCR.use_cassette('record status reserve', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT30000105498' }
+      assert_response :success
+      assert_select('.fa-map-marker') do |value|
+        assert(value.first[:href].include?('libraries.mit.edu/rotch/'))
+      end
+    end
+  end
+end

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -5,8 +5,8 @@ class RecordTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record: article', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'aci', an: '123877356' }
       assert_response :success
-      assert_select('h1') do |value|
-        assert(value.text.include?('Ultrasensitive Label-Free Sensing of IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular Recognition Elements.'))
+      assert_select('h2') do |value|
+        assert(value.text.include?('Ultrasensitive Label-Free Sensing of IL-6'))
       end
     end
   end
@@ -15,8 +15,8 @@ class RecordTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record: book', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
       assert_response :success
-      assert_select('h1') do |value|
-        assert(value.text.include?('Bananas : how the United Fruit Company shaped the world.'))
+      assert_select('h2') do |value|
+        assert(value.text.include?('Bananas : how the United Fruit Company'))
       end
     end
   end
@@ -25,7 +25,7 @@ class RecordTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record: journal', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.000292123' }
       assert_response :success
-      assert_select('h1') do |value|
+      assert_select('h2') do |value|
         assert(value.text.include?('Blood.'))
       end
     end
@@ -34,8 +34,8 @@ class RecordTest < ActionDispatch::IntegrationTest
   test 'back to search results link is shown where available' do
     VCR.use_cassette('record: book', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a',
-                             an: 'mit.001492509',
-                             previous: 'bananas' }
+                                an: 'mit.001492509',
+                                previous: 'bananas' }
       assert_response :success
       assert_select('a[href=?]', search_bento_path(q: 'bananas')) do |value|
         assert(value.text.include?('Back to search results'))
@@ -45,8 +45,9 @@ class RecordTest < ActionDispatch::IntegrationTest
 
   test 'back to search results link not shown where unavailable' do
     VCR.use_cassette('record: book', allow_playback_repeats: true) do
-      get record_url, params: { db_source: 'cat00916a',
-                             an: 'mit.001492509' }  # note: no 'previous' param
+      get record_url, params:
+                        { db_source: 'cat00916a',
+                          an: 'mit.001492509' } # note: no 'previous' param
       assert_response :success
       assert response.body.exclude? 'Back to search results'
     end

--- a/test/models/hint_test.rb
+++ b/test/models/hint_test.rb
@@ -14,7 +14,6 @@
 require 'test_helper'
 
 class HintTest < ActiveSupport::TestCase
-
   setup do
     @cached_env_hint_sources = ENV['HINT_SOURCES']
   end

--- a/test/vcr_cassettes/record_status_archives.yml
+++ b/test/vcr_cassettes/record_status_archives.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01001975671/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:39:18 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01001975671/items/MIT50001975671000020"><z30-sub-library-code>HUM</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001975671</z30-doc-number><z30-item-sequence>000020</z30-item-sequence><z30-barcode>39080035696811</z30-barcode><z30-sub-library>Hayden
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20110923</z30-open-date><z30-update-date>20130524</z30-update-date><z30-cataloger>KREE</z30-cataloger><z30-date-last-return>20170619</z30-date-last-return><z30-hour-last-return>1344</z30-hour-last-return><z30-ip-last-return>18.113.2.43</z30-ip-last-return><z30-no-loans>021</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>T171.M49
+        P48 2011</z30-call-no><z30-call-no-key>t&quot;171 m49 p48 2011</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number></z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>20150108</z30-last-shelf-report-date><z30-price></z30-price><z30-shelf-report-number>2</z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic>g</z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002049599</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>013</z30-maintenance-count><z30-process-status-date>20110928</z30-process-status-date><z30-upd-time-stamp>201706191714474</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001975671</z13-doc-number><z13-year>2011</z13-year><z13-open-date>20110610</z13-open-date><z13-update-date>20161219</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST8</z13-call-no-code><z13-call-no>**See
+        URL(s)</z13-call-no><z13-author-code></z13-author-code><z13-author>Peterson,
+        T. F.</z13-author><z13-title-code></z13-title-code><z13-title>Nightwork :
+        a history of hacks and pranks at MIT / T.F. Peterson ; with a new essay by
+        Eric Bender.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>MIT
+        Press,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9780262515849
+        (pbk. : alk. paper)</z13-isbn-issn><z13-upd-time-stamp>201612191305450</z13-upd-time-stamp></z13><status>Due
+        10/14/2017 07:00 PM</status></item><item href="http://fake_server.example.com/rest-dlf/record/MIT01001975671/items/MIT50001975671000030"><z30-sub-library-code>HUM</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001975671</z30-doc-number><z30-item-sequence>000030</z30-item-sequence><z30-barcode>39080035827572</z30-barcode><z30-sub-library>Hayden
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20110914</z30-open-date><z30-update-date>20130522</z30-update-date><z30-cataloger>SPOSTAK</z30-cataloger><z30-date-last-return>20160514</z30-date-last-return><z30-hour-last-return>1141</z30-hour-last-return><z30-ip-last-return>18.51.3.114</z30-ip-last-return><z30-no-loans>016</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>T171.M49
+        P48 2011</z30-call-no><z30-call-no-key>t&quot;171 m49 p48 2011</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>12-3691</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>20150108</z30-last-shelf-report-date><z30-price>19.28</z30-price><z30-shelf-report-number>2</z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>001975671</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002049599</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>009</z30-maintenance-count><z30-process-status-date>20130522</z30-process-status-date><z30-upd-time-stamp>201605141301294</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001975671</z13-doc-number><z13-year>2011</z13-year><z13-open-date>20110610</z13-open-date><z13-update-date>20161219</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST8</z13-call-no-code><z13-call-no>**See
+        URL(s)</z13-call-no><z13-author-code></z13-author-code><z13-author>Peterson,
+        T. F.</z13-author><z13-title-code></z13-title-code><z13-title>Nightwork :
+        a history of hacks and pranks at MIT / T.F. Peterson ; with a new essay by
+        Eric Bender.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>MIT
+        Press,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9780262515849
+        (pbk. : alk. paper)</z13-isbn-issn><z13-upd-time-stamp>201612191305450</z13-upd-time-stamp></z13><status>Long
+        Overdue</status></item><item href="http://fake_server.example.com/rest-dlf/record/MIT01001975671/items/MIT50001975671000010"><z30-sub-library-code>ARC</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>02</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>REF</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001975671</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080035666566</z30-barcode><z30-sub-library>Institute
+        Archives</z30-sub-library><z30-material>Book</z30-material><z30-item-status>Room
+        Use Only</z30-item-status><z30-open-date>20110610</z30-open-date><z30-update-date>20110610</z30-update-date><z30-cataloger>SAULEAN</z30-cataloger><z30-date-last-return>00000000</z30-date-last-return><z30-hour-last-return>0000</z30-hour-last-return><z30-ip-last-return></z30-ip-last-return><z30-no-loans>000</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Reference
+        Collection</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>T171.M49
+        P48 2011</z30-call-no><z30-call-no-key>t&quot;171 m49 p48 2011</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number></z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price></z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002025193</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>000</z30-maintenance-count><z30-process-status-date>20110610</z30-process-status-date><z30-upd-time-stamp>200001011200000</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001975671</z13-doc-number><z13-year>2011</z13-year><z13-open-date>20110610</z13-open-date><z13-update-date>20161219</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST8</z13-call-no-code><z13-call-no>**See
+        URL(s)</z13-call-no><z13-author-code></z13-author-code><z13-author>Peterson,
+        T. F.</z13-author><z13-title-code></z13-title-code><z13-title>Nightwork :
+        a history of hacks and pranks at MIT / T.F. Peterson ; with a new essay by
+        Eric Bender.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>MIT
+        Press,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9780262515849
+        (pbk. : alk. paper)</z13-isbn-issn><z13-upd-time-stamp>201612191305450</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:39:19 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_barker.yml
+++ b/test/vcr_cassettes/record_status_barker.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01001251550/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:32:00 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01001251550/items/MIT50001251550000010"><z30-sub-library-code>ENG</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001251550</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080026563954</z30-barcode><z30-sub-library>Barker
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20040406</z30-open-date><z30-update-date>20081002</z30-update-date><z30-cataloger>CAROLF</z30-cataloger><z30-date-last-return>20161108</z30-date-last-return><z30-hour-last-return>1336</z30-hour-last-return><z30-ip-last-return>18.90.1.18</z30-ip-last-return><z30-no-loans>012</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>TA157.A96
+        2004</z30-call-no><z30-call-no-key>ta&quot;157 a96 2004</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>04-17995</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price>33.56</z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>001251550</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id>0</z30-copy-id><z30-hol-doc-number>001265900</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>002</z30-maintenance-count><z30-process-status-date>00000000</z30-process-status-date><z30-upd-time-stamp>201611081336357</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001251550</z13-doc-number><z13-year>2004</z13-year><z13-open-date>20040406</z13-open-date><z13-update-date>20090524</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST0</z13-call-no-code><z13-call-no>TA157.A96
+        2004</z13-call-no><z13-author-code></z13-author-code><z13-author>Auyang, Sunny
+        Y.</z13-author><z13-title-code></z13-title-code><z13-title>Engineering : an
+        endless frontier / Sunny Y. Auyang.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>Harvard
+        University Press,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>0674013328
+        (alk. paper)</z13-isbn-issn><z13-upd-time-stamp>201606131903034</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:32:00 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_dewey.yml
+++ b/test/vcr_cassettes/record_status_dewey.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01002519066/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:34:46 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01002519066/items/MIT50002519066000010"><z30-sub-library-code>DEW</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>002519066</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080037178586</z30-barcode><z30-sub-library>Dewey
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20170126</z30-open-date><z30-update-date>20170227</z30-update-date><z30-cataloger>ANCLARK</z30-cataloger><z30-date-last-return>20170815</z30-date-last-return><z30-hour-last-return>1753</z30-hour-last-return><z30-ip-last-return>18.171.2.112</z30-ip-last-return><z30-no-loans>000</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>HB171.5.G96
+        2018</z30-call-no><z30-call-no-key>hb&quot;171.5 g96 2018</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>17-6678</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price>346.06</z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002579730</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>000</z30-maintenance-count><z30-process-status-date>20170227</z30-process-status-date><z30-upd-time-stamp>201708151753509</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>002519066</z13-doc-number><z13-year>2018</z13-year><z13-open-date>20170126</z13-open-date><z13-update-date>20170429</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST0</z13-call-no-code><z13-call-no>HB171.5.G96
+        2018</z13-call-no><z13-author-code></z13-author-code><z13-author>Gwartney,
+        James D., author.</z13-author><z13-title-code></z13-title-code><z13-title>Economics
+        : private and public choice / James D. Gwartney (Florida State University),
+        Richard L. Str</z13-title><z13-imprint-code>264 1</z13-imprint-code><z13-imprint>Cengage
+        Learning,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9781305506725</z13-isbn-issn><z13-upd-time-stamp>201702230725397</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:34:46 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_hayden.yml
+++ b/test/vcr_cassettes/record_status_hayden.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01001739356/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:04:20 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01001739356/items/MIT50001739356000010"><z30-sub-library-code>HUM</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001739356</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080032830363</z30-barcode><z30-sub-library>Hayden
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20100731</z30-open-date><z30-update-date>20120312</z30-update-date><z30-cataloger>STBROWN</z30-cataloger><z30-date-last-return>20120130</z30-date-last-return><z30-hour-last-return>1713</z30-hour-last-return><z30-ip-last-return>18.51.4.94</z30-ip-last-return><z30-no-loans>001</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>PN1995.9.M86
+        M855 2010</z30-call-no><z30-call-no-key>pn#1995.9 m86 m855 2010</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>11-1627</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>20150108</z30-last-shelf-report-date><z30-price>25.36</z30-price><z30-shelf-report-number>2</z30-shelf-report-number><z30-on-shelf-date>20150623</z30-on-shelf-date><z30-on-shelf-seq>074971</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>001929852</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>001</z30-maintenance-count><z30-process-status-date>20110107</z30-process-status-date><z30-upd-time-stamp>201506231750178</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001739356</z13-doc-number><z13-year>2010</z13-year><z13-open-date>20100731</z13-open-date><z13-update-date>20110806</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST0</z13-call-no-code><z13-call-no>PN1995.9.M86
+        M855 2010</z13-call-no><z13-author-code></z13-author-code><z13-author>Mulholland,
+        Garry.</z13-author><z13-title-code></z13-title-code><z13-title>Popcorn : fifty
+        years of rock &apos;n&apos; roll movies / Garry Mulholland.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>Orion
+        Books,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9780752889351</z13-isbn-issn><z13-upd-time-stamp>201606131911464</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:04:20 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_music.yml
+++ b/test/vcr_cassettes/record_status_music.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01001528789/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:24:41 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01001528789/items/MIT50001528789000010"><z30-sub-library-code>MUS</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>MEDIA</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>001528789</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080034050739</z30-barcode><z30-sub-library>Lewis
+        Music Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20081020</z30-open-date><z30-update-date>20160711</z30-update-date><z30-cataloger>CSMOORE</z30-cataloger><z30-date-last-return>00000000</z30-date-last-return><z30-hour-last-return>0000</z30-hour-last-return><z30-ip-last-return></z30-ip-last-return><z30-no-loans>000</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Media</z30-collection><z30-call-no-type>7</z30-call-no-type><z30-call-no>CD
+        PhonCD P J69 ora</z30-call-no><z30-call-no-key>phoncd p j69 ora</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number></z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price></z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>001556267</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>000</z30-maintenance-count><z30-process-status-date>00000000</z30-process-status-date><z30-upd-time-stamp>201607111001143</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>001528789</z13-doc-number><z13-year>1994</z13-year><z13-open-date>20081020</z13-open-date><z13-update-date>20100126</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST7</z13-call-no-code><z13-call-no>PhonCD
+        P J69 ora</z13-call-no><z13-author-code></z13-author-code><z13-author>Jon
+        Spencer Blues Explosion (Musical group) prf</z13-author><z13-title-code></z13-title-code><z13-title>Orange
+        [sound recording] / [the Jon Spencer Blues Explosion].</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>Matador,</z13-imprint><z13-isbn-issn-code></z13-isbn-issn-code><z13-isbn-issn></z13-isbn-issn><z13-upd-time-stamp>201606131907567</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:24:41 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_reserve.yml
+++ b/test/vcr_cassettes/record_status_reserve.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT30000105498/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 19:22:02 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT30000105498/items/MIT50002415555000010"><z30-sub-library-code>RTC</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>24</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>RSERV</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>002415555</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080037039317</z30-barcode><z30-sub-library>Rotch
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>Fall
+        2 Hours</z30-item-status><z30-open-date>20160723</z30-open-date><z30-update-date>20170901</z30-update-date><z30-cataloger>GPADILLA</z30-cataloger><z30-date-last-return>20170901</z30-date-last-return><z30-hour-last-return>1231</z30-hour-last-return><z30-ip-last-return>18.113.0.60</z30-ip-last-return><z30-no-loans>007</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Reserve
+        Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>HQ1150.E45
+        2017</z30-call-no><z30-call-no-key>hq#1150 e45 2017</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>17-1103</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price>17.70</z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002580866</z30-hol-doc-number><z30-temp-location>Yes</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>002</z30-maintenance-count><z30-process-status-date>20170308</z30-process-status-date><z30-upd-time-stamp>201709011233541</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>002415555</z13-doc-number><z13-year>2017</z13-year><z13-open-date>20160723</z13-open-date><z13-update-date>20170603</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST0</z13-call-no-code><z13-call-no>HQ1150.E45
+        2017</z13-call-no><z13-author-code></z13-author-code><z13-author>Elkin, Lauren,
+        author.</z13-author><z13-title-code></z13-title-code><z13-title>Flâneuse :
+        women walk the city in Paris, New York, Tokyo, Venice, and London / Lauren
+        Elkin.</z13-title><z13-imprint-code>264 1</z13-imprint-code><z13-imprint>Farrar,
+        Straus and Giroux,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9780374156046</z13-isbn-issn><z13-upd-time-stamp>201703030725385</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 19:22:03 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_status_rotch.yml
+++ b/test/vcr_cassettes/record_status_rotch.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01002403936/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Sep 2017 18:35:28 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01002403936/items/MIT50002403936000010"><z30-sub-library-code>RTC</z30-sub-library-code><z30-item-process-status-code></z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>STACK</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>002403936</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>39080036631924</z30-barcode><z30-sub-library>Rotch
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>60
+        Day Loan</z30-item-status><z30-open-date>20160511</z30-open-date><z30-update-date>20160607</z30-update-date><z30-cataloger>JHANKINS</z30-cataloger><z30-date-last-return>20170227</z30-date-last-return><z30-hour-last-return>0924</z30-hour-last-return><z30-ip-last-return>18.113.0.60</z30-ip-last-return><z30-no-loans>001</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Stacks</z30-collection><z30-call-no-type>0</z30-call-no-type><z30-call-no>NA645.A72
+        2015</z30-call-no><z30-call-no-key>na&quot;645 a72 2015</z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>16-11611</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price>32.80</z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status></z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>002482332</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>001</z30-maintenance-count><z30-process-status-date>20160607</z30-process-status-date><z30-upd-time-stamp>201702270924065</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>002403936</z13-doc-number><z13-year>2015</z13-year><z13-open-date>20160511</z13-open-date><z13-update-date>20160903</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST0</z13-call-no-code><z13-call-no>NA645.A72
+        2015</z13-call-no><z13-author-code></z13-author-code><z13-author></z13-author><z13-title-code></z13-title-code><z13-title>Architecture
+        : movements and trends from the 19th century to the present / edited by Luca
+        Molinari.</z13-title><z13-imprint-code>264 1</z13-imprint-code><z13-imprint>Skira
+        Editore,</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9788857204734</z13-isbn-issn><z13-upd-time-stamp>201606131918585</z13-upd-time-stamp></z13><status>In
+        Library</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Fri, 01 Sep 2017 18:35:29 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

- Moves full record sections to partials
- Adds call to aleph API for local non-serial records and does initial logic for the various buttons we want to display. The buttons are not linking to where they need to go yet (https://mitlibraries.atlassian.net/browse/DI-513).
- Serial records will be handled via a separate process to display holding records (https://mitlibraries.atlassian.net/browse/DI-512).
- full text links will be handled in a separate ticket (https://mitlibraries.atlassian.net/browse/DI-514)

#### How can a reviewer manually see the effects of these changes?

In the PR build, enable Full Record displays ( https://mit-bento-staging-pr-251.herokuapp.com/toggle?feature=local_full_record ) then search for things we own locally and see the resulting realtime availability work for book-like things but not serial-like things. Some Items don't have local holdings and need to fallback on holdings displays. A ticket has been opened to address that.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-482

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO