### PR TITLE
Local serial availability

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -3,21 +3,6 @@ module RecordHelper
     aleph_record? || aleph_cr_record?
   end
 
-  # determines if an item is serial-ish or monograph-ish to help us determine
-  # if we should use holdings records or item records for realtime status
-  def non_serial?
-    if book_like.include?(@record.eds_publication_type)
-      true
-    else
-      false
-    end
-  end
-
-  # Publication types that we want to treat like books
-  def book_like
-    ['Book', 'Audio', 'Video Recording']
-  end
-
   # Link to local source record
   def local_record_source_url
     if aleph_record?

--- a/app/views/aleph/_list_local_locations.html.erb
+++ b/app/views/aleph/_list_local_locations.html.erb
@@ -1,0 +1,68 @@
+<ul class="list-local-locations">
+<% @status.each do |s| %>
+  <li class="result-local-location">
+    <div class="location-wrap">
+      <span class="location">
+        <span class="library"><%= s[:library] %></span>
+        <span class="collection"><%= s[:collection] %>:</span>
+        <span class="callno"><%= s[:call_number] %></span>
+        <span class="desc">
+          <% if s[:description].present? %> <%= s[:description] %> <% end %>
+        </span>
+        <span class="sr"><%= s[:label] %></span>
+      </span>
+      <span class="location-actions">
+        <a href="<%= map_link(s[:library]) %>"
+           class="btn button-subtle map-link">
+           <i class="fa fa-map-marker" aria-hidden="true"></i>
+           <span class="sr">View <%= s[:library] %> location map</span>
+        </a>
+      </span>
+    </div>
+    <div class="availability-wrap">
+
+      <% if s[:available?] %>
+        <span class="availability-status">
+          <i class="fa fa-check" aria-hidden="true"></i>
+          Available
+        </span>
+        <span class="availability-actions">
+
+          <% if archives?(s[:library]) %>
+
+            <a class="btn button-secondary button-small" href="https://libraries.mit.edu/archives/">Contact Us</a>
+
+          <% elsif reserve?(s[:collection]) %>
+
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
+
+          <% elsif media?(s[:call_number]) %>
+
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
+
+          <% else %>
+
+            <a class="btn button-secondary button-small" href="">Place Hold</a>
+
+            <a class="btn button-secondary button-small" href="">Request Scan</a>
+
+          <% end %>
+
+        </span>
+
+      <% else %>
+        <span class="availability-status">
+          <i class="fa fa-times" aria-hidden="true"></i>
+          Not available at MIT
+        </span>
+        <span class="availability-actions">
+          <a class="btn button-subtle button-small" href="">Recall (7+ days)</a>
+          <a class="btn button-secondary button-small" href="">Get it with ILL (3-4 days)</a>
+        </span>
+
+      <% end %>
+
+    </div>
+  </li>
+<% end %>
+</ul>

--- a/app/views/aleph/full_item_status.html.erb
+++ b/app/views/aleph/full_item_status.html.erb
@@ -1,69 +1,17 @@
 <p class="sr">Library locations: </p>
-<ul class="list-local-locations">
-<% @status.each do |s| %>
-  <li class="result-local-location">
-    <div class="location-wrap">
-      <span class="location">
-        <span class="library"><%= s[:library] %></span>
-        <span class="collection"><%= s[:collection] %>:</span>
-        <span class="callno"><%= s[:call_number] %></span>
-        <span class="desc">
-          <% if s[:description].present? %> <%= s[:description] %> <% end %> 
-        </span>
-        <span class="sr"><%= s[:label] %></span> 
-      </span>
-      <span class="location-actions">
-        <a href="<%= map_link(s[:library]) %>"
-           class="btn button-subtle map-link">
-           <i class="fa fa-map-marker" aria-hidden="true"></i>
-           <span class="sr">View <%= s[:library] %> location map</span>
-        </a>        
-      </span>
-    </div>
-    <div class="availability-wrap">
 
