### PR TITLE
Restrict what we consider full text links

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -62,6 +62,17 @@ module RecordHelper
     )
   end
 
+  # domains we consider relevant when evaluating links
+  def relevant_links
+    ['libproxy.mit.edu', 'library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu',
+     'libraries.mit.edu', 'content.ebscohost.com']
+  end
+
+  # Check fulltext_link to confirm it has a domain from relevant_links
+  def relevant_fulltext_link?(link)
+    relevant_links.map { |x| link[:url].include?(x) }.any?
+  end
+
   # The value in @record.eds_languages is sometimes a string and sometimes an
   # array. We're going to make it always be an array, so we can handle it in
   # the same way in the template regardless, and also use its arrayness to

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -10,7 +10,7 @@
           <a class="button button-secondary" href="<%= login_url %>">Sign in for access</a>
         </div>
       </div>
-    <% else %>
+    <% elsif relevant_fulltext_link?(@record.fulltext_link) %>
       <a class="button button-primary green" href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>
     <% end %>
   </div>

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -59,4 +59,14 @@ DOC
                   controller.clean_other_titles)
 
   end
+
+  test 'link with a domain in relavent links' do
+    link = { url: 'https://libraries.mit.edu/F/stuff' }
+    assert(relevant_fulltext_link?(link))
+  end
+
+  test 'link without a domain in relevant links' do
+    link = { url: 'https://loc.gov/toc/because/whynot' }
+    refute(relevant_fulltext_link?(link))
+  end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Only considers something full text if it is going through SFX, our
catalog (which is probably going to end up in SFX), or Ebscohost.

This is very similar to, but not identical to, the code in the Result
model we use for the initial Bento results pages.

#### Helpful background context (if appropriate)

We often find links in our catalog records to non-fulltext resources, such as Publisher pages or Table of Contents pages.

#### How can a reviewer manually see the effects of these changes?

New behavior (no View online button since we filtered out most domains): 
https://mit-bento-staging-pr-268.herokuapp.com/record/cat00916a/mit.001738931

Old behavior (link to ToC from View online button):
https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.001738931

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-539

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO