### PR TITLE
Adds safe_output helper

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -76,7 +76,9 @@ module RecordHelper
 
   def clean_affiliations
     return if @record.eds_author_affiliations.blank?
-    affs = Nokogiri::HTML.fragment(CGI.unescapeHTML(@record.eds_author_affiliations))
+    affs = Nokogiri::HTML.fragment(
+      CGI.unescapeHTML(@record.eds_author_affiliations)
+    )
     affs.search('relatesto').each(&:remove)
     nodes = affs.children.map(&:text).map(&:strip)
     nodes.reject!(&:empty?)
@@ -95,5 +97,14 @@ module RecordHelper
     # notice the parameter and prefill the search, which is behavior we *don't*
     # want.
     params[:previous]
+  end
+
+  # Turns out metadata in the wild can include HTML markup, which is encoded and
+  # rendered as strings, such as a user-visible "<br />". Let's not do that.
+  # Instead, let's strip potentially dangerous tags but render the rest.
+  # Nokogiri is being used because it is :rainbow: at handling poorly formed
+  # HTML, which appears to be the norm.
+  def safe_output(input)
+    sanitize Nokogiri::HTML.fragment(CGI.unescapeHTML(input)).to_s
   end
 end

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -15,7 +15,7 @@
     <%# todo: this will need updating once Ebsco resolves a data mapping
         problem described here
         https://mitlibraries.atlassian.net/browse/DI-547 %>
-    <%= @record.eds_extras_TOC %>
+    <%= safe_output(@record.eds_extras_TOC) %>
   </div>
 <% end %>
 

--- a/app/views/record/_extended_info.html.erb
+++ b/app/views/record/_extended_info.html.erb
@@ -45,7 +45,7 @@
 
   <% if @record.eds_publication_info.present? %>
     <li>
-      Publication info: <%= @record.eds_publication_info %>
+      Publication info: <%= safe_output(@record.eds_publication_info) %>
     </li>
   <% end %>
 
@@ -82,7 +82,7 @@
 
   <% if @record.eds_physical_description.present? %>
     <li>
-      Physical description: <%= @record.eds_physical_description %>
+      Physical description: <%= safe_output(@record.eds_physical_description) %>
     </li>
   <% end %>
 
@@ -122,15 +122,12 @@
 
 <% if @record.eds_abstract.present? %>
   <h4>Abstract/summary</h4>
-  <%= sanitize raw @record.eds_abstract %>
+  <%= safe_output(@record.eds_abstract) %>
 <% end %>
 
 <% if @record.eds_notes.present? %>
   <h4>Notes</h4>
-  <%# Turns out notes in the wild can include HTML markup, which is encoded and
-      rendered as strings, such as a user-visible "<br />". Let's not do that.
-      Instead, let's strip potentially dangerous tags but render the rest. %>
-  <%= sanitize raw @record.eds_notes %>
+  <%= safe_output(@record.eds_notes) %>
 <% end %>
 
 <% if clean_other_titles.present? %>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This adds a `safe_output(input)` helper which handles the sanitization of html
in API supplied metadata while also handling poorly formed HTML (which
the internal Rails methods seem to have some issues with).

#### How can a reviewer manually see the effects of these changes?

Before change see notes section here:
https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.000953977

After change see note section here:
https://mit-bento-staging-pr-264.herokuapp.com/record/cat00916a/mit.000953977

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-548

#### Screenshots (if appropriate)
![screen shot 2017-09-28 at 10 28 02 am](https://user-images.githubusercontent.com/1386650/30975681-d748a558-a440-11e7-8082-1510a39d55de.png)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
