### PR TITLE
Adds an in app toggle link to preview full records

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,6 +41,9 @@
     "FLIPFLOP_KEY": {
       "required": true
     },
+    "FULL_RECORD_TOGGLE_BUTTON": {
+      "required": true
+    },
     "GLOBAL_ALERT": {
       "required": true
     },

--- a/app/assets/stylesheets/_bento.scss
+++ b/app/assets/stylesheets/_bento.scss
@@ -37,6 +37,20 @@
   }
 }
 
+.nudge-fullrecord-toggle {
+  float: left;
+  font-size: $fs-small;
+  font-weight: $fw-bold;
+
+  p {
+    margin-bottom: 0;
+  }
+
+  a {
+    color: $orange;
+  }
+}
+
 /* big boxes */
 .wrap-results {
   margin-top: 2rem;
@@ -130,4 +144,3 @@
     font-size: $fs-xsmall;
   }
 }
-

--- a/app/assets/stylesheets/_bento.scss
+++ b/app/assets/stylesheets/_bento.scss
@@ -38,14 +38,9 @@
 }
 
 .nudge-fullrecord-toggle {
-  float: left;
   font-size: $fs-small;
   font-weight: $fw-bold;
-
-  p {
-    margin-bottom: 0;
-  }
-
+  
   a {
     color: $orange;
   }

--- a/app/controllers/feature_controller.rb
+++ b/app/controllers/feature_controller.rb
@@ -10,7 +10,7 @@ class FeatureController < ApplicationController
 
   def full_record_toggle
     session[:local_full_record] = session[:local_full_record].!
-    flash[:info] = "In app full record displays are now #{full_record_message}."
+    flash[:info] = "The beta item detail view is now #{full_record_message}."
     redirect_back(fallback_location: root_path)
   end
 
@@ -18,9 +18,9 @@ class FeatureController < ApplicationController
 
   def full_record_message
     if Flipflop.local_full_record?
-      'enabled'
+      'on'
     else
-      'disabled'
+      'off'
     end
   end
 

--- a/app/controllers/feature_controller.rb
+++ b/app/controllers/feature_controller.rb
@@ -1,5 +1,5 @@
 class FeatureController < ApplicationController
-  before_action :validate_feature!
+  before_action :validate_feature!, only: :toggle
 
   # Toggles boolean for session based feature flags
   def toggle
@@ -8,7 +8,21 @@ class FeatureController < ApplicationController
     redirect_to root_path
   end
 
+  def full_record_toggle
+    session[:local_full_record] = session[:local_full_record].!
+    flash[:info] = "In app full record displays are now #{full_record_message}."
+    redirect_back(fallback_location: root_path)
+  end
+
   private
+
+  def full_record_message
+    if Flipflop.local_full_record?
+      'enabled'
+    else
+      'disabled'
+    end
+  end
 
   # message to display on successful toggle of a feature
   def success_message

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -166,4 +166,13 @@ module RecordHelper
   def excluded_subjects
     ENV['SCAN_EXCLUSIONS'].split(';')
   end
+
+  def full_record_toggle_link
+    link_text = if Flipflop.local_full_record?
+                  'Disable beta record display.'
+                else
+                  'Preview beta record display.'
+                end
+    link_to(link_text, full_record_toggle_path)
+  end
 end

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -169,9 +169,9 @@ module RecordHelper
 
   def full_record_toggle_link
     link_text = if Flipflop.local_full_record?
-                  'Disable beta record display.'
+                  'Turn off beta item detail view'
                 else
-                  'Preview beta record display.'
+                  'Try our new beta item detail view'
                 end
     link_to(link_text, full_record_toggle_path)
   end

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -13,8 +13,14 @@
   </p>
 </div>
 
+<% if Flipflop.full_record_toggle_button? %>
+  <div class="nudge-fullrecord-toggle">
+    <p><%= full_record_toggle_link %></p>
+  </div>
+<% end %>
+
 <div class="nudge-feedback">
-  <p>Was this search useful? <%= link_to('Send feedback', feedback_path) %>
+  <p>Was this search useful? <%= link_to('Send feedback', feedback_path) %></p>
 </div>
 
 <div id="hint"></div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,9 +1,9 @@
 <div class="space-wrap">
+  <%= render partial: "form" %>
+
   <% if Flipflop.full_record_toggle_button? %>
     <div class="nudge-fullrecord-toggle">
       <p><%= full_record_toggle_link %></p>
     </div>
   <% end %>
-
-  <%= render partial: "form" %>
 </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,3 +1,9 @@
 <div class="space-wrap">
-<%= render partial: "form" %>
+  <% if Flipflop.full_record_toggle_button? %>
+    <div class="nudge-fullrecord-toggle">
+      <p><%= full_record_toggle_link %></p>
+    </div>
+  <% end %>
+
+  <%= render partial: "form" %>
 </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,7 @@ Rails.application.configure do
   ENV['PER_PAGE'] = '10'
   ENV['FLIPFLOP_KEY'] = 'yoyo'
   ENV['ALEPH_HINT_SOURCE'] = 'https://fake.example.com/s/fake/getserial_mini.xml?dl=1'
+  ENV['FULL_RECORD_TOGGLE_BUTTON'] = 'true'
 
   ENV['SCAN_EXCLUSIONS']='Materials -- Standards -- United States -- Periodicals;Materials -- Standards -- United States -- Periodicals;Standards, Engineering;Standards, Engineering -- Periodicals'
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -26,4 +26,10 @@ Flipflop.configure do
   feature :pride,
     default: ENV['PRIDE'],
     description: 'Enables rainbows for records with LGBT subjects/keywords'
+
+  feature :full_record_toggle_button,
+    default: ENV['FULL_RECORD_TOGGLE_BUTTON'],
+    description: 'Enables a UI element to toggle full record. local_full_record,
+                  still controls the actual full record display. This just
+                  enables an affordance to toggle between states.'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
 
   get 'hint', to: 'hint#hint'
   get 'toggle', to: 'feature#toggle'
+  get 'full_record_toggle', to: 'feature#full_record_toggle'
 
   get 'record/(:db_source)/(:an)', to: 'record#record',
                                    as: :record,

--- a/test/features/toggle_fullrecord_test.rb
+++ b/test/features/toggle_fullrecord_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+feature 'ToggleFullrecord' do
+  before do
+    Capybara.current_session.driver.browser.clear_cookies
+  end
+
+  after do
+    Capybara.current_session.driver.browser.clear_cookies
+  end
+
+  test 'can toggle full record from app' do
+    visit '/'
+    assert_text('Preview beta record display.')
+
+    click_on('Preview beta record display.')
+    refute_text('Preview beta record display.')
+    assert_text('Disable beta record display.')
+
+    click_on('Disable beta record display.')
+    assert_text('Preview beta record display.')
+    refute_text('Disable beta record display.')
+  end
+end

--- a/test/features/toggle_fullrecord_test.rb
+++ b/test/features/toggle_fullrecord_test.rb
@@ -11,14 +11,14 @@ feature 'ToggleFullrecord' do
 
   test 'can toggle full record from app' do
     visit '/'
-    assert_text('Preview beta record display.')
+    assert_text('Try our new beta item detail view')
 
-    click_on('Preview beta record display.')
-    refute_text('Preview beta record display.')
-    assert_text('Disable beta record display.')
+    click_on('Try our new beta item detail view')
+    refute_text('Try our new beta item detail view')
+    assert_text('Turn off beta item detail view')
 
-    click_on('Disable beta record display.')
-    assert_text('Preview beta record display.')
-    refute_text('Disable beta record display.')
+    click_on('Turn off beta item detail view')
+    assert_text('Try our new beta item detail view')
+    refute_text('Turn off beta item detail view')
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

* Adds a feature flagged link to enable another feature. Oh my.
* Provides an in app link to enable the full record displays.
* The intent is that once we are ready and enable this feature, users
will be able to self opt-in / opt-out of the full record displays for
some period of time.

#### How can a reviewer manually see the effects of these changes?

Go to the PR build and click madly on the toggle link (and ideally also confirm the results pages change target URLs as appropriate).

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-609

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO