### PR TITLE
479 extended info

### DIFF
--- a/app/controllers/concerns/rainbows.rb
+++ b/app/controllers/concerns/rainbows.rb
@@ -1,0 +1,77 @@
+module Rainbows
+  # Determines whether the rainbow header should be shown.
+  # Context: when library director Chris Bourg was apprised of the existence
+  # of the rainbows Easter egg, she thought it was great and could we show it
+  # if people were looking at LGBT stuff. Why, yes. Yes we can.
+  #
+  # CITATIONS:
+  #
+  # This is partly inspired by the approach in
+  # https://www.ideals.illinois.edu/handle/2142/97437 . It uses the
+  # author's list of LGBT vocabulary as a starting point for checking
+  # uncontrolled keywords. It removes a few terms that also commonly refer to
+  # non-LGBT topics, and adds some inflected forms as they would otherwise be
+  # missed by the set-intersection logic.
+  #
+  # It also uses http://www.netanelganin.com/projects/QueerLCSH/QueerLCSH.xml
+  # (as of 13 September 2017) for LCSH, again removing terms that also commonly
+  # refer to non-LGBT topics.
+  #
+  # GIANT CAVEATS:
+  #
+  # LCSH doesn't fit well with the language that actual LGBT
+  # people use in searching for and describing LGBT topics, so this is an
+  # extremely rough estimate. Also the thesis referenced above had a small
+  # number of study participants who were not broadly representative of LGBT
+  # identities. This code should be treated as a very rough draft with
+  # substantial room for improvement. Pull requests welcome.
+
+  QUEERLCSH = YAML.load_file(Rails.root.join('config', 'rainbows.yml'))
+
+  def pride?
+    vocabulary = ['bisexual', 'bisexuals', 'fag', 'fags', 'femme', 'femmes',
+                  'gay', 'gays', 'gay men', 'gender identity',
+                  'gender identities', 'homosexual', 'homosexuals', 'lesbian',
+                  'lesbians', 'lgbt', 'lgbts', 'lgbtqia', 'multiple genders',
+                  'queer', 'queers', 'queering', 'pansexual', 'transgender',
+                  'transsexual', 'trans*', 'butch']
+
+    kw = normalize_keywords
+    subj = normalize_subjects
+
+    (kw & vocabulary).present? || (subj & QUEERLCSH).present?
+  end
+
+  # If rainbows are already in the params, leave them alone. If not, check to
+  # see if they should be inserted.
+  def rainbowify?
+    return if params.keys.include?('rainbows')
+    params.merge!(rainbows: true) if pride?
+  end
+
+  def normalize_keywords
+    return if @keywords.blank?
+    # Note that we're not *changing* the instance variable here; we want to
+    # normalize all our keywords to lowercase so we don't have false negatives
+    # in comparing them against our vocabulary, but we want to display them to
+    # end users with traditional capitalization.
+    @keywords.map(&:downcase)
+  end
+
+  def normalize_subjects
+    return if @subjects.blank?
+
+    # We don't want to mutate the instance variable here, either.
+    subj = @subjects.map(&:downcase)
+    subj.map! { |x| x.gsub(/ & /, ' and ') }
+
+    # This step throws out subdivisions (e.g. geographical ones) that would
+    # otherwise be too numerous to handle, but unfortunately means we miss a
+    # handful of LCSH terms that include dashes at the level we care about
+    # (such as `libraries--services to bisexuals`; we don't want to just match
+    # "libraries" here, even though libraries are also in a way :rainbow: .)
+    subj.map! { |x| x.split('--')[0] }
+    subj.map!(&:strip)
+    subj
+  end
+end

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -3,15 +3,20 @@ class RecordController < ApplicationController
     raise ActionController::RoutingError, 'Record not found'
   }
 
+  include Rainbows
+
   def record
     return redirect_to root_url unless valid_url?
 
     fetch_eds_record
+    @keywords = extract_eds_text(@record.eds_author_supplied_keywords)
+    @subjects = extract_eds_text(@record.eds_subjects)
 
     # Don't use q as the parameter here - that will cause the search form to
     # notice the parameter and prefill the search, which is behavior we *don't*
     # want.
     @previous = params[:previous]
+    rainbowify? if Flipflop.enabled?(:pride)
     render 'record'
   end
 
@@ -29,5 +34,15 @@ class RecordController < ApplicationController
                                       org: 'mit',
                                       use_cache: false)
     @record = session.retrieve(dbid: @record_source, an: @record_an)
+  end
+
+  # Keywords and subjects are sometimes provided as lists and sometimes as
+  # provided as chunks of HTML suitable for rendering EDS links, but we need
+  # them as simple lists of items.
+  def extract_eds_text(stuff)
+    return if stuff.blank?
+    return stuff if stuff.is_a? Array
+    parsed_html = Nokogiri::HTML.fragment(CGI.unescapeHTML(stuff))
+    parsed_html.search('searchlink').map(&:text).map(&:strip)
   end
 end

--- a/app/views/record/_extended_info.html.erb
+++ b/app/views/record/_extended_info.html.erb
@@ -1,0 +1,145 @@
+<% if Flipflop.enabled?(:local_browse) %>
+  <% search_prefix = '/search/bento?q=' %>
+<% else %>
+  <% search_prefix = ENV['EDS_PROFILE_URI'] %>
+<% end %>
+
+<h3 class="subtitle3">More information</h3>
+
+<ul>
+  <% if @record.eds_publication_type.present? %>
+    <li>
+      Document type: <%= @record.eds_publication_type %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_source_title.present? %>
+    <li>
+      Source: <%= @record.eds_source_title %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_authors.present? %>
+    <li>
+      <ul>
+        <% @record.eds_authors.each do |author| %>
+          <li>
+            <%= author %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+
+  <% if clean_affiliations.present? %>
+    <li>
+      <ul>
+        <% clean_affiliations.each do |aff| %>
+          <li>
+            <%= aff %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+
+  <% if @record.eds_publication_info.present? %>
+    <li>
+      Publication info: <%= @record.eds_publication_info %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_isbn_print.present? %>
+    <li>
+      ISBN: <%= @record.eds_isbn_print %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_isbn_electronic.present? %>
+    <li>
+      ISBN: <%= @record.eds_isbn_electronic %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_issn_print.present? %>
+    <li>
+      ISSN: <%= @record.eds_issn_print %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_document_doi.present? %>
+    <li>
+      DOI: <%= @record.eds_document_doi %>
+    </li>
+  <% end %>
+
+  <% if clean_language.present? %>
+    <li>
+      <%= "Language".pluralize(clean_language.count) %>:
+      <%= clean_language.join(',') %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_physical_description.present? %>
+    <li>
+      Physical description: <%= @record.eds_physical_description %>
+    </li>
+  <% end %>
+
+  <% if @record.eds_database_name.present? %>
+    <li>
+      Database: <%= @record.eds_database_name %>
+    </li>
+  <% end %>
+
+  <%# The wireframes also included edition (for books) and serial publication
+      dates and frequency (for serials), but this info isn't exposed by the
+      EBSCO gem, so we're leaving it out. If this makes it hard for users to
+      evaluate documents, we may have to look harder for that information. %>
+</ul>
+
+<% if @subjects.present? %>
+  <h3 class="subtitle3">Subjects</h3>
+  <ul>
+    <% @subjects.each do |subject| %>
+      <li>
+        <%= link_to(subject, search_prefix + subject, data: {type: "Subject"} ) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @keywords.present? %>
+<h4>Author supplied Keywords:</h4>
+<ul>
+  <% @keywords.each do |keyword| %>
+    <li>
+      <%= link_to(keyword, search_prefix + keyword, data: {type: "Subject"} ) %>
+    </li>
+  <% end %>
+</ul>
+<% end %>
+
+<% if @record.eds_abstract.present? %>
+  <h4>Abstract/summary</h4>
+  <%= sanitize raw @record.eds_abstract %>
+<% end %>
+
+<% if @record.eds_notes.present? %>
+  <h4>Notes</h4>
+  <%# Turns out notes in the wild can include HTML markup, which is encoded and
+      rendered as strings, such as a user-visible "<br />". Let's not do that.
+      Instead, let's strip potentially dangerous tags but render the rest. %>
+  <%= sanitize raw @record.eds_notes %>
+<% end %>
+
+<% if clean_other_titles.present? %>
+  <h4>Other titles</h4>
+  <ul>
+    <% clean_other_titles.each do |title| %>
+      <li>
+        <%= title %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/record/_more_information.html.erb
+++ b/app/views/record/_more_information.html.erb
@@ -1,3 +1,0 @@
-<h3 class="subtitle3">More information</h3>
-
-coming soon!!!

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "search/form" %>
-<% if @previous.present? %>
+<% if path_to_previous.present? %>
   <%= link_to('Back to search results', search_bento_path(q: @previous)) %>
 <% end %>
 