-      <% if s[:available?] %>
-        <span class="availability-status">
-          <i class="fa fa-check" aria-hidden="true"></i>
-          Available
-        </span>
-        <span class="availability-actions">
-
-          <% if archives?(s[:library]) %>
-
-            <a class="btn button-secondary button-small" href="https://libraries.mit.edu/archives/">Contact Us</a>
-
-          <% elsif reserve?(s[:collection]) %>
-
-            <a class="btn button-secondary button-small" href="">Place Hold</a>
-
-          <% elsif media?(s[:call_number]) %>
-
-            <a class="btn button-secondary button-small" href="">Place Hold</a>
-
-          <% else %>
-
-            <a class="btn button-secondary button-small" href="">Place Hold</a>
-
-            <a class="btn button-secondary button-small" href="">Request Scan</a>
-
-          <% end %>
-
-        </span>
-
-      <% else %>
-        <span class="availability-status">
-          <i class="fa fa-times" aria-hidden="true"></i>
-          Not available at MIT
-        </span>
-        <span class="availability-actions">
-          <a class="btn button-subtle button-small" href="">Recall (7+ days)</a>
-          <a class="btn button-secondary button-small" href="">Get it with ILL (3-4 days)</a>
-        </span>
-
-      <% end %>
-
-    </div>
-  </li>
+<%# this conditionally opens two divs that are conditional closed below %>
+<% if @status.count > 5 %>
+<div class="expand-collapse-wrap is-collapsed">
+  <p class="expand-collapse-control"><button class="button">See more</button></p>
+  <div class="expand-container">
 <% end %>
-</ul>
+
+    <%= render partial: "list_local_locations" %>
+
+<%# this conditionally closes two divs that are conditional open above %>
+<% if @status.count > 5 %>
+  </div>
+</div>
+<script>Toggler();</script>
+<% end %>

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -1,4 +1,4 @@
-<h3 class="subtitle3">Availability</h2>
+<h2 class="subtitle2">Availability</h2>
 <% if @record.fulltext_link.present? %>
   <% if check_online? %>
     <a href="<%= @record.fulltext_link[:url] %>">Check for online copy</a>
@@ -7,13 +7,22 @@
   <% end %>
 <% end %>
 
+<%# using try instead of .present? due to how edsapi dynamically adds this
+    element. It's either there or a no method error. %>
+<% if @record.try(:eds_extras_TOC) %>
+  <div id="full-holdings" class="discovery-full-record-holdings-info">
+    <h3 class="subtitle3">Holdings</h3>
+    <%# todo: this will need updating once Ebsco resolves a data mapping
+        problem described here
+        https://mitlibraries.atlassian.net/browse/DI-547 %>
+    <%= @record.eds_extras_TOC %>
+  </div>
+<% end %>
+
 <%# This div id is used by the javascript - don't move or change it.) %>
 <div id="full-avail" class="discovery-full-record-availability-info">
   <% if local_record? %>
-    <% if non_serial? %>
-      <script>RealtimeItem( "<%= clean_an %>" );</script>
-    <% else %>
-      Call for realtime holdings instead of items. (coming soon!)
-    <% end %>
+    Loading availability information <i class="fa fa-spinner fa-spin"></i>
+    <script>RealtimeItem( "<%= clean_an %>" );</script>
   <% end %>
 </div>

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -89,6 +89,21 @@ class RecordTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'summary holdings are shown when available' do
+    VCR.use_cassette('record: journal', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.000292123' }
+      assert_select 'div#full-holdings'
+      assert @response.body.include? 'v.1 (1946)- v.115:p.1315-2560 (2010)'
+    end
+  end
+
+  test 'summary holdings are not shown when not available' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_select('div#full-holdings', false)
+    end
+  end
+
   # ~~~~~~~~~~~~~~~~~~~ tests of 'more information' section ~~~~~~~~~~~~~~~~~~~
   # For the following tests, note that not all information is available for all
   # sources.


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Removes condition that prevented local serials records from getting realtime availability displays.

Adds support for collapsible availability lists.

#### How can a reviewer manually see the effects of these changes?

Both features this adds can be seen here:
https://mit-bento-staging-pr-260.herokuapp.com/record/cat00916a/mit.000953977

And comparing to:
https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.000953977

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-512 (completed with this work)
- https://mitlibraries.atlassian.net/browse/DI-503 (completed with this work)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO