### PR TITLE
497 login prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Search API. Appropriate credentials for both are required (see below).
 ## Bento System Overview
 ![alt text](docs/charts/bento_overview.png "Bento system overview chart")
 
+## Authentication Flow and Guest Mode Details
+
+https://mitlibraries.atlassian.net/wiki/x/CoAeAw
+
 ## Loading Hints
 
 Tasks exist to reload hints from supported sources.

--- a/app.json
+++ b/app.json
@@ -56,6 +56,9 @@
     "MAX_AUTHORS": {
       "required": true
     },
+    "PROXY_PREFIX": {
+      "required": true
+    },
     "RACK_ENV": {
       "required": true
     },

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -30,7 +30,7 @@ class RecordController < ApplicationController
     session = EBSCO::EDS::Session.new(user: ENV['EDS_USER_ID'],
                                       pass: ENV['EDS_PASSWORD'],
                                       profile: ENV['EDS_PROFILE'],
-                                      guest: false, # this will be dynamic soon
+                                      guest: helpers.guest?,
                                       org: 'mit',
                                       use_cache: false)
     @record = session.retrieve(dbid: @record_source, an: @record_an)

--- a/app/helpers/login_helper.rb
+++ b/app/helpers/login_helper.rb
@@ -1,0 +1,11 @@
+module LoginHelper
+  # Authentication Flow and Guest Mode documentation is available
+  # https://mitlibraries.atlassian.net/wiki/x/CoAeAw
+  def login_url
+    if !Rails.env.production?
+      request.original_url + '?guest=false'
+    else
+      ENV['PROXY_PREFIX'] + request.original_url
+    end
+  end
+end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -107,4 +107,9 @@ module RecordHelper
   def safe_output(input)
     sanitize Nokogiri::HTML.fragment(CGI.unescapeHTML(input)).to_s
   end
+
+  # User is a guest and the link is restricted
+  def guest_and_restricted_link?
+    guest? && @record.fulltext_link[:url] == 'detail'
+  end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -11,7 +11,11 @@ module SearchHelper
 
   # Current request IP is outside our campus range
   def guest?
-    !member?
+    if !Rails.env.production? && params[:guest].present?
+      params[:guest] == 'true'
+    else
+      !member?
+    end
   end
 
   # Current request IP is included in our campus range

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -2,6 +2,8 @@
 <% if @record.fulltext_link.present? %>
   <% if check_online? %>
     <a href="<%= @record.fulltext_link[:url] %>">Check for online copy</a>
+  <% elsif guest_and_restricted_link? %>
+    <a href="<%= login_url %>">Sign in for full text link</a>
   <% else %>
     <a href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>
   <% end %>

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -6,6 +6,12 @@
 <div class="gridband layout-3q1q">
   <div class="col3q box-content region" data-region="Full record">
 
+    <% if guest? %>
+      <div class="alert alert-banner warning">
+        <a href="<%= login_url %>">Sign in for full access</a>
+      </div>
+    <% end %>
+
     <div class="discovery-full-record-basic-info">
       <%= render partial: "basic_info" %>
     </div>

--- a/test/vcr_cassettes/record_article.yml
+++ b/test/vcr_cassettes/record_article.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"cb9c84e2-5928-4792-bdd3-5037e052140a.6vrfaGQCvB63gAaxFquqrDzQLkYOlFvsB1mZCK\/d3KU="}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
 - request:
     method: post
@@ -361,6 +361,6 @@ http_interactions:
         Farhad"}}},{"PersonEntity":{"Name":{"NameFull":"Loeian, Seyed Masoud"}}},{"PersonEntity":{"Name":{"NameFull":"Panchapakesan,
         Balaji"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"06","Text":"Jun2017","Type":"published","Y":"2017"}],"Identifiers":[{"Type":"issn-print","Value":"20796374"}],"Numbering":[{"Type":"volume","Value":"7"},{"Type":"issue","Value":"2"}],"Titles":[{"TitleFull":"Biosensors
         (2079-6374)","Type":"main"}]}}]}}}}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:43 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_bananas.yml
+++ b/test/vcr_cassettes/record_bananas.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"FakeSessiontoken"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:07 GMT
 - request:
     method: post
