### PR TITLE
full record availability layout and styles

### DIFF
--- a/app/assets/stylesheets/_aleph.scss
+++ b/app/assets/stylesheets/_aleph.scss
@@ -11,3 +11,45 @@
   margin-right: .1rem;
  color: $error;
 }
+
+.discovery-full-record-availability-info {
+
+  .list-local-locations {
+    list-style-type: none;
+    margin-top: 1rem;
+    padding-left: 0;
+    font-size: 1.4rem;
+  }
+
+  .result-local-location {
+    margin-bottom: 0;
+    border-top: 1px solid $gray-l2;
+    padding: .5rem 1rem;
+  }
+
+  .location-wrap, 
+  .availability-wrap {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: .5rem;
+  }
+  
+  .location-actions {
+
+    .btn {
+      padding: 2px 10px 4px 10px;
+    }
+
+    .fa-map-marker {
+      vertical-align: middle;
+      font-size: 1.8rem;
+    }
+
+    .fa-mobile-phone {
+      vertical-align: middle;
+      font-size: 2rem;
+    }
+  }
+
+}

--- a/app/helpers/aleph_helper.rb
+++ b/app/helpers/aleph_helper.rb
@@ -17,23 +17,17 @@ module AlephHelper
   # generates a link to an map for each library on campus
   def map_link(library)
     if library == 'Barker Library'
-      map_link_to('https://libraries.mit.edu/barker/')
+      'https://libraries.mit.edu/barker/'
     elsif library == 'Dewey Library'
-      map_link_to('https://libraries.mit.edu/dewey/')
+      'https://libraries.mit.edu/dewey/'
     elsif library == 'Hayden Library'
-      map_link_to('https://libraries.mit.edu/hayden/')
+      'https://libraries.mit.edu/hayden/'
     elsif library == 'Institute Archives'
-      map_link_to('https://libraries.mit.edu/archives/')
+      'https://libraries.mit.edu/archives/'
     elsif library == 'Lewis Music Library'
-      map_link_to('https://libraries.mit.edu/music/')
+      'https://libraries.mit.edu/music/'
     elsif library == 'Rotch Library'
-      map_link_to('https://libraries.mit.edu/rotch/')
+      'https://libraries.mit.edu/rotch/'
     end
-  end
-
-  private
-
-  def map_link_to(url)
-    link_to('', url, class: 'fa fa-map-marker', aria: { hidden: true })
   end
 end

--- a/app/views/aleph/full_item_status.html.erb
+++ b/app/views/aleph/full_item_status.html.erb
@@ -2,49 +2,68 @@
 <ul class="list-local-locations">
 <% @status.each do |s| %>
   <li class="result-local-location">
-    <%= s[:library] %> <%= s[:collection] %>: <%= s[:call_number] %>
-    <% if s[:description].present? %> <%= s[:description] %> <% end %>
-    <span class="sr"><%= s[:label] %></span>
+    <div class="location-wrap">
+      <span class="location">
+        <span class="library"><%= s[:library] %></span>
+        <span class="collection"><%= s[:collection] %>:</span>
+        <span class="callno"><%= s[:call_number] %></span>
+        <span class="desc">
+          <% if s[:description].present? %> <%= s[:description] %> <% end %> 
+        </span>
+        <span class="sr"><%= s[:label] %></span> 
+      </span>
+      <span class="location-actions">
+        <a href="<%= map_link(s[:library]) %>"
+           class="btn button-subtle map-link">
+           <i class="fa fa-map-marker" aria-hidden="true"></i>
+           <span class="sr">View <%= s[:library] %> location map</span>
+        </a>        
+      </span>
+    </div>
+    <div class="availability-wrap">
 
-    <br />
+      <% if s[:available?] %>
+        <span class="availability-status">
+          <i class="fa fa-check" aria-hidden="true"></i>
+          Available
+        </span>
+        <span class="availability-actions">
 
-    <% if s[:available?] %>
-      <i class="fa fa-check" aria-hidden="true"></i>
+          <% if archives?(s[:library]) %>
 
-      <% if archives?(s[:library]) %>
+            <a class="btn button-secondary button-small" href="https://libraries.mit.edu/archives/">Contact Us</a>
 
-        <a class="btn button-secondary" href="https://libraries.mit.edu/archives/">Contact Us</a>
+          <% elsif reserve?(s[:collection]) %>
 
-        <%= map_link(s[:library]) %>
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
 
-      <% elsif reserve?(s[:collection]) %>
+          <% elsif media?(s[:call_number]) %>
 
-        <a class="btn button-secondary" href="">Place Hold</a>
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
 
-        <%= map_link(s[:library]) %>
+          <% else %>
 
-      <% elsif media?(s[:call_number]) %>
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
 
-        <a class="btn button-secondary" href="">Place Hold</a>
+            <a class="btn button-secondary button-small" href="">Request Scan</a>
 
-        <%= map_link(s[:library]) %>
+          <% end %>
+
+        </span>
 
       <% else %>
-
-        <a class="btn button-secondary" href="">Place Hold</a>
-
-        <a class="btn button-secondary" href="">Request Scan</a>
-
-        <%= map_link(s[:library]) %>
+        <span class="availability-status">
+          <i class="fa fa-times" aria-hidden="true"></i>
+          Not available at MIT
+        </span>
+        <span class="availability-actions">
+          <a class="btn button-subtle button-small" href="">Recall (7+ days)</a>
+          <a class="btn button-secondary button-small" href="">Get it with ILL (3-4 days)</a>
+        </span>
 
       <% end %>
 
-    <% else %>
-      <i class="fa fa-times" aria-hidden="true"></i>
-      Not available at MIT
-      <a class="btn button-secondary" href="">Get it with ILL (3-4 days)</a>
-    <% end %>
-
+    </div>
   </li>
 <% end %>
 </ul>

--- a/test/integration/aleph_test.rb
+++ b/test/integration/aleph_test.rb
@@ -5,7 +5,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status barker', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01001251550' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/barker/'))
       end
     end
@@ -15,7 +15,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status dewey', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01002519066' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/dewey/'))
       end
     end
@@ -25,7 +25,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status hayden', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01001739356' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/hayden/'))
       end
     end
@@ -35,7 +35,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status archives', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01001975671' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.last[:href].include?('libraries.mit.edu/archives/'))
       end
     end
@@ -45,7 +45,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status music', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01001528789' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/music/'))
       end
     end
@@ -55,7 +55,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status rotch', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT01002403936' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/rotch/'))
       end
     end
@@ -65,7 +65,7 @@ class AlephTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record status reserve', allow_playback_repeats: true) do
       get full_item_status_path, params: { id: 'MIT30000105498' }
       assert_response :success
-      assert_select('.fa-map-marker') do |value|
+      assert_select('.map-link') do |value|
         assert(value.first[:href].include?('libraries.mit.edu/rotch/'))
       end
     end


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

#### What does this PR do?
This PR adds semantic/layout html and styles to format the availability block on the full record page.

#### How can a reviewer manually see the effects of these changes?
View a record on the sandbox, like `record/cat00916a/mit.001134881`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-504

#### Screenshots (if appropriate)
Should match mockups: https://mitlibraries.atlassian.net/wiki/spaces/DI/pages/32833537/Full+record