@@ -15,7 +15,7 @@
     </div>
 
     <div class="discovery-full-record-basic-info">
-      <%= render partial: "more_information" %>
+      <%= render partial: "extended_info" %>
     </div>
 
     <%# 'Show even more information' section will go here. %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -26,4 +26,8 @@ Flipflop.configure do
   feature :hint_tracker,
     default: ENV['HINT_TRACKER'],
     description: 'Sends hint display to GA'
+
+  feature :pride,
+    default: ENV['PRIDE'],
+    description: 'Enables rainbows for records with LGBT subjects/keywords'
 end

--- a/config/rainbows.yml
+++ b/config/rainbows.yml
@@ -1,0 +1,1390 @@
+---
+- sexual minorities
+- bisexual men
+- young bisexual men
+- hiv-positive bisexual men
+- hispanic american bisexual women
+- african american bisexual men
+- internet and bisexual men
+- stonewall book awards
+- bisexual college students
+- bisexual parents
+- bisexual librarians
+- bisexual feminism
+- bisexual students
+- bisexual youth
+- bisexual women
+- bisexuality in marriage
+- bisexual teenagers
+- bisexual teachers
+- bisexual high school students
+- bisexuals
+- social work with bisexuals
+- bisexuality on television
+- libraries and bisexuals
+- bisexuals' writings, canadian
+- bisexuals' writings, american
+- bisexuals' writings
+- intersexuality
+- bisexuality in motion pictures
+- sexual minority business enterprises
+- children of sexual minority parents
+- sexual minority men
+- sexual minority women
+- jewish sexual minorities
+- web sites for sexual minorities
+- sexual minority college athletes
+- sexual minority youth in mass media
+- sexual minority public officers
+- sexual minority students
+- sexual minority parents
+- sexual minority youth
+- sexual minority religious leaders
+- sexual minority college students
+- sexual minority consumers
+- sexual minority politicians
+- sexual minority community
+- gay business enterprises
+- sexual minorities' writings
+- sexual minorities' writings, canadian
+- sexual minorities' writings, american
+- libraries and sexual minorities
+- indian sexual minorities
+- sexual minorities in literature
+- sexual minorities in advertising
+- sexual minorities on television
+- sexual minorities with disabilities
+- sexual minorities in art
+- asian american sexual minorities
+- hispanic american sexual minorities
+- alaska native sexual minorities
+- arab american sexual minorities
+- pacific islander american sexual minorities
+- social work with sexual minority youth
+- sexual minorities in higher education
+- parents of sexual minority youth
+- sexual minorities' families
+- police services for sexual minorities
+- social work with sexual minorities
+- middle-aged sexual minorities
+- unitarian universalist sexual minorities
+- christian sexual minorities
+- social work with older sexual minorities
+- older sexual minorities
+- queer theology
+- queer theory
+- gay pride parades
+- gay men's writings, south african (english)
+- gay erotic poetry, philippine (english)
+- gay erotic stories, philippine (english)
+- gay and lesbian studies
+- gay and lesbian dance parties
+- gay men's writings, indic (english)
+- gay and lesbian film festivals
+- gay rights
+- gay military personnel
+- gay theatrical producers and directors
+- gay labor union members
+- gay police officers
+- participation, gay
+- gay men, white
+- gay-straight alliances in schools
+- gay pride day
+- gay erotica
+- gay liberation movement
+- gay bathhouses
+- parents of intersex children
+- intersex athletes
+- intersex children
+- intersex military personnel
+- lesbian erotic stories, american
+- lesbian erotic poetry, american
+- lesbian erotic poetry, puerto rican
+- lesbian erotic poetry, english
+- lesbian erotic poetry, mexican
+- lesbian erotic stories, canadian
+- lesbian erotic poetry, canadian
+- lesbian couples as parents
+- lesbian community
+- lesbian business enterprises
+- lesbian mothers
+- lesbian separatism
+- lesbian clergy
+- lesbian feminist theory
+- lesbian erotica
+- lesbian partner abuse
+- butch and femme (lesbian culture)
+- gay erotic poetry, french
+- gay men's writings, scottish
+- gay erotic poetry, english
+- gay men's writings, dutch
+- gay erotic stories, english
+- gay man-heterosexual woman relationships on television
+- gay men's writings, italian
+- gay men's writings, afrikaans
+- gay men's writings, canadian
+- african american gay actors
+- gay erotic films
+- gay couples
+- gay community
+- bears (gay culture)
+- gay culture
+- gay pornography
+- gay pride celebrations
+- gay pornographic films
+- gender identity on television
+- gender identity in dance
+- gender identity in literature
+- gender identity in motion pictures
+- gender identity in art
+- gender identity in the theater
+- gender identity in music
+- gender identity in mass media
+- gender identity in science
+- gender identity disorders
+- gender expression
+- gender-neutral toilet facilities
+- gender identity in the qurʼan
+- gender identity
+- lesbian dramatists
+- lesbian vampires in motion pictures
+- lesbian bars in motion pictures
+- lesbian psychotherapists
+- lesbian cartoonists
+- lesbian motorcyclists
+- lesbian businesswomen
+- lesbian nurses
+- lesbian theater
+- lesbian musicians
+- lesbian artists
+- lesbian college teachers
+- lesbian anthropologists
+- lesbian activists
+- music by lesbian composers
+- abusive lesbian partners
+- lesbian erotic stories, english
+- gay men's writings, irish
+- gay men's writings, mexican
+- gay men's writings, english
+- gay men's writings
+- gay erotic poetry, japanese
+- gay men and musicals
+- gay erotic stories, german
+- gay erotic poetry, american
+- gay erotic stories, tagalog
+- gay erotic literature, american
+- gay men's writings, argentine
+- gay men's writings, japanese
+- gay men's writings, french
+- gay erotic stories, american
+- gay men's writings, arabic
+- gay men's writings, german
+- gay men, black
+- gay erotic literature, french
+- gay men's writings, russian
+- gay men's writings, american
+- sex discrimination
+- sex role
+- gender identity disorders in adolescence
+- gender identity disorders in children
+- gender identity in the workplace
+- gender identity in the bible
+- gender identity in education
+- gender identity in advertising
+- lesbian photographers
+- lesbian consumers
+- lesbian teenagers in literature
+- lesbian bars
+- lesbian youth
+- lesbian couples
+- lesbian college students
+- lesbian teachers
+- lesbian feminism
+- lesbian librarians
+- lesbian police officers
+- lesbian erotic literature
+- lesbian students
+- lesbian girl scouts
+- lesbian actresses
+- lesbian rabbis
+- lesbian culture
+- lesbian composers
+- lesbian teenagers
+- lesbian athletes
+- gay men's writings, north african (french)
+- gay men's writings, philippine
+- gay men's writings, latin (medieval and modern)
+- gay erotic poetry, greek
+- gay erotic drama, american
+- gay men's writings, indic
+- same-sex partner abuse
+- children of gay parents
+- motion pictures and gay men
+- christian gay men
+- etiquette for gay men
+- music by gay composers
+- muslim gay men
+- gay choirs
+- gay erotic poetry, greek (modern)
+- gay men's writings, latin american
+- gay men's writings, greek
+- gay youths' writings
+- gay erotic literature, english
+- lesbianism
+- same-sex marriage
+- gay adoption
+- lesbian heroines in literature
+- lesbian private investigators
+- lesbian artists in popular culture
+- lesbian motion picture producers and directors
+- lesbian erotic stories
+- lesbian authors
+- lesbian high school students
+- lesbian libraries
+- lesbian erotic poetry
+- butch and femme (lesbian culture) in motion pictures
+- lesbian online chat groups
+- lesbian erotic films
+- lesbian physical education teachers
+- lesbian heroes
+- lesbian erotic art
+- lesbian nuns
+- gay human services personnel
+- gay military cadets
+- gay composers
+- gays
+- asian american gay men
+- presbyterian gay men
+- hispanic american gay artists
+- internet and gay men
+- young gay men
+- hiv-positive gay men
+- catholic gay men
+- african american gay men
+- jewish gay men
+- drag balls
+- lesbians
+- gay men's writings, brazilian
+- gay men's writings, new zealand
+- gay men's writings, australian
+- transgender veterans
+- sexual minority veterans
+- gay veterans
+- parents of transgender children
+- transgender parents
+- transgender people in motion pictures
+- transgender athletes
+- transgender librarians
+- transgender prisoners
+- transgender college students
+- transgender people in art
+- african american transgender people
+- jewish transgender people
+- children of transgender parents
+- christian transgender people
+- transsexualism
+- transgender people's writings, canadian
+- libraries and transgender people
+- transgender people's writings
+- transgender people's writings, american
+- transgender people
+- transgender military personnel
+- transgender musicians
+- lesbians in mass media
+- lesbians in art
+- lesbians in motion pictures
+- lesbians in literature
+- lesbians in advertising
+- lesbians in popular culture
+- middle-aged lesbians
+- social work with lesbian youth
+- abused lesbians
+- internalized homophobia in lesbians
+- women's music
+- christian lesbians
+- lesbian vampires
+- gay bodybuilders
+- gay caregivers
+- gay personals
+- gay newspapers
+- gay columns in newspapers
+- gay erotic drama
+- gay singers
+- gay interpretations
+- gay real estate agents
+- gay travelers
+- gay wit and humor
+- gay teachers
+- gay coaches (athletics)
+- gay psychoanalysts
+- gay activists
+- gay immigrants
+- gay sailors
+- gay lawyers
+- social work with transgender youth
+- social work with transgender people
+- legal assistance to transgender people
+- transgenderism
+- transgender teachers
+- transgender artists
+- transgenderism on television
+- transgender youth
+- transphobia
+- transgender people in literature
+- lesbianism on television
+- african american lesbians in motion pictures
+- working class lesbians
+- sex instruction for lesbians
+- ordination of lesbians
+- lesbians in the performing arts
+- rural lesbians
+- lesbians on postage stamps
+- jewish lesbians
+- social work with lesbians
+- gay press
+- gay musicians
+- gay anthropologists
+- gay physical education teachers
+- gay men in literature
+- gay critics
+- gay skinheads in motion pictures
+- gay public officers
+- gay men in motion pictures
+- gay college teachers
+- gay motion picture actors and actresses
+- gay students
+- gay rights in literature
+- gay high school students
+- gay teenagers in literature
+- gay erotic art
+- gay librarians
+- gay men on postage stamps
+- gay spies
+- transsexuals in motion pictures
+- transsexuals in literature
+- parents of transsexuals
+- male-to-female transsexuals
+- jewish transsexuals
+- older transsexuals
+- transsexuals
+- christian transsexuals
+- sex change
+- female-to-male transsexuals
+- transsexual college students
+- transsexual parents
+- transsexual youth
+- transsexual students
+- transsexual librarians
+- children of transsexual parents
+- homophobia
+- outing (sexual orientation)
+- coming out (sexual orientation) in literature
+- coming out (sexual orientation)
+- sexual reorientation programs
+- sexual orientation
+- italian american lesbians
+- gay nurses
+- gay businessmen
+- gay men on television
+- gay executives
+- gay youth
+- gay counselors
+- gay men in mass media
+- gay cartoonists
+- gay men in art
+- gay deacons
+- gay skinheads
+- gay libraries
+- gay journalists
+- gay actors
+- gay press publications
+- gay discotheques
+- gay conductors (music)
+- gay prisoners
+- libraries and transsexuals
+- transsexuals' writings, american
+- transsexuals' writings
+- african american transsexuals
+- church work with gays
+- gays' writings, american
+- gay men
+- african american gays
+- social work with gays
+- gays' writings, english
+- gays' writings, latin american
+- sex instruction for gay men
+- ex-gay movement
+- same-sex divorce
+- gay parents
+- ex-gays
+- gays' writings
+- gay teenagers
+- gay theater
+- gay politicians
+- gay culture in literature
+- gay legislators
+- gay artists
+- gay dramatists
+- gay broadcasters
+- gay political refugees
+- gay men's writings, cuban
+- gay social workers
+- gay ocean liner passengers
+- gay consumers
+- gay psychologists
+- gay heroes
+- gay authors
+- gay clergy
+- gay erotic literature
+- gay psychiatrists
+- lesbians' writings, puerto rican
+- lesbians' writings, italian
+- lesbians and sports
+- lesbians' writings, spanish
+- lesbians' writings, brazilian
+- lesbians' writings, russian
+- lesbians' writings, argentine
+- lesbians' writings, french
+- lesbians, black
+- puerto rican lesbians
+- etiquette for lesbians
+- lesbians' writings, american
+- pacific islander american lesbians
+- lesbians' writings, canadian
+- cuban american lesbians
+- asian american lesbians
+- hispanic american lesbians
+- older lesbians
+- minority lesbians
+- lesbians' writings, north african (french)
+- gay rodeos
+- gay fathers
+- gay online chat groups
+- gay erotic photography
+- gay motion picture producers and directors
+- gay photographers
+- gay song festivals
+- gay private investigators
+- gay artists in popular culture
+- gay figure skaters
+- gay motorcycle clubs
+- gay kings and rulers
+- gay erotic poetry
+- gay erotic stories
+- glam rock music
+- libraries and lesbians
+- lesbians' writings, south african (english)
+- mexican american lesbians
+- lesbians' writings, hispanic american (spanish)
+- lesbians' writings, indic (english)
+- african american lesbians
+- lesbians' writings, scottish
+- indian lesbians
+- lesbians' writings, irish
+- lesbians and musicals
+- lesbians' writings, new zealand
+- lesbians' writings, german
+- lesbians' writings, english
+- lesbians' writings, spanish american
+- lesbians' writings, israeli
+- lesbians' writings
+- lesbians' writings, australian
+- rural gay men
+- gay clubs
+- gay conservatives
+- deaf gays
+- presbyterian gays
+- gays in advertising
+- older gay men
+- abused gay men
+- buddhist gays
+- catholic gays
+- mormon gays
+- christian gays
+- protestant gays
+- gay college students
+- gay bars
+- gay accommodations
+- gay erotic drawing
+- gay erotic comic books, strips, etc
+- parents of gays
+- deaf gay men
+- middle-aged gay men
+- social work with gay youth
+- gays in the performing arts
+- radio programs for gays
+- middle-aged gays
+- church work with african american gays
+- gays in mass media
+- gays in literature
+- muslim gays
+- closeted gays in literature
+- ordination of gays
+- jewish gays
+- homosexuality on television
+- gays in higher education
+- gays in the civil service
+- gays with disabilities
+- internalized homophobia
+- television programs for gays
+- minority gays in literature
+- gays in popular culture
+- gays in motion pictures
+- indian gays
+- closeted gays
+- gays' writings, dominican
+- gays' writings, caribbean
+- gays' writings, spanish american
+- gays' writings, catalan
+- asian american gays
+- mexican american gays
+- gays' writings, portuguese
+- television and gays
+- gays' writings, israeli
+- gays' writings, scottish
+- gays and rock music
+- south asian american gays
+- gays' writings, chilean
+- gays' writings, austrian
+- minority gays
+- gays' writings, galician
+- gays' writings, puerto rican
+- gays' writings, basque
+- gays' writings, irish
+- radical faeries (new age movement)
+- gays' writings, spanish
+- gays' writings, french
+- gays' writings, german
+- gays and sports
+- gays' writings, costa rican
+- gays' writings, tagalog
+- gays' writings, canadian
+- gays' writings, australian
+- gays and the performing arts
+- pacific islander american gays
+- hispanic american gays
+- mass media and gays
+- gays' writings, chinese
+- legal assistance to gays
+- italian american gays
+- gays, black
+- older gays
+- libraries and gays
+- gays' writings, south african (english)
+- gays' writings, philippine (english)
+- gays' writings, malaysian (english)
+- gays' writings, italian
+- heterosexism in high schools
+- heterosexism in schools
+- heterosexism in medicine
+- heterosexism in gerontology
+- heterosexism in child welfare
+- heterosexism in higher education
+- heterosexism in literature
+- heterosexism in medical care
+- heterosexism in nursing
+- heterosexism
+- sexism
+- gender mainstreaming
+- two-spirit people
+- civil unions
+- sexual minority political refugees
+- two-spirit people in literature
+- homosexuality and art
+- homosexuality on radio
+- homosexuality
+- children and homosexuality
+- homosexuality and education
+- homosexuality and television
+- homosexuality and architecture
+- male homosexuality in literature
+- socialism and homosexuality
+- male homosexuality in art
+- psychoanalysis and homosexuality
+- astrology and homosexuality
+- homosexuality and music
+- homosexuality and theater
+- homosexuality and popular music
+- homosexuality and the arts
+- homosexuality and motion pictures
+- homosexuality and literature
+- homosexuality and dance
+- homosexuality in the workplace
+- homosexuality in animals
+- homosexuality in the theater
+- homosexuality (canon law)
+- homosexuality in the bible
+- homosexuality in literature
+- homosexuality in opera
+- homosexuality in video games
+- homosexuality in dance
+- homosexuality in motion pictures
+- homosexuality in music
+- homosexuality in art
+- male homosexuality in music
+- bible and homosexuality
+- male homosexuality in motion pictures
+- male homosexuality
+- national socialism and homosexuality
+- male prostitution
+- lesbianism in opera
+- lesbianism in art
+- lesbianism in literature
+- lesbianism in motion pictures
+- bisexuality
+- lgbt history month
+- intersexuality in art
+- intersexuality in children
+- intersexuality in literature
+- homophobia in the workplace
+- homophobia in literature
+- homophobia in schools
+- homophobia in medicine
+- homophobia in social work
+- homophobia in child welfare
+- homophobia in gerontology
+- homophobia in higher education
+- homophobia in medical care
+- homophobia in the military
+- homophobia in physical education
+- homophobia in sports
+- homophobia in art
+- homophobia in high schools
+- homophobia in anthropology
+- homophobia in psychoanalysis
+- homophobia in children
+- female impersonators on television
+- female impersonators in motion pictures
+- female impersonators
+- male impersonators in motion pictures
+- male impersonators
+- handkerchief codes
+- stonewall riots, new york, n.y., 1969
+- androgyny (psychology) in art
+- androgyny (psychology)
+- androgyny (psychology) in literature
+- homomonument (amsterdam, netherlands)
+- sexual orientation in art
+- polari
+- african american bisexuals
+- pacific islander american bisexuals
+- asian american bisexuals
+- transvestites
+- leather bars
+- same-sex marriage in literature
+- children of same-sex parents
+- same-sex parents
+- same-sex marriage in art
+- drag shows
+- same-sex marriage (islamic law)
+- transgender children
+- sexual minorities (islamic law)
+- cisgender people
+- african american sexual minorities
+- african american bisexual women
+- asexual people
+- asexuality (sexual orientation)
+- gay detectives
+- intersex people
+- discrimination against intersex people
+- female-to-male transsexuals in art
+- gay musicologists
+- neopagan gays
+- bisexuality and education
+- hispanic american bisexual men
+- hispanic american gay men
+- sexual minorities' writings, australian
+- museums and sexual minorities
+- male homosexuality in the theater
+- gender minorities
+- glbt people
+- glbtq people
+- lbg people
+- lgbt people
+- lesbigay people
+- lgbtq people
+- non-heterosexual people
+- non-heterosexuals
+- sexual dissidents
+- male bisexuals
+- men bisexuals
+- bisexual young men
+- bisexual hiv-positive men
+- bisexual women, hispanic american
+- bisexual men, african american
+- bisexual men and the internet
+- ala gay, lesbian, bisexual, and transgendered book award
+- american library association gay, lesbian, bisexual, and transgendered book award
+- gay, lesbian, and bisexual book award
+- gay, lesbian, bisexual, and transgendered book award
+- gay and lesbian book award
+- gay book award
+- glbt book award
+- stonewall awards (book awards)
+- feminist bisexuality
+- female bisexuals
+- women bisexuals
+- bisexual marriages
+- bi people
+- bis (bisexuals)
+- bisexual people
+- bisexuals on television
+- bisexuals and libraries
+- libraries--services to bisexuals
+- services to bisexuals
+- library services to bisexuals
+- public libraries--services to bisexuals
+- canadian bisexuals' writings
+- american bisexuals' writings
+- writings of bisexuals
+- bisexuality (biology)
+- hermaphroditism
+- intersex conditions
+- sexual minority-owned business enterprises
+- sexual minority parents' children
+- male sexual minorities
+- men sexual minorities
+- female sexual minorities
+- women sexual minorities
+- sexual minority jews
+- sexual minority web sites
+- queer community
+- gay-owned business enterprises
+- writings of sexual minorities
+- canadian sexual minorities' writings
+- american sexual minorities' writings
+- library services to sexual minorities
+- public libraries--services to sexual minorities
+- services to sexual minorities
+- sexual minorities and libraries
+- sexual minorities, indian
+- sexual minorities, asian american
+- sexual minorities, hispanic american
+- sexual minorities, alaska native
+- sexual minorities, arab american
+- sexual minorities, pacific islander american
+- police social work with sexual minorities
+- glbt seniors
+- gay pride marches
+- lgbt pride parades
+- pride parades, gay
+- gay men's writings, english--south africa
+- south africa
+- south african gay men's writings (english)
+- gay erotic poetry, english--philippines
+- philippines
+- philippine gay erotic poetry (english)
+- gay erotic stories, english--philippines
+- philippine gay erotic stories (english)
+- gay studies
+- homophile studies
+- lesbian and gay studies
+- lesbian studies
+- gay dance parties
+- lesbian and gay dance parties
+- gay men's writings, english--india
+- india
+- indic gay men's writings (english)
+- gay film festivals
+- lesbian and gay film festivals
+- gay and lesbian rights
+- gay men--civil rights
+- civil rights
+- gays--civil rights
+- lesbian rights
+- lesbians--civil rights
+- rights of gays
+- rights of lesbians
+- gay armed forces members
+- gay service members
+- gay soldiers
+- gays in military service
+- gays in the armed forces
+- gays in the military
+- gay theatrical directors
+- labor unions--gay membership
+- labor unions
+- gay membership
+- gay participation
+- gay white men
+- white gay men
+- gay-straight school alliances
+- gsas (gay-straight alliances) in schools
+- straight-gay school alliances
+- gay and lesbian pride day
+- gay freedom day
+- gay liberation day
+- glbt pride day
+- lesbian and gay pride day
+- lgbt pride day
+- pride day, gay
+- gay eroticism
+- gay male erotica
+- gay male eroticism
+- gay men's erotica
+- gay and lesbian liberation movement
+- gay and lesbian movement
+- gay and lesbian rights movement
+- gay lib
+- gay movement
+- gay rights movement
+- homophile movement
+- homosexual liberation movement
+- homosexual movement
+- homosexual rights movement
+- lesbian liberation movement
+- lesbian rights movement
+- baths, gay
+- gay baths
+- gay men's bathhouses
+- gay saunas
+- gay steam baths
+- saunas, gay
+- steam baths, gay
+- tubs (gay bathhouses)
+- children with intersexuality
+- intersexuality in children--patients
+- patients
+- intersex armed forces members
+- intersex people in the armed forces
+- intersex people in the military
+- intersex service members
+- intersex soldiers
+- american lesbian erotic stories
+- american lesbian erotic poetry
+- puerto rican lesbian erotic poetry
+- english lesbian erotic poetry
+- mexican lesbian erotic poetry
+- canadian lesbian erotic stories
+- canadian lesbian erotic poetry
+- lesbian-couple parents
+- lesbian communities
+- lesbian-owned business enterprises
+- lesbian parents
+- separatism, lesbian
+- lesbian ministers
+- lesbian feminism--philosophy
+- philosophy
+- lesbian feminist sociology
+- theory of lesbian feminism
+- lesbian eroticism
+- abuse of lesbian partners
+- battering of lesbian partners
+- beating of lesbian partners
+- lesbian battering
+- lesbian partner battering
+- lesbian partner beating
+- partner abuse, lesbian
+- butch-fem (lesbian culture)
+- butch-femme (lesbian culture)
+- femme-butch (lesbian culture)
+- femme and butch (lesbian culture)
+- french gay erotic poetry
+- scottish gay men's writings
+- english gay erotic poetry
+- dutch gay men's writings
+- english gay erotic stories
+- heterosexual woman-gay man relationships on television
+- italian gay men's writings
+- afrikaans gay men's writings
+- canadian gay men's writings
+- afro-american gay actors
+- gay actors, african american
+- gay afro-american actors
+- gay erotic videos
+- domestic partners
+- gay male couples
+- homosexual couples
+- same-sex couples
+- gay communities
+- otters (gay culture)
+- gay subculture
+- lavender culture
+- gay male pornography
+- celebrations, gay pride
+- gay pride festivals
+- glbt pride celebrations
+- lgbt pride celebrations
+- pride celebrations, gay
+- gay porn films
+- gay sex films
+- dysphoria, gender
+- gender dysphoria
+- expression, gender
+- all-gender toilet facilities
+- gender-open toilet facilities
+- non-gendered toilet facilities
+- unisex toilet facilities
+- gender identity in the koran
+- sex identity (gender identity)
+- sexual identity (gender identity)
+- lesbian composers' music
+- lesbian partners, abusive
+- english lesbian erotic stories
+- irish gay men's writings
+- mexican gay men's writings
+- english gay men's writings
+- writings of gay men
+- japanese gay erotic poetry
+- musicals and gay men
+- german gay erotic stories
+- american gay erotic poetry
+- tagalog gay erotic stories
+- american gay erotic literature
+- argentine gay men's writings
+- japanese gay men's writings
+- french gay men's writings
+- american gay erotic stories
+- arabic gay men's writings
+- german gay men's writings
+- black gay men
+- french gay erotic literature
+- russian gay men's writings
+- american gay men's writings
+- discrimination, sexual
+- gender discrimination
+- sexual discrimination
+- gender role
+- north african gay men's writings (french)
+- philippine gay men's writings
+- latin gay men's writings, medieval and modern
+- greek gay erotic poetry
+- american gay erotic drama
+- indic gay men's writings
+- abuse of same-sex partners
+- battering of same-sex partners
+- beating of same-sex partners
+- domestic violence, same-sex
+- gay domestic violence
+- gay male partner abuse
+- gay partner abuse
+- partner abuse, same-sex
+- same-sex domestic violence
+- same-sex partner battering
+- same-sex partner beating
+- children of gay men
+- children of homosexual parents
+- children of lesbians
+- gay parents' children
+- gay men and motion pictures
+- gay christian men
+- gay men--etiquette
+- etiquette
+- gay composers' music
+- gay muslim men
+- gay choruses
+- greek gay erotic poetry, modern
+- modern greek gay erotic poetry
+- latin american gay men's writings
+- greek gay men's writings
+- writings of gay youths
+- english gay erotic literature
+- female homosexuality
+- lesbian love
+- sapphism
+- gay marriage
+- homosexual marriage
+- lesbian marriage
+- same-sex unions
+- lesbian adoption
+- same-sex adoption
+- gay people
+- gay persons
+- homosexuals
+- gay men, asian american
+- gay presbyterian men
+- gay artists, hispanic american
+- gay men and the internet
+- gay young men
+- gay hiv-positive men
+- gay catholic men
+- gay men, african american
+- gay jewish men
+- ball culture (gay culture)
+- house ballroom scene (gay culture)
+- female gays
+- female homosexuals
+- gay females
+- gay women
+- gayelles
+- gays, female
+- homosexuals, female
+- lesbian women
+- sapphists
+- women, gay
+- women homosexuals
+- brazilian gay men's writings
+- new zealand gay men's writings
+- australian gay men's writings
+- transgender people, african american
+- transgender jews
+- transgender parents' children
+- transgender christians
+- transexualism
+- transexuality
+- transsexuality
+- canadian transgender people's writings
+- library services to transgender people
+- public libraries--services to transgender people
+- services to transgender people
+- transgender people and libraries
+- writings of transgender people
+- american transgender people's writings
+- tg people
+- tgs (transgender people)
+- trannies
+- trans-identified people
+- trans people
+- transgender-identified people
+- transgendered people
+- transgenders
+- transpeople
+- transgender armed forces members
+- transgender people in the armed forces
+- transgender people in the military
+- transgender service members
+- transgender soldiers
+- battered lesbians
+- lesbian victims of abuse
+- victimized lesbians
+- homophobia in lesbians, internalized
+- lesbian internalized homophobia
+- lesbian music
+- womansong
+- women-identified music
+- women's music--united states
+- united states
+- womyn's music
+- lesbian christians
+- vampire lesbians
+- homoerotic drama
+- legal representation of transgender people
+- transgender orientation
+- transgender people on television
+- anti-transgender bias
+- cissexism
+- discrimination against transgender people
+- transgender discrimination
+- transprejudice
+- lesbians on television
+- homoerotic art
+- m-fs (male-to-female transsexuals)
+- male transsexuals
+- mtfs (male-to-female transsexuals)
+- transsexual women
+- trans-women
+- transwomen
+- transsexual jews
+- transsexual older people
+- transexuals
+- transsexual people
+- transsexualism--patients
+- transsexual christians
+- change of sex
+- reassignment, sex
+- sex change surgery
+- sex reassignment
+- transsexual surgery
+- f-t-ms (female-to-male transsexuals)
+- f2ms (female-to-male transsexuals)
+- female transsexuals
+- ftm transsexuals
+- ftms (female-to-male transsexuals)
+- trans men
+- transmales
+- transmen
+- transsexual males
+- transsexual men
+- transsexual parents' children
+- anti-gay bias
+- anti-glbt bias
+- anti-homosexual bias
+- anti-lgbt bias
+- antigay bias
+- discrimination against gays
+- fear of gays
+- fear of homosexuality
+- glbt bias
+- homonegativity
+- homophobic attitudes
+- homoprejudice
+- lesbophobia
+- lgbt bias
+- sexual orientation discrimination
+- coming out (sexual identity)
+- conversion programs, sexual
+- reorientation programs, sexual
+- reparative programs (sexual orientation)
+- sexual conversion programs
+- orientation, sexual
+- sexual preference
+- lesbians, italian american
+- library services to transsexuals
+- public libraries--services to transsexuals
+- services to transsexuals
+- transsexuals and libraries
+- american transsexuals' writings
+- writings of transsexuals
+- transsexuals, african american
+- church work with homosexuals
+- american gays' writings
+- homosexuals' writings, american
+- gays, male
+- homosexuals, male
+- male gays
+- urnings
+- afro-american gays
+- afro-american homosexuals
+- gays, african american
+- social work with homosexuals
+- english gays' writings
+- homosexuals' writings, english
+- homosexuals' writings, latin american
+- latin american gays' writings
+- sex instruction for homosexual men
+- ex-gay ministries
+- ex-homosexual movement
+- exgay movement
+- exodus movement (ex-gay movement)
+- former-gay movement
+- former-homosexual movement
+- gay divorce
+- homosexual divorce
+- homosexual parents
+- ex-homosexuals
+- exgays
+- former gays
+- former homosexuals
+- homosexuals' writings
+- writings of gays
+- writings of homosexuals
+- homoerotic literature
+- puerto rican lesbians' writings
+- italian lesbians' writings
+- sports and lesbians
+- spanish lesbians' writings
+- brazilian lesbians' writings
+- russian lesbians' writings
+- argentine lesbians' writings
+- french lesbians' writings
+- black lesbians
+- lesbians, puerto rican
+- lesbians--etiquette
+- american lesbians' writings
+- lesbians, pacific islander american
+- canadian lesbians' writings
+- lesbians, cuban american
+- lesbians, asian american
+- lesbians, hispanic american
+- aged lesbians
+- ethnic lesbians
+- north african lesbians' writings (french)
+- homoerotic photography
+- homoerotic poetry
+- homoerotic stories
+- gay rock music
+- glitter rock music
+- shock rock music
+- theater rock music (glam rock)
+- lesbians and libraries
+- libraries--services to lesbians
+- services to lesbians
+- library services to lesbians
+- public libraries--services to lesbians
+- lesbians' writings, english--south africa
+- south african lesbians' writings (english)
+- chicana lesbians
+- lesbians, mexican american
+- hispanic american lesbians' writings (spanish)
+- lesbians' writings, spanish--united states
+- indic lesbians' writings (english)
+- lesbians' writings, english--india
+- afro-american lesbians
+- lesbians, african american
+- scottish lesbians' writings
+- lesbians, indian
+- irish lesbians' writings
+- musicals and lesbians
+- new zealand lesbians' writings
+- german lesbians' writings
+- english lesbians' writings
+- spanish american lesbians' writings
+- israeli lesbians' writings
+- writings of lesbians
+- australian lesbians' writings
+- gays--societies and clubs
+- societies and clubs
+- gays' clubs
+- conservative gays
+- gay deaf people
+- gay presbyterians
+- gay men in advertising
+- homosexuality in advertising
+- male homosexuality in advertising
+- aged gay men
+- battered gay men
+- gay buddhists
+- gay catholics
+- gay mormons
+- gay christians
+- gay protestants
+- homoerotic drawing
+- homoerotic comic books, strips, etc
+- parents of gay men
+- gays on television
+- homosexuality in television
+- ego-dystonic homophobia
+- homophobia in gays, internalized
+- internalized homophobia in gays
+- gays, indian
+- closet gays
+- dominican gays' writings
+- caribbean gays' writings
+- spanish american gays' writings
+- catalan gays' writings
+- gays, asian american
+- gays, mexican american
+- portuguese gays' writings
+- gays and television
+- israeli gays' writings
+- scottish gays' writings
+- rock music and gays
+- gays, south asian american
+- chilean gays' writings
+- austrian gays' writings
+- ethnic gays
+- galician gays' writings
+- puerto rican gays' writings
+- basque gays' writings
+- irish gays' writings
+- faeries, radical (new age movement)
+- fairies, radical (new age movement)
+- radical fairies (new age movement)
+- spanish gays' writings
+- french gays' writings
+- german gays' writings
+- sports and gays
+- costa rican gays' writings
+- tagalog gays' writings
+- canadian gays' writings
+- australian gays' writings
+- performing arts and gays
+- gays, pacific islander american
+- gays, hispanic american
+- gays and mass media
+- chinese gays' writings
+- legal representation of gays
+- gays, italian american
+- black gays
+- aged gays
+- gays and libraries
+- libraries--services to gays
+- services to gays
+- library services to gays
+- public libraries--services to gays
+- gays' writings, english--south africa
+- south african gays' writings (english)
+- gays' writings, english--philippines
+- philippine gays' writings (english)
+- gays' writings, english--malaysia
+- malaysia
+- malaysian gays' writings (english)
+- italian gays' writings
+- heterocentrism
+- heteronormativity
+- heterosexualism
+- sex bias
+- analysis, gender-based
+- gba (gender-based analysis)
+- gender-based analysis
+- gender mainstreaming in biodiversity conservation
+- mainstreaming, gender
+- bardashes
+- berdaches
+- indian men-women
+- two-spirits (indians of north america)
+- unions, civil
+- art and homosexuality
+- homosexuality in radio
+- same-sex attraction
+- homosexuality and children
+- education and homosexuality
+- television and homosexuality
+- architecture and homosexuality
+- homosexuality, male, in literature
+- homosexuality and socialism
+- homosexuality, male, in art
+- homosexuality and psychoanalysis
+- homosexuality and astrology
+- music and homosexuality
+- theater and homosexuality
+- popular music and homosexuality
+- arts and homosexuality
+- motion pictures and homosexuality
+- literature and homosexuality
+- dance and homosexuality
+- lesbianism in the workplace
+- homosexual behavior in animals
+- homosexuality, male, in music
+- homosexuality and the bible
+- homosexuality, male, in motion pictures
+- homosexuality, male
+- homosexuality and national socialism
+- homosexual prostitution
+- male hustling
+- male sex work
+- prostitution, male
+- same-sex male prostitution
+- bi-sexuality
+- lesbian gay bisexual trans history month
+- hermaphroditism in art
+- hermaphroditism in literature
+- cross-dressers
+- crossdressers
+- drag queens
+- impersonators, female
+- impersonators of women
+- queens, drag
+- drag kings
+- impersonators, male
+- impersonators of men
+- kings, drag
+- bandana codes
+- codes, handkerchief
+- codes, hankie
+- codes, hanky
+- flagging (handkerchief codes)
+- hankie codes
+- hanky codes
+- stonewall inn riot, new york, n.y., 1969
+- stonewall inn riots, new york, n.y., 1969
+- stonewall rebellion, new york, n.y., 1969
+- stonewall uprising, new york, n.y., 1969
+- androgynous behavior
+- bisexuals, african american
+- bisexuals, pacific islander american
+- bisexuals, asian american
+- femmiphilliacs
+- leather clubs (bars)
+- same-sex parents' children
+- drag performances (shows)
+- drag queen shows
+- performances, drag (shows)
+- shows, drag
+- sexual minorities, african american
+- bisexual women, african american
+- aces (asexual people)
+- asexuals
+- hermaphrodites (persons)
+- hermaphroditic people
+- inter* individuals
+- intersex-identified people
+- intersexed people
+- intersexual people
+- intersexuals (persons)
+- gay neopagans
+- education and bisexuality
+- bisexual men, hispanic american
+- gay men, hispanic american
+- australian sexual minorities' writings
+- sexual minorities and museums

