### PR TITLE
Adds check for ga to exist before calling it

### DIFF
--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -17,7 +17,10 @@ function TrackLinks( element ) {
       eventLabel: label
     };
 
-    ga( 'send', fields );
+    if ('function' === typeof(ga)) {
+      ga( 'send', fields );
+    }
+
   });
 }
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

#### What does this PR do?
After disabling GA, watching the console as you click a link (that would normally result in data being sent to GA about what type of link had been clicked), there is a brief flash as the app tries to call the `ga()` function at the end of `TrackLinks()`. Because GA is not present, the function doesn't exist so an error is briefly thrown. The app still functions, but it isn't ideal.

This PR tweaks TrackLinks to check if the `ga()` function exists before calling it - which in local testing eliminates the error.

#### Helpful background context (if appropriate)
This was discovered after we removed the GA integration within Bento.

#### How can a reviewer manually see the effects of these changes?
Open production Bento with the developer console open, and click a link on the results page. There should be briefly visible a JS error complaining about an unknown ga function. That same behavior is not present under this review app.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-582

#### Todo:
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
