### PR TITLE
Show all available ISBNs/ISSNs per UX advice

### DIFF
--- a/app/views/record/_extended_info.html.erb
+++ b/app/views/record/_extended_info.html.erb
@@ -49,21 +49,19 @@
     </li>
   <% end %>
 
-  <% if @record.eds_isbn_print.present? %>
+  <% if @record.eds_isbns.present? %>
     <li>
-      ISBN: <%= @record.eds_isbn_print %>
+      ISBN: <% @record.eds_isbns.each do |isbn| %>
+        <span class="isbn"><%= isbn %></span>
+      <% end %>
     </li>
   <% end %>
 
-  <% if @record.eds_isbn_electronic.present? %>
+  <% if @record.eds_issns.present? %>
     <li>
-      ISBN: <%= @record.eds_isbn_electronic %>
-    </li>
-  <% end %>
-
-  <% if @record.eds_issn_print.present? %>
-    <li>
-      ISSN: <%= @record.eds_issn_print %>
+      ISSN: <% @record.eds_issns.each do |issn| %>
+        <span class="isbn"><%= issn %></span>
+      <% end %>
     </li>
   <% end %>
 

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -161,7 +161,8 @@ class RecordTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record: article', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'aci', an: '123877356' }
       assert_response :success
-      assert @response.body.include? 'ISSN: 20796374'
+      assert @response.body.include? 'ISSN:'
+      assert @response.body.include? '20796374'
     end
   end
 
@@ -169,7 +170,8 @@ class RecordTest < ActionDispatch::IntegrationTest
     VCR.use_cassette('record: book', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
       assert_response :success
-      assert @response.body.include? 'ISBN: 9781841958811'
+      assert @response.body.include? 'ISBN:'
+      assert @response.body.include? '9781841958811'
     end
   end
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Displays all available ISBNs & ISSNs.

#### Helpful background context (if appropriate)
We were doing something more complicated but I asked Melissa and she said this is what we do in the status quo so let's keep doing it.

#### How can a reviewer manually see the effects of these changes?

Check out `/record/cat00916a/mit.001712021` on the PR review app. It has multiple ISBNs. The corresponding page on staging has only one.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-543

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