--- a/test/concerns/rainbow_concern_test.rb
+++ b/test/concerns/rainbow_concern_test.rb
@@ -1,0 +1,98 @@
+require 'test_helper'
+
+class RainbowTestClass
+  include Rainbows
+  include RecordHelper # needed to supply clean_keywords
+end
+
+class RainbowConcernTest < MiniTest::Test
+  def setup
+    @Rainbows = RainbowTestClass.new
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ normalize_keywords ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  def test_normalize_keywords
+    @Rainbows.instance_variable_set(:@keywords, ['Gender Identities'])
+
+    kw = @Rainbows.normalize_keywords
+    assert kw.present?
+    assert_equal(kw.map(&:downcase), kw)
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ normalize_subjects ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  def test_that_subjects_downcase
+    @Rainbows.instance_variable_set(:@subjects, ['Capitalized'])
+
+    subj = @Rainbows.normalize_subjects
+    assert subj.present?
+    assert_equal(subj.map(&:downcase), subj)
+  end
+
+  def test_that_subjects_replace_ampersands
+    @Rainbows.instance_variable_set(:@subjects, ['this & that'])
+
+    subj = @Rainbows.normalize_subjects
+    assert subj.present?
+    assert_equal(['this and that'], subj)
+  end
+
+  def test_that_subjects_throw_out_subdivisions
+    @Rainbows.instance_variable_set(:@subjects,
+                                    ['LCSH--may subdivide geographically'])
+
+    subj = @Rainbows.normalize_subjects
+    assert subj.present?
+    assert_equal(['lcsh'], subj)
+  end
+
+  def test_that_subjects_strip_whitespace
+    @Rainbows.instance_variable_set(:@subjects, ['whitespace '])
+
+    subj = @Rainbows.normalize_subjects
+    assert subj.present?
+    assert_equal(['whitespace'], subj)
+  end
+
+  def test_that_subjects_strip_whitespace_when_subdivided
+    @Rainbows.instance_variable_set(:@subjects,
+                                    ['LCSH -- may subdivide geographically'])
+
+    subj = @Rainbows.normalize_subjects
+    assert subj.present?
+    assert_equal(['lcsh'], subj)
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ pride ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  def test_that_pride_true_with_good_keyword
+    @Rainbows.instance_variable_set(:@subjects, '')
+    @Rainbows.instance_variable_set(:@keywords, ['gender identities'])
+
+    assert @Rainbows.pride?
+  end
+
+  def test_that_pride_true_with_good_subject
+    @Rainbows.instance_variable_set(:@record, nil)
+    @Rainbows.instance_variable_set(:@subjects,
+                                    ['butch and femme (lesbian culture)'])
+
+    assert @Rainbows.pride?
+  end
+
+  def test_that_pride_true_with_good_subject_and_keyword
+    @Rainbows.instance_variable_set(:@keywords, ['gender identities'])
+    @Rainbows.instance_variable_set(:@subjects,
+                                    ['butch and femme (lesbian culture)'])
+
+    assert @Rainbows.pride?
+  end
+
+  def test_that_pride_false_without_subject_or_keyword
+    @Rainbows.instance_variable_set(:@keywords, ['no rainbows'])
+    @Rainbows.instance_variable_set(:@subjects,
+                                    ['extremely straight and cis people'])
+
+    # assert_not is unavailable since this subclasses MiniTest::Test, not Rails
+    # testing stuff.
+    assert !@Rainbows.pride?
+  end
+end

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -21,4 +21,13 @@ class RecordControllerTest < ActionController::TestCase
       end
     end
   end