@@ -351,6 +351,6 @@ http_interactions:
         Peter"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2007"}],"Identifiers":[{"Type":"isbn-print","Value":"9781841958811"},{"Type":"isbn-print","Value":"1841958816"}],"Titles":[{"TitleFull":"Bananas
         : how the United Fruit Company shaped the world \/ Peter Chapman.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
         Library - Stacks","ShelfLocator":"HD9259.B3.U523 2007b"}]}}]}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:07 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_book.yml
+++ b/test/vcr_cassettes/record_book.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:43 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"FakeSessiontoken"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:43 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:43 GMT
 - request:
     method: post
@@ -351,6 +351,6 @@ http_interactions:
         Peter"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2007"}],"Identifiers":[{"Type":"isbn-print","Value":"9781841958811"},{"Type":"isbn-print","Value":"1841958816"}],"Titles":[{"TitleFull":"Bananas
         : how the United Fruit Company shaped the world \/ Peter Chapman.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
         Library - Stacks","ShelfLocator":"HD9259.B3.U523 2007b"}]}}]}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:44 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_course_reserve.yml
+++ b/test/vcr_cassettes/record_course_reserve.yml
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Wed, 13 Sep 2017 16:38:16 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''

--- a/test/vcr_cassettes/record_journal.yml
+++ b/test/vcr_cassettes/record_journal.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:44 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"FakeSessiontoken"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:44 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:44 GMT
 - request:
     method: post
@@ -331,6 +331,6 @@ http_interactions:
         -- Periodicals","Type":"general"},{"SubjectFull":"Hematology -- Periodicals","Type":"general"}],"Titles":[{"TitleFull":"Blood.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"American
         Society of Hematology."}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1946"}],"Identifiers":[{"Type":"issn-print","Value":"00064971"}],"Titles":[{"TitleFull":"Blood.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Library
         Storage Annex - Off Campus Collection","ShelfLocator":"RB.B655"}]}}]}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:07:45 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_no_such_database.yml
+++ b/test/vcr_cassettes/record_no_such_database.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:07 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"a051211c-479e-4eab-a05a-7079e1f20498.9A137+3PeI25e\/KVs8HZ2ApBhnKY5XDegexqrriEu4M="}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:08 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
 - request:
     method: post
@@ -293,6 +293,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"DetailedErrorDescription":"DbId dog00916a not available for profile
         FAKE_EDS_PROFILE.","ErrorDescription":"DbId Not In Profile","ErrorNumber":"135"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_not_fulltext.yml
+++ b/test/vcr_cassettes/record_not_fulltext.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"FakeSessiontoken"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:11:22 GMT
 - request:
     method: post
@@ -319,6 +319,6 @@ http_interactions:
         Kimberly R."}}},{"PersonEntity":{"Name":{"NameFull":"Peterson, Shenita R."}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"05","M":"03","Text":"Nov
         2016","Type":"published","Y":"2017"}],"Identifiers":[{"Type":"issn-electronic","Value":"00296554"}],"Titles":[{"TitleFull":"Nursing
         Outlook","Type":"main"}]}}]}}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:11:23 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_rainbows.yml
+++ b/test/vcr_cassettes/record_rainbows.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 22 Sep 2017 16:07:48 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"FakeSessiontoken"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 - request:
     method: post
@@ -334,6 +334,6 @@ http_interactions:
         in New York.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Gamson,
         Joshua"}}},{"PersonEntity":{"Name":{"NameFull":"Duberman, Martin"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Text":"1997","Type":"published","Y":"1997"}],"Identifiers":[{"Type":"isbn-print","Value":"9780814718759"}],"Titles":[{"TitleFull":"Queer
         World: The Center for Lesbian & Gay Studies Reader","Type":"main"}]}}]}}}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 22 Sep 2017 16:07:49 GMT
 recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/record_sfx_fulltext.yml
+++ b/test/vcr_cassettes/record_sfx_fulltext.yml
@@ -45,11 +45,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:02:28 GMT
 - request:
     method: get
-    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
     body:
       encoding: US-ASCII
       string: ''
@@ -100,7 +100,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"SessionToken":"ab36405d-1eec-4265-a2d0-bcf9efb17f6f.xvYgOzyKEsR8eR62HZh\/EsIeysYnGqhfYg1DA7p4HHo="}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
 - request:
     method: get
@@ -237,7 +237,7 @@ http_interactions:
         Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
         Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
         You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
 - request:
     method: post
@@ -333,6 +333,6 @@ http_interactions:
         and the Future of Library Discovery.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Sadler,
         Bess"}}},{"PersonEntity":{"Name":{"NameFull":"Bourg, Chris"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"15","M":"04","Text":"2015","Type":"published","Y":"2015"}],"Identifiers":[{"Type":"issn-print","Value":"19405758"}],"Numbering":[{"Type":"issue","Value":"28"}],"Titles":[{"TitleFull":"Code4Lib
         Journal","Type":"main"}]}}]}}}}}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 20 Sep 2017 18:02:29 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Activates guest mode for full record views.

Provides links to proxy site in production and override guest mode in development/test.

#### How can a reviewer manually see the effects of these changes?

From a non-MIT IP access restricted records and records with expiring direct links.

https://mit-bento-staging-pr-262.herokuapp.com/record/mdc/25750248

From a non-MIT IP, instead of a direct PDFLINK, you'll see a link to sign in. Once signed in, you'll get the direct PDFLINK.

Any other redacted information should automatically be suppressed by the guest mode included in this PR (but I don't have examples of other content that is only accessible to signed in users).

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-497

#### Screenshots

Guest mode
![screen shot 2017-09-22 at 2 56 37 pm](https://user-images.githubusercontent.com/1386650/30760035-89934802-9fa6-11e7-9450-dbf8e076f18c.png)

non-Guest mode
![screen shot 2017-09-22 at 2 56 42 pm](https://user-images.githubusercontent.com/1386650/30760045-8ea86c64-9fa6-11e7-9fd4-171aa58aad60.png)


#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO