### PR TITLE
Make HTML on search page render rather than display to users

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -16,7 +16,7 @@
   </h3>
   <div class="result-uniform-title">
     <% if result.uniform_title %>
-      <span class="sr">Alternate Title: </span><%= result.uniform_title.html_safe %>
+      <span class="sr">Alternate Title: </span><%= safe_output(result.uniform_title) %>
     <% end %>
   </div>
   <p>
@@ -42,7 +42,7 @@
 
     <% if result.blurb %>
       <p class="result-blurb">
-        <%= sanitize(result.blurb) %><br />
+        <%= safe_output(result.blurb) %><br />
       </p>
     <% end %>
 


### PR DESCRIPTION
This moves our safe_output function from RecordHelper to
ApplicationController, so that it is available to everybody.
Sharing is caring!

## Status
**READY**

#### What does this PR do?
Bad:
![screen shot 2017-10-25 at 11 01 46 am](https://user-images.githubusercontent.com/959761/32006129-ed7688b6-b973-11e7-9bc6-e16152cbbb28.png)

Good:
![screen shot 2017-10-25 at 10 59 30 am](https://user-images.githubusercontent.com/959761/32006024-b174457e-b973-11e7-867e-961be7b9bffa.png)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

`/search/bento?q=TX335.A1.C7581.B9` on the PR build

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-574

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