+
+  test 'clean_keywords' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get :record, params: { db_source: 'aci', an: '123877356' }
+
+      assert_equal(['Carbon Nanotube Biosensors', 'Field Effect Transistors', 'IL6'],
+                    @controller.instance_variable_get(:@keywords))
+    end
+  end
 end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+include RecordHelper
+
+class RecordHelperTest < ActionView::TestCase
+  test 'clean_language case 1' do
+    mock_record = stub(:eds_languages => 'English, Russian')
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['English', 'Russian'], controller.clean_language)
+  end
+
+  test 'clean_language case 2' do
+    mock_record = stub(:eds_languages => ['English', 'Russian'])
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['English', 'Russian'], controller.clean_language)
+  end
+
+  test 'clean_language case 3' do
+    mock_record = stub(:eds_languages => 'English')
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['English'], controller.clean_language)
+  end
+
+  test 'clean_language case 4' do
+    mock_record = stub(:eds_languages => ['English'])
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['English'], controller.clean_language)
+  end
+
+  test 'clean_affiliations' do
+    affiliations = <<-DOC
+    <relatesTo>1</relatesTo>Small
+            Systems Laboratory, Department of Mechanical Engineering, Worcester Polytechnic
+            Institute, Worcester, MA 01532, USA
+DOC
+    affiliations = affiliations.gsub(/\s+/, " ").strip
+    mock_record = stub(:eds_author_affiliations => affiliations)
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['Small Systems Laboratory, Department of Mechanical Engineering, Worcester Polytechnic Institute, Worcester, MA 01532, USA'],
+                  controller.clean_affiliations)
+
+  end
+
+  test 'clean_other_titles' do
+    titles = <<-DOC
+    <searchLink fieldCode="TI" term="%22Jungle+capitalists%22">
+    Jungle capitalists</searchLink>
+DOC
+    titles = titles.gsub(/\s+/, " ").strip
+    mock_record = stub(:eds_other_titles => titles)
+    controller.instance_variable_set(:@record, mock_record)
+
+    assert_equal(['Jungle capitalists'],
+                  controller.clean_other_titles)
+
+  end
+end

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -82,10 +82,156 @@ class RecordTest < ActionDispatch::IntegrationTest
 
   test 'check for view online button shown when SFX URL is fulltext' do
     VCR.use_cassette('record: sfx fulltext', allow_playback_repeats: true) do
