### PR TITLE
Debug item actions per discussion with IDLA

### DIFF
--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -17,7 +17,6 @@ class ButtonMakerTest < ActiveSupport::TestCase
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_ill
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_recall
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_special_ill
-    refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_call
   end
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Test item properties ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -120,26 +119,17 @@ class ButtonMakerTest < ActiveSupport::TestCase
     refute maker.eligible_for_contact?
   end
 
-  test 'eligible for call' do
-    maker = ButtonMaker.new(@item, @oclc)
-    maker.instance_variable_set(:@on_reserve, true)
-    assert maker.eligible_for_call?
-
-    maker.instance_variable_set(:@on_reserve, false)
-    refute maker.eligible_for_call?
-  end
-
   test 'eligible for hold' do
     maker = ButtonMaker.new(@item, @oclc)
     maker.instance_variable_set(:@status, 'In Library')
     maker.instance_variable_set(:@requestable, true)
     assert maker.eligible_for_hold?
 
-    maker.instance_variable_set(:@requestable, false)
-    refute maker.eligible_for_hold?
-
     maker.instance_variable_set(:@status, 'MIT Reads')
     assert maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@requestable, false)
+    refute maker.eligible_for_hold?
 
     maker.instance_variable_set(:@on_reserve, true)
     refute maker.eligible_for_hold?


### PR DESCRIPTION
## Status
**HOLD**

#### What does this PR do?
I talked through the logic of ticket 513 with people from IDLA. They had a few clarifications about how circ actually works, so I am updating item action rules accordingly.

#### Helpful background context (if appropriate)

_Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn_

#### How can a reviewer manually see the effects of these changes?

They're going to be hard to see on a staging server since you would need to know of an item with the correct statuses, and these statuses can be transient.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-513
- https://mitlibraries.atlassian.net/browse/DI-564

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
