### PR TITLE
What happens in the physics room stays in the physics room

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -68,7 +68,7 @@ class ButtonMaker
   end
 
   def eligible_for_hold?
-    return false if @on_reserve
+    return false if @on_reserve || @library == 'Physics Dept. Reading Room'
     [
       # You can request things that are in the library and have reasonable
       # loan policies.
@@ -115,7 +115,7 @@ class ButtonMaker
   end
 
   def eligible_for_recall?
-    return false if @on_reserve
+    return false if @on_reserve || @library == 'Physics Dept. Reading Room'
     # It's not enough to say `@status != 'In Library'`, because the item might
     # have a status of 'On Order' or 'Missing', and those are not recallable.
     @status.start_with?('Due') && @requestable
@@ -305,7 +305,7 @@ class ButtonMaker
 
   # Items with these process & item statuses may be put on hold/recalled.
   def requestable?
-    return false if @on_reserve
+    return false if @on_reserve || @library == 'Physics Dept. Reading Room'
     [
       # Items with these status codes may be requested from any library,
       # except the Annex.

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -143,6 +143,10 @@ class ButtonMakerTest < ActiveSupport::TestCase
 
     maker.instance_variable_set(:@on_reserve, true)
     refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@on_reserve, false)
+    maker.instance_variable_set(:@library, 'Physics Dept. Reading Room')
+    refute maker.eligible_for_hold?
   end
 
   test 'eligible for ill' do
@@ -153,6 +157,7 @@ class ButtonMakerTest < ActiveSupport::TestCase
     maker.instance_variable_set(:@requestable, true)
     refute maker.eligible_for_ill?
 
+    maker.instance_variable_set(:@library, 'Hayden Library')
     maker.instance_variable_set(:@status, 'Received')
     refute maker.eligible_for_ill?
 
@@ -168,6 +173,10 @@ class ButtonMakerTest < ActiveSupport::TestCase
     assert maker.eligible_for_recall?
 
     maker.instance_variable_set(:@on_reserve, true)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@on_reserve, false)
+    maker.instance_variable_set(:@library, 'Physics Dept. Reading Room')
     refute maker.eligible_for_recall?
   end
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
The physics department reading room is special, and its items are not
eligible for hold, recall, or scan.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.001512948 and the same record in the PR build.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-572

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