-      get record_url, params: { db_source: 'mdc', an: '28632713' }
+      get record_url, params: { db_source: 'lxh', an: '102229662' }
       assert_response :success
       assert_select 'a.button-primary', text: 'View online'
       assert_select 'a', text: 'Check for online copy', count: 0
+    end
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~ tests of 'more information' section ~~~~~~~~~~~~~~~~~~~
+  # For the following tests, note that not all information is available for all
+  # sources.
+  test 'document type is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Document type: Academic Journal'
+    end
+  end
+
+  test 'source is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Source: Biosensors (2079-6374)'
+    end
+  end
+
+  test 'authors are shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Khosravi, Farhad'
+      assert @response.body.include? 'Loeian, Seyed Masoud'
+      assert @response.body.include? 'Panchapakesan, Balaji'
+    end
+  end
+
+  test 'author affiliations are shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Small Systems Laboratory, Department of Mechanical Engineering, Worcester Polytechnic Institute, Worcester, MA 01532, USA'
+    end
+  end
+
+  test 'publication info is shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'Publication info: Edinburgh ; New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group West, c2007.'
+    end
+  end
+
+  test 'issn is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'ISSN: 20796374'
+    end
+  end
+
+  test 'isbn is shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'ISBN: 9781841958811'
+    end
+  end
+
+  test 'doi is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'DOI: 10.3390/bios7020017'
+    end
+  end
+
+  test 'language is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.gsub(/\s+/, " ").include? 'Language: English'
+    end
+  end
+
+  test 'physical description is shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'Physical description: xv, 224 p. : map ; 21 cm.'
+    end
+  end
+
+  test 'database is shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'Database: MIT Barton Catalog'
+    end
+  end
+
+  test 'subjects are shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Carbon nanotubes'
+      assert @response.body.include? 'Biosensors'
+      assert @response.body.include? 'Molecular recognition'
+    end
+  end
+
+  test 'keywords are shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'Carbon Nanotube Biosensors'
+      assert @response.body.include? 'Field Effect Transistors'
+      assert @response.body.include? 'IL6'
+    end
+  end
+
+  test 'abstract is shown' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response :success
+      assert @response.body.include? 'This study demonstrates the rapid and label-free detection of Interleukin-6'
+    end
+  end
+
+  test 'notes are shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'Originally published as: Jungle capitalists.'
+    end
+  end
+
+  test 'other titles are shown' do
+    VCR.use_cassette('record: book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response :success
+      assert @response.body.include? 'Other titles'
+    end
+  end
+
+  test 'should be able to display rainbows' do
+    get '/toggle/?feature=pride'
+    VCR.use_cassette('record: rainbows', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'qth', an: '17660728' }
+      assert_response :success
+      assert_select 'div.reasons'
     end
   end
 end

--- a/test/vcr_cassettes/record_not_fulltext.yml
+++ b/test/vcr_cassettes/record_not_fulltext.yml
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Sep 2017 20:33:58 GMT
+      - Wed, 20 Sep 2017 18:11:22 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
     http_version: 
-  recorded_at: Tue, 19 Sep 2017 20:32:43 GMT
+  recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: get
     uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
@@ -80,7 +80,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Sep 2017 20:33:59 GMT
+      - Wed, 20 Sep 2017 18:11:23 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -88,20 +88,20 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - 693291fa-ff43-4d61-b859-2a36a71e1077
+      - 8c663132-3986-4086-b226-053c91511d16
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '1601328783'
+      - "-1695688900"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
-      - '101'
+      - '100'
     body:
       encoding: UTF-8
-      string: '{"SessionToken":"c611749c-4440-40a6-9b12-14a70423dbc7.bJEDAX3cvjPJdqpwU6ozWjK77HEhizlyUO\/kXvHJGno="}'
+      string: '{"SessionToken":"FakeSessiontoken"}'
     http_version: 
-  recorded_at: Tue, 19 Sep 2017 20:32:43 GMT
+  recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: get
     uri: https://eds-api.ebscohost.com/edsapi/rest/Info
@@ -135,7 +135,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Sep 2017 20:33:59 GMT
+      - Wed, 20 Sep 2017 18:11:22 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -143,15 +143,15 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - 1a88a7de-9f11-4634-855b-d978d2645afd
+      - c7d00324-fe34-4010-b103-917ecf7b0238
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '1601328783'
+      - "-1695688900"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
-      - '3631'
+      - '3632'
     body:
       encoding: UTF-8
       string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"date","Label":"Date
@@ -161,9 +161,9 @@ http_interactions:
         equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"},{"Id":"thesaurus","Label":"Apply
         related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
         search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
-        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"TI","Label":"Reviewed
-        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"2"},{"Id":"FR","Label":"References
-        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"2"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
         Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
         Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
         Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
@@ -238,7 +238,7 @@ http_interactions:
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
     http_version: 
-  recorded_at: Tue, 19 Sep 2017 20:32:43 GMT
+  recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: post
     uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
@@ -272,7 +272,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 19 Sep 2017 20:33:59 GMT
+      - Wed, 20 Sep 2017 18:11:22 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -280,11 +280,11 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - 78c437c6-1771-4a00-83f2-628d7c5a9762
+      - ef729e02-0f0d-4adb-97f9-66fe3029e509
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '1601328783'
+      - "-1695688900"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
@@ -320,5 +320,5 @@ http_interactions:
         2016","Type":"published","Y":"2017"}],"Identifiers":[{"Type":"issn-electronic","Value":"00296554"}],"Titles":[{"TitleFull":"Nursing
         Outlook","Type":"main"}]}}]}}}}}'
     http_version: 
-  recorded_at: Tue, 19 Sep 2017 20:32:44 GMT
+  recorded_at: Wed, 20 Sep 2017 18:11:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_rainbows.yml
+++ b/test/vcr_cassettes/record_rainbows.yml
@@ -33,7 +33,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 20 Sep 2017 18:02:29 GMT
+      - Fri, 22 Sep 2017 16:22:00 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -46,7 +46,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
     http_version: 
-  recorded_at: Wed, 20 Sep 2017 18:02:28 GMT
+  recorded_at: Fri, 22 Sep 2017 16:07:48 GMT
 - request:
     method: get
     uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
@@ -80,7 +80,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 20 Sep 2017 18:02:29 GMT
+      - Fri, 22 Sep 2017 16:22:00 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -88,20 +88,20 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - 34cd0221-53f7-4fff-b58c-ef85fa2a11d5
+      - d2b2b982-c354-4646-9b27-35520311f744
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '856068910'
+      - "-746598171"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
-      - '101'
+      - '100'
     body:
       encoding: UTF-8
-      string: '{"SessionToken":"ab36405d-1eec-4265-a2d0-bcf9efb17f6f.xvYgOzyKEsR8eR62HZh\/EsIeysYnGqhfYg1DA7p4HHo="}'
+      string: '{"SessionToken":"FakeSessiontoken"}'
     http_version: 
-  recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
+  recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 - request:
     method: get
     uri: https://eds-api.ebscohost.com/edsapi/rest/Info
@@ -135,7 +135,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 20 Sep 2017 18:02:29 GMT
+      - Fri, 22 Sep 2017 16:22:01 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -143,11 +143,11 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - fedd1fd3-3abe-409d-b8eb-0e900d559b27
+      - eebac749-6528-462e-842d-4c39d0c9f20c
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '856068910'
+      - "-746598171"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
@@ -238,13 +238,13 @@ http_interactions:
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
     http_version: 
-  recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
+  recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 - request:
     method: post
     uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
     body:
       encoding: UTF-8
-      string: '{"DbId":"lxh","An":"102229662","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+      string: '{"DbId":"qth","An":"17660728","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
     headers:
       Content-Type:
       - application/json;charset=UTF-8
@@ -272,7 +272,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 20 Sep 2017 18:02:29 GMT
+      - Fri, 22 Sep 2017 16:22:01 GMT
       Server:
       - Microsoft-IIS/8.5
       X-Aspnet-Version:
@@ -280,59 +280,60 @@ http_interactions:
       X-Authenticationtoken:
       - FakeAuthenticationtoken
       X-Msg-Correlid:
-      - a803a9f3-2398-4e3e-8507-4fc517e16dcc
+      - 520b98e3-9cdc-4ba0-a488-41f4e04d8194
       X-Powered-By:
       - ASP.NET
       X-Sessionno:
-      - '856068910'
+      - "-746598171"
       X-Sessiontoken:
       - FakeSessiontoken
       Content-Length:
-      - '2182'
+      - '2095'
     body:
       encoding: UTF-8
-      string: '{"Record":{"ResultId":1,"Header":{"DbId":"lxh","DbLabel":"Library,
-        Information Science & Technology Abstracts","An":"102229662","PubType":"Academic
-        Journal","PubTypeId":"academicJournal"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=lxh&AN=102229662&authtype=sso&custid=s8978330","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/owens.mit.edu\/sfx_local?genre=article&isbn=&issn=19405758&title=Code4Lib
-        Journal&volume=&issue=28&date=20150415&atitle=Feminism%20and%20the%20Future%20of%20Library%20Discovery.&aulast=Sadler,
-        Bess&spage=1&sid=EBSCO:Library%2C%20Information%20Science%20%26%20Technology%20Abstracts&pid=<authors>Sadler,
-        Bess<\/authors><ui>102229662<\/ui><date>20150415<\/date><db>Library%2C%20Information%20Science%20%26%20Technology%20Abstracts<\/db>","Name":"SFX
-        link filtered to collection fthi1 (For su)","Category":"fullText","Text":"","Icon":"http:\/\/libraries.mit.edu\/img\/sfx\/sfx-mit.gif"}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Feminism
-        and the Future of Library Discovery."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
-        fieldCode=&quot;AR&quot; term=&quot;%22Sadler%2C+Bess%22&quot;&gt;Sadler,
-        Bess&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;AR&quot;
-        term=&quot;%22Bourg%2C+Chris%22&quot;&gt;Bourg, Chris&lt;\/searchLink&gt;&lt;relatesTo&gt;1&lt;\/relatesTo&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"&lt;searchLink
-        fieldCode=&quot;JN&quot; term=&quot;%22Code4Lib+Journal%22&quot;&gt;Code4Lib
-        Journal&lt;\/searchLink&gt;. 2015, Issue 28, p1-1. 1p."},{"Name":"TypeDocument","Label":"Document
-        Type","Group":"TypDoc","Data":"Article"},{"Name":"Subject","Label":"Subject
-        Terms","Group":"Su","Data":"*&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Libraries%22&quot;&gt;Libraries&lt;\/searchLink&gt;&lt;br
-        \/&gt;*&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Librarians%22&quot;&gt;Librarians&lt;\/searchLink&gt;&lt;br
-        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Feminism%22&quot;&gt;Feminism&lt;\/searchLink&gt;&lt;br
-        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Women&#39;s+rights%22&quot;&gt;Women&#39;s
-        rights&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
-        term=&quot;%22Feminist+psychology%22&quot;&gt;Feminist psychology&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"This
-        paper discusses the various ways in which the practices of libraries and librarians
-        influence the diversity (or lack thereof) of scholarship and information access.
-        We examine some of the cultural biases inherent in both library classification
-        systems and newer forms of information access like Google search algorithms,
-        and propose ways of recognizing bias and applying feminist principles in the
-        design of information services for scholars, particularly as libraries re-invent
-        themselves to grapple with digital collections. [ABSTRACT FROM AUTHOR]"},{"Name":"AbstractSuppliedCopyright","Label":"","Group":"","Data":"&lt;i&gt;Copyright
-        of Code4Lib Journal is the property of Code4Lib Journal and its content may
-        not be copied or emailed to multiple sites or posted to a listserv without
-        the copyright holder&#39;s express written permission. However, users may
-        print, download, or email articles for individual use. This abstract may be
-        abridged. No warranty is given about the accuracy of the copy. Users should
-        refer to the original published version of the material for the full abstract.&lt;\/i&gt;
-        (Copyright applies to all Abstracts.)"},{"Name":"AffiliationAuthor","Label":"Author
-        Affiliations","Group":"AuInfo","Data":"&lt;relatesTo&gt;1&lt;\/relatesTo&gt;Director
-        of Libraries at Massachusetts Institute of Technology (MIT)"},{"Name":"FullTextWordCount","Label":"Full
-        Text Word Count","Group":"FTInfo","Data":"3214"},{"Name":"ISSN","Label":"ISSN","Group":"ISSN","Data":"1940-5758"},{"Name":"AN","Label":"Accession
-        Number","Group":"ID","Data":"102229662"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"1","StartPage":"1"}},"Subjects":[{"SubjectFull":"Libraries","Type":"general"},{"SubjectFull":"Librarians","Type":"general"},{"SubjectFull":"Feminism","Type":"general"},{"SubjectFull":"Women''s
-        rights","Type":"general"},{"SubjectFull":"Feminist psychology","Type":"general"}],"Titles":[{"TitleFull":"Feminism
-        and the Future of Library Discovery.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Sadler,
-        Bess"}}},{"PersonEntity":{"Name":{"NameFull":"Bourg, Chris"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"15","M":"04","Text":"2015","Type":"published","Y":"2015"}],"Identifiers":[{"Type":"issn-print","Value":"19405758"}],"Numbering":[{"Type":"issue","Value":"28"}],"Titles":[{"TitleFull":"Code4Lib
-        Journal","Type":"main"}]}}]}}}}}'
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"qth","DbLabel":"LGBT Life
+        with Full Text","An":"17660728","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=qth&AN=17660728&authtype=sso&custid=s8978330","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=book&atitle=&title=The%20Organizational%20Shaping%20of%20Collective%20Identity%3A%20The%20Case%20of%20Lesbian%20and%20Gay%20Film%20Festivals%20in%20New%20York.&isbn=9780814718759&volume=&issue=&date=19970101&aulast=Gamson,
+        Joshua&spage=526&pages=526-543&sid=EBSCO:LGBT%20Life%20with%20Full%20Text:17660728","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability."}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"The
+        Organizational Shaping of Collective Identity: The Case of Lesbian and Gay
+        Film Festivals in New York."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Gamson%2C+Joshua%22&quot;&gt;Gamson,
+        Joshua&lt;\/searchLink&gt;&lt;relatesTo&gt;1&lt;\/relatesTo&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Duberman%2C+Martin%22&quot;&gt;Duberman,
+        Martin&lt;\/searchLink&gt;&lt;relatesTo&gt;2,3&lt;\/relatesTo&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"&lt;searchLink
+        fieldCode=&quot;JN&quot; term=&quot;%22Queer+World%3A+The+Center+for+Lesbian+%26+Gay+Studies+Reader%22&quot;&gt;Queer
+        World: The Center for Lesbian &amp; Gay Studies Reader&lt;\/searchLink&gt;.
+        1997, p526-543. 18p."},{"Name":"TypeDocument","Label":"Document Type","Group":"TypDoc","Data":"Article"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"*&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Adaptability+%28Psychology%29%22&quot;&gt;Adaptability
+        (Psychology)&lt;\/searchLink&gt;&lt;br \/&gt;*&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Gay+%26+lesbian+film+festivals%22&quot;&gt;Gay &amp; lesbian
+        film festivals&lt;\/searchLink&gt;&lt;br \/&gt;*&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22LGBT+film+festivals%22&quot;&gt;LGBT film festivals&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Organization%22&quot;&gt;Organization&lt;\/searchLink&gt;"},{"Name":"SubjectGeographic","Label":"Geographic
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22New+York+%28State%29%22&quot;&gt;New
+        York (State)&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"This
+        article analyzes the organizational adaptations to the external environment
+        using the case of lesbian and gay film festivals in New York as basis. The
+        shifting opportunities provided by the discovery of gay film as an artistic
+        and commercial genre, most prominently, have made pursuits of higher cultural
+        capital and demonstrations of consumer group status smart survival strategies.
+        But these are not incidental inward moves. Success in the organizational field
+        appears to favor identity formulations that are less explicitly oppositional
+        and it is tempting to assert that this trajectory is a generalizable one."},{"Name":"AffiliationAuthor","Label":"Author
+        Affiliations","Group":"AuInfo","Data":"&lt;relatesTo&gt;1&lt;\/relatesTo&gt;Assistant
+        professor of sociology, Yale University&lt;br \/&gt;&lt;relatesTo&gt;2&lt;\/relatesTo&gt;Distinguished
+        Professor of History, Lehman College and the Graduate Center of the City University
+        of New York&lt;br \/&gt;&lt;relatesTo&gt;3&lt;\/relatesTo&gt;Founder, Center
+        for Lesbian and Gay Studies (CLAGS)"},{"Name":"ISBN","Label":"ISBN","Group":"ISBN","Data":"9780814718759"},{"Name":"AN","Label":"Accession
+        Number","Group":"ID","Data":"17660728"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"18","StartPage":"526"}},"Subjects":[{"SubjectFull":"Adaptability
+        (Psychology)","Type":"general"},{"SubjectFull":"Gay & lesbian film festivals","Type":"general"},{"SubjectFull":"LGBT
+        film festivals","Type":"general"},{"SubjectFull":"Organization","Type":"general"},{"SubjectFull":"New
+        York (State)","Type":"general"}],"Titles":[{"TitleFull":"The Organizational
+        Shaping of Collective Identity: The Case of Lesbian and Gay Film Festivals
+        in New York.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Gamson,
+        Joshua"}}},{"PersonEntity":{"Name":{"NameFull":"Duberman, Martin"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Text":"1997","Type":"published","Y":"1997"}],"Identifiers":[{"Type":"isbn-print","Value":"9780814718759"}],"Titles":[{"TitleFull":"Queer
+        World: The Center for Lesbian & Gay Studies Reader","Type":"main"}]}}]}}}}}'
     http_version: 
-  recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
+  recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Adds the more-information section to the full record page. See wireframes: https://mitlibraries.atlassian.net/wiki/spaces/DI/pages/32833537/Full+record

Does *not* make it pretty - that will be for @frrrances later.

Super secretly also adds the feature we discussed with CB at Randi's party. Shhh, don't tell her yet. 

#### How can a reviewer manually see the effects of these changes?

To see the effect of the 479 work: PR build, toggle feature `local_full_record` on, look at item record pages. Behold! Information!

To see the super secret bonus feature: PR build, toggle feature `pride` on, find something with LGBT subject headers. 🌈 !

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-479

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
