### PR TITLE
[WIP] First attempt at Zotero-compatible metadata on full record page

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,6 +1,9 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<%= yield(:head) %>
+
 <title><%= content_for?(:title) ? yield(:title) : " Search | MIT Libraries" %></title>
 <%= csrf_meta_tags %>
 

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -33,3 +33,12 @@
     <%= render partial: "sidebar" %>
   </div>
 </div>
+
+<% content_for(:head) do %>
+  <meta name="DC.title" content="<%= @record.title %>" />
+  <meta name="DC.type" content="<%= @record.eds_publication_type %>" />
+  <meta name="DC.date" content="<%= @record.eds_publication_year %>" />
+  <% @record.eds_authors.each do |author| %>
+    <meta name="DC.creator" content="<%= author %>" />
+  <% end %>
+<% end %>

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -35,6 +35,8 @@
 </div>
 
 <% content_for(:head) do %>
+  <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+  <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
   <meta name="DC.title" content="<%= @record.title %>" />
   <meta name="DC.type" content="<%= @record.eds_publication_type %>" />
   <meta name="DC.date" content="<%= @record.eds_publication_year %>" />


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

#### What does this PR do?
This is meant to add support for Zotero on the full record page, enabling users to save citations to Zotero from within the app.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
In a Zotero-enabled browser, load a full record and try to save the citation. Note what comes into Zotero. Compare with what gets recorded on a non-enhanced page like https://libraries.mit.edu/about/ , and an article page like http://mit.worldcat.org/title/enceladus-crisis/oclc/920719168

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-476

#### Screenshots:
This is how Zotero currently sees a record submitted from the full page ( https://lib.mit.edu/record/a9h/118119123 )
![image](https://user-images.githubusercontent.com/1403248/31965891-c0f2e1d8-b8d6-11e7-897d-ec3b614e3a35.png)

This is how the record looks after the PR ( https://mit-bento-staging-pr-280.herokuapp.com/record/a9h/118119123 )
![image](https://user-images.githubusercontent.com/1403248/31965914-d827fef6-b8d6-11e7-928b-86bb2dd7beaa.png)

This is how the record looks when saved from PubMed ( https://www.ncbi.nlm.nih.gov/pubmed/27798575 )
![image](https://user-images.githubusercontent.com/1403248/31965957-06834df0-b8d7-11e7-82b4-ba2e93eb1133.png)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES | NO

#### Includes new or updated dependencies?
YES | NO
