### PR TITLE
Force http thumbnail images to use https

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -128,4 +128,21 @@ module RecordHelper
   def guest_and_restricted_link?
     guest? && restricted_link?
   end
+
+  # force http images to use https. If remote server cannot handle https a
+  # broken image is expected. The `alt` keyword argument is required for
+  # accessibility reasons and is a keyword argument instead of positional to
+  # match the syntax of `image_tag` which this wraps.
+  def force_https_image_tag(url, alt:)
+    image_tag(force_https(url), alt: alt)
+  end
+
+  # force scheme of a url to https if it is currently http. if it is not http
+  # just return the input with no changes
+  def force_https(url)
+    uri = URI(url)
+    return url unless uri.scheme == 'http'
+    uri.scheme = 'https'
+    uri.to_s
+  end
 end

--- a/app/views/record/_basic_info.html.erb
+++ b/app/views/record/_basic_info.html.erb
@@ -6,7 +6,7 @@
 
 <% if @record.eds_cover_thumb_url.present? %>
 <div class="record-image">
-  <%= image_tag(@record.eds_cover_thumb_url, alt: "Cover for #{@record.title}") %>
+  <%= force_https_image_tag(@record.eds_cover_thumb_url, alt: "Cover for #{@record.title}") %>
 </div>
 <% end %>
 

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -7,7 +7,7 @@
 
   <% if result.thumbnail %>
     <div class="result-image">
-      <%= image_tag(result.thumbnail, alt: "Cover for #{result.title}") %>
+      <%= force_https_image_tag(result.thumbnail, alt: "Cover for #{result.title}") %>
     </div>
   <% end %>
 

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -69,4 +69,17 @@ DOC
     link = { url: 'https://loc.gov/toc/because/whynot' }
     refute(relevant_fulltext_link?(link))
   end
+
+  test 'force_https with http url changes to https' do
+    assert_equal('https://example.com/yo', force_https('http://example.com/yo'))
+  end
+
+  test 'force_https with https url' do
+    assert_equal('https://example.com/yo',
+                 force_https('https://example.com/yo'))
+  end
+
+  test 'force_https with no scheme returns input unchanged' do
+    assert_equal('example.com/yo', force_https('example.com/yo'))
+  end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Forces http thumbnails to use https (argh!)

If the url returned from the API is http, it changes it to https. If it is not http, we just use whatever we were given (either https already or something weird. Who knows!)

#### Helpful background context (if appropriate)

EDS API returns http thumbnail images. It appears the service they use can handle https. Some browsers are starting to get a bit more vocal with mixed content messages, and there is a desire for this application to avoid that if possible.

#### How can a reviewer manually see the effects of these changes?

In the PR build, do a search and note the images we display in bento view and full record view are using https scheme. The same search in staging will show http scheme.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-509

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO