### PR TITLE
Add style for full record auth states

### DIFF
--- a/app/assets/stylesheets/_aleph.scss
+++ b/app/assets/stylesheets/_aleph.scss
@@ -61,3 +61,20 @@
   }
 
 }
+
+.full-record {
+
+  .link-fulltext {
+    margin: .5rem 0 1.5rem 0;
+  }
+
+  .signin-fulltext {
+    margin: .5rem 0;
+    padding: 1rem 2rem;
+    font-size: 1.4rem;
+
+    .message {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/_full-record.scss
+++ b/app/assets/stylesheets/_full-record.scss
@@ -7,7 +7,7 @@
     @extend .alert-banner;
     @extend .inline-action;
     @extend .alert-banner;
-    margin: -3rem -3rem 2rem -3rem;
+    margin: -3.1rem -3.1rem 2rem -3.1rem;
   }
 
 }

--- a/app/assets/stylesheets/_full-record.scss
+++ b/app/assets/stylesheets/_full-record.scss
@@ -1,0 +1,13 @@
+
+// full record
+.full-record {
+
+  .signin-guest {
+    @extend .alert;
+    @extend .alert-banner;
+    @extend .inline-action;
+    @extend .alert-banner;
+    margin: -3rem -3rem 2rem -3rem;
+  }
+
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "_bento.scss";
 @import "_search.scss";
 @import "_results.scss";
+@import "_full-record.scss";
 @import "_hint.scss";
 @import "_aleph.scss";
 @import "_feedback.scss";

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -1,12 +1,19 @@
 <h2 class="subtitle2">Availability</h2>
 <% if @record.fulltext_link.present? %>
-  <% if check_online? %>
-    <a href="<%= @record.fulltext_link[:url] %>">Check for online copy</a>
-  <% elsif guest_and_restricted_link? %>
-    <a href="<%= login_url %>">Sign in for full text link</a>
-  <% else %>
-    <a href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>
-  <% end %>
+  <div class="link-fulltext">
+    <% if check_online? %>
+      <a class="button button-secondary" href="<%= @record.fulltext_link[:url] %>">Check for online copy</a>
+    <% elsif guest_and_restricted_link? %>
+      <div class="inline-action well signin-fulltext">
+        <p class="message">Full text available</p>
+        <div class="actions">
+          <a class="button button-secondary" href="<%= login_url %>">Sign in for access</a>
+        </div>
+      </div>
+    <% else %>
+      <a class="button button-primary green" href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>
+    <% end %>
+  </div>
 <% end %>
 
 <%# using try instead of .present? due to how edsapi dynamically adds this

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -4,11 +4,12 @@
 <% end %>
 
 <div class="gridband layout-3q1q">
-  <div class="col3q box-content region" data-region="Full record">
+  <div class="col3q box-content region full-record" data-region="Full record">
 
     <% if guest? %>
-      <div class="alert alert-banner warning">
-        <a href="<%= login_url %>">Sign in for full access</a>
+      <div class="alert info signin-guest">
+        <p class="message">You are browsing as a guest. Sign in for full access.</p>
+        <div class="actions"><a class="button button-primary" href="<%= login_url %>">Sign in</a></div>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Adjust the prompt to authenticate when viewing a full record from not-an-MIT-IP. 

#### How can a reviewer manually see the effects of these changes?
Go off campus and try to view a full record. Or fire up the VM and add ?guest=true to a full record URL.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-520

#### Screenshots (if appropriate)
<img width="876" alt="screen shot 2017-10-02 at 3 47 07 pm" src="https://user-images.githubusercontent.com/4327102/31096113-213c1848-a789-11e7-8c69-f9f852d1b4b5.png">

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
