### PR TITLE
Adds caching for eds-api and aleph responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 ruby '2.4.1'
 
+gem 'actionpack-action_caching'
 gem 'devise'
 gem 'ebsco-eds'
 gem 'flipflop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-action_caching (1.2.0)
+      actionpack (>= 4.0.0, < 6)
     actionview (5.1.4)
       activesupport (= 5.1.4)
       builder (~> 3.1)
@@ -404,6 +406,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   annotate
   better_errors
   binding_of_caller

--- a/app/controllers/aleph_controller.rb
+++ b/app/controllers/aleph_controller.rb
@@ -1,4 +1,7 @@
 class AlephController < ApplicationController
+  # We are using ActionCaching here because we also use it in EDS full records.
+  # This would work fine with low level caching, but ActiveCache is so clean
+  # and once we are using it someplace else we may as well use it here.
   caches_action :full_item_status, expires_in: 15.minutes,
                                    cache_path: :cache_path
   caches_action :item_status, expires_in: 15.minutes, cache_path: :cache_path

--- a/app/controllers/aleph_controller.rb
+++ b/app/controllers/aleph_controller.rb
@@ -1,4 +1,8 @@
 class AlephController < ApplicationController
+  caches_action :full_item_status, expires_in: 15.minutes,
+                                   cache_path: :cache_path
+  caches_action :item_status, expires_in: 15.minutes, cache_path: :cache_path
+
   # item_status and full_item_status render different html
   def item_status
     @status = AlephItem.new.items(params[:id], params[:oclc], params[:scan])
@@ -9,5 +13,19 @@ class AlephController < ApplicationController
   def full_item_status
     @status = AlephItem.new.items(params[:id], params[:oclc], params[:scan])
     render layout: false
+  end
+
+  protected
+
+  # This is effectively a cache key based on the parameters we care about.
+  # Note: aleph cache is not guest dependent so we can just use parameters for
+  # the key.
+  def cache_path
+    url_for(
+      id: params[:id],
+      oclc: params[:oclc],
+      scan: params[:scan],
+      method: action_name
+    )
   end
 end

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -7,6 +7,11 @@ class RecordController < ApplicationController
 
   class NoSuchRecordError < StandardError; end
 
+  # We are using ActionCaching due to EDS not providing an readily cacheable
+  # object to use with low level caching like we do with our bento results.
+  # They provide a cache option but it is hardcoded to use a file system cache.
+  # I have asked for that to be revisited upstream. Fragment Caching is an
+  # option but in initial exploration this honestly seems easier.
   caches_action :record, expires_in: 1.day, cache_path: :cache_path
 
   include Rainbows

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -7,6 +7,8 @@ class RecordController < ApplicationController
 
   class NoSuchRecordError < StandardError; end
 
+  caches_action :record, expires_in: 1.day, cache_path: :cache_path
+
   include Rainbows
 
   # See https://github.com/ebsco/edsapi-ruby/ . The page which gives all the
@@ -24,9 +26,24 @@ class RecordController < ApplicationController
     render 'record'
   end
 
+  # this method should never be cached because we need a fresh expiring URL
   def direct_link
     fetch_eds_record
     redirect_to @record.fulltext_link[:url]
+  end
+
+  protected
+
+  # This is effectively a cache key based on the parameters we care about.
+  # record cache is guest dependent because it stores rendered HTML, and some
+  # of that rendered HTML is different for guests.
+  def cache_path
+    url_for(
+      guest: helpers.guest?,
+      action: action_name,
+      an: @record_an,
+      source: @record_source
+    )
   end
 
   private

--- a/test/controllers/aleph_controller_test.rb
+++ b/test/controllers/aleph_controller_test.rb
@@ -1,9 +1,25 @@
 require 'test_helper'
 
 class AlephControllerTest < ActionDispatch::IntegrationTest
-  test 'index' do
+  test 'item_status' do
     VCR.use_cassette('realtime aleph') do
       get '/item_status?id=MIT01001739356'
+      assert_response :success
+    end
+  end
+
+  test 'full_item_status' do
+    VCR.use_cassette('realtime aleph') do
+      get '/full_item_status?id=MIT01001739356'
+      assert_response :success
+    end
+  end
+
+  test 'cache_path' do
+    VCR.use_cassette('realtime aleph') do
+      get '/full_item_status?id=MIT01001739356'
+      assert_equal(@controller.send(:cache_path),
+                   'http://www.example.com/full_item_status?id=MIT01001739356&method=full_item_status')
       assert_response :success
     end
   end

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -62,4 +62,25 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_includes(@response.body, 'Restricted access.')
   end
+
+  test 'cache_path for guests' do
+    VCR.use_cassette('record: bananas', allow_playback_repeats: true) do
+      get record_url('cat00916a', 'mit.001492509')
+      assert_equal(@controller.send(:cache_path),
+                   'http://www.example.com/record/cat00916a/mit.001492509?guest=true&source=cat00916a')
+      assert_response :success
+    end
+  end
+
+  test 'cache_path for non-guests' do
+    VCR.use_cassette('record: bananas nonguest',
+                     allow_playback_repeats: true) do
+      ActionDispatch::Request.any_instance.stubs(:remote_ip)
+                             .returns('18.42.101.101')
+      get record_url('cat00916a', 'mit.001492509')
+      assert_equal(@controller.send(:cache_path),
+                   'http://www.example.com/record/cat00916a/mit.001492509?guest=false&source=cat00916a')
+      assert_response :success
+    end
+  end
 end

--- a/test/vcr_cassettes/record_bananas_nonguest.yml
+++ b/test/vcr_cassettes/record_bananas_nonguest.yml
@@ -1,0 +1,356 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:11:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:11:04 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 41bd5946-24a6-4965-9998-3904abca7c87
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '1546235666'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:11:06 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:11:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 0235b8cb-846d-459a-92df-b38a56526b95
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '1546235666'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '3632'
+    body:
+      encoding: UTF-8
+      string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"date","Label":"Date
+        Newest","AddAction":"setsort(date)"},{"Id":"date2","Label":"Date Oldest","AddAction":"setsort(date2)"},{"Id":"relevance","Label":"Relevance","AddAction":"setsort(relevance)"}],"AvailableSearchFields":[{"FieldCode":"TX","Label":"All
+        Text"},{"FieldCode":"AU","Label":"Author"},{"FieldCode":"TI","Label":"Title"},{"FieldCode":"SU","Label":"Subject
+        Terms"},{"FieldCode":"SO","Label":"Source"},{"FieldCode":"AB","Label":"Abstract"},{"FieldCode":"IS","Label":"ISSN"},{"FieldCode":"IB","Label":"ISBN"}],"AvailableExpanders":[{"Id":"relatedsubjects","Label":"Apply
+        equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"},{"Id":"thesaurus","Label":"Apply
+        related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
+        search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"2"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
+        Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
+        Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
+        Barton Catalog","AddAction":"addlimiter(LB:MIT Barton Catalog)","LimiterValues":[{"Value":"Barker
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Barker Library)"},{"Value":"Dewey
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Dewey Library)"},{"Value":"Hayden
+        Library - Humanities","AddAction":"addlimiter(LB:MIT Barton Catalog-Hayden
+        Library - Humanities)"},{"Value":"Hayden Library - Science","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Library - Science)"},{"Value":"Hayden Reserves","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Reserves)"},{"Value":"Institute Archives","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Institute Archives)"},{"Value":"Internet Resource","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Internet Resource)"},{"Value":"Lewis Music Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Lewis Music Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Visual Collections)"}]},{"Value":"MIT Course Reserves","AddAction":"addlimiter(LB:MIT
+        Course Reserves)","LimiterValues":[{"Value":"Barker Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Barker Library)"},{"Value":"Dewey Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Dewey Library)"},{"Value":"Hayden Library - Humanities","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Hayden Library - Humanities)"},{"Value":"Hayden Library -
+        Science","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Library - Science)"},{"Value":"Hayden
+        Reserves","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Reserves)"},{"Value":"Institute
+        Archives","AddAction":"addlimiter(LB:MIT Course Reserves-Institute Archives)"},{"Value":"Internet
+        Resource","AddAction":"addlimiter(LB:MIT Course Reserves-Internet Resource)"},{"Value":"Lewis
+        Music Library","AddAction":"addlimiter(LB:MIT Course Reserves-Lewis Music
+        Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Visual Collections)"}]}],"DefaultOn":"n","Order":"8"},{"Id":"FT1","Label":"Available
+        in Library Collection","Type":"select","AddAction":"addlimiter(FT1:value)","DefaultOn":"n","Order":"9"},{"Id":"LA99","Label":"Language","Type":"multiselectvalue","LimiterValues":[{"Value":"Catalan","AddAction":"addlimiter(LA99:Catalan)"},{"Value":"Chinese","AddAction":"addlimiter(LA99:Chinese)"},{"Value":"Croatian","AddAction":"addlimiter(LA99:Croatian)"},{"Value":"Dutch\/Flemish","AddAction":"addlimiter(LA99:Dutch\/Flemish)"},{"Value":"English","AddAction":"addlimiter(LA99:English)"},{"Value":"French","AddAction":"addlimiter(LA99:French)"},{"Value":"German","AddAction":"addlimiter(LA99:German)"},{"Value":"Italian","AddAction":"addlimiter(LA99:Italian)"},{"Value":"Lithuanian","AddAction":"addlimiter(LA99:Lithuanian)"},{"Value":"Portuguese","AddAction":"addlimiter(LA99:Portuguese)"},{"Value":"Romanian","AddAction":"addlimiter(LA99:Romanian)"},{"Value":"Russian","AddAction":"addlimiter(LA99:Russian)"},{"Value":"Spanish","AddAction":"addlimiter(LA99:Spanish)"},{"Value":"Turkish","AddAction":"addlimiter(LA99:Turkish)"},{"Value":"Bosnian","AddAction":"addlimiter(LA99:Bosnian)"},{"Value":"Czech","AddAction":"addlimiter(LA99:Czech)"},{"Value":"Finnish","AddAction":"addlimiter(LA99:Finnish)"},{"Value":"Hungarian","AddAction":"addlimiter(LA99:Hungarian)"},{"Value":"Latvian","AddAction":"addlimiter(LA99:Latvian)"},{"Value":"Norwegian","AddAction":"addlimiter(LA99:Norwegian)"},{"Value":"Polish","AddAction":"addlimiter(LA99:Polish)"},{"Value":"Slovak","AddAction":"addlimiter(LA99:Slovak)"},{"Value":"Slovenian","AddAction":"addlimiter(LA99:Slovenian)"},{"Value":"Serbian","AddAction":"addlimiter(LA99:Serbian)"},{"Value":"Ukrainian","AddAction":"addlimiter(LA99:Ukrainian)"},{"Value":"Afrikaans","AddAction":"addlimiter(LA99:Afrikaans)"},{"Value":"Japanese","AddAction":"addlimiter(LA99:Japanese)"},{"Value":"Persian","AddAction":"addlimiter(LA99:Persian)"},{"Value":"Swahili","AddAction":"addlimiter(LA99:Swahili)"},{"Value":"Swedish","AddAction":"addlimiter(LA99:Swedish)"},{"Value":"Arabic","AddAction":"addlimiter(LA99:Arabic)"},{"Value":"Azerbaijani","AddAction":"addlimiter(LA99:Azerbaijani)"},{"Value":"Basque","AddAction":"addlimiter(LA99:Basque)"},{"Value":"Bulgarian","AddAction":"addlimiter(LA99:Bulgarian)"},{"Value":"Danish","AddAction":"addlimiter(LA99:Danish)"},{"Value":"Greek","AddAction":"addlimiter(LA99:Greek)"},{"Value":"Hebrew","AddAction":"addlimiter(LA99:Hebrew)"},{"Value":"Hindi","AddAction":"addlimiter(LA99:Hindi)"},{"Value":"Icelandic","AddAction":"addlimiter(LA99:Icelandic)"},{"Value":"Indonesian","AddAction":"addlimiter(LA99:Indonesian)"},{"Value":"Korean","AddAction":"addlimiter(LA99:Korean)"},{"Value":"Latin","AddAction":"addlimiter(LA99:Latin)"},{"Value":"Malay","AddAction":"addlimiter(LA99:Malay)"},{"Value":"Serbo-Croatian","AddAction":"addlimiter(LA99:Serbo-Croatian)"},{"Value":"Urdu","AddAction":"addlimiter(LA99:Urdu)"},{"Value":"Dutch","AddAction":"addlimiter(LA99:Dutch)"},{"Value":"Welsh","AddAction":"addlimiter(LA99:Welsh)"},{"Value":"Albanian","AddAction":"addlimiter(LA99:Albanian)"},{"Value":"Armenian","AddAction":"addlimiter(LA99:Armenian)"},{"Value":"Georgian","AddAction":"addlimiter(LA99:Georgian)"},{"Value":"Macedonian","AddAction":"addlimiter(LA99:Macedonian)"},{"Value":"Thai","AddAction":"addlimiter(LA99:Thai)"},{"Value":"Greek,
+        Modern","AddAction":"addlimiter(LA99:Greek\\, Modern)"},{"Value":"Abkhazian","AddAction":"addlimiter(LA99:Abkhazian)"},{"Value":"Belarusian","AddAction":"addlimiter(LA99:Belarusian)"},{"Value":"Catalan;
+        Valencian","AddAction":"addlimiter(LA99:Catalan; Valencian)"},{"Value":"Spanish;
+        Castilian","AddAction":"addlimiter(LA99:Spanish; Castilian)"},{"Value":"Dutch;
+        Flemish","AddAction":"addlimiter(LA99:Dutch; Flemish)"},{"Value":"Galician","AddAction":"addlimiter(LA99:Galician)"},{"Value":"Romanian;
+        Moldavian; Moldovan","AddAction":"addlimiter(LA99:Romanian; Moldavian; Moldovan)"},{"Value":"Sotho,
+        Southern","AddAction":"addlimiter(LA99:Sotho\\, Southern)"},{"Value":"Venda","AddAction":"addlimiter(LA99:Venda)"},{"Value":"Xhosa","AddAction":"addlimiter(LA99:Xhosa)"},{"Value":"Zulu","AddAction":"addlimiter(LA99:Zulu)"},{"Value":"Aragonese","AddAction":"addlimiter(LA99:Aragonese)"},{"Value":"Breton","AddAction":"addlimiter(LA99:Breton)"},{"Value":"Greek,
+        Ancient","AddAction":"addlimiter(LA99:Greek\\, Ancient)"},{"Value":"Occitan","AddAction":"addlimiter(LA99:Occitan)"},{"Value":"Ukranian","AddAction":"addlimiter(LA99:Ukranian)"},{"Value":"Estonian","AddAction":"addlimiter(LA99:Estonian)"},{"Value":"Irish","AddAction":"addlimiter(LA99:Irish)"},{"Value":"Modern
+        Greek","AddAction":"addlimiter(LA99:Modern Greek)"},{"Value":"Tagalog","AddAction":"addlimiter(LA99:Tagalog)"},{"Value":"Amharic","AddAction":"addlimiter(LA99:Amharic)"},{"Value":"Mapudungun;
+        Mapuche","AddAction":"addlimiter(LA99:Mapudungun; Mapuche)"},{"Value":"Asturian;
+        Bable; Leonese; Asturleonese","AddAction":"addlimiter(LA99:Asturian; Bable;
+        Leonese; Asturleonese)"},{"Value":"Australian languages","AddAction":"addlimiter(LA99:Australian
+        languages)"},{"Value":"Bengali","AddAction":"addlimiter(LA99:Bengali)"},{"Value":"Burmese","AddAction":"addlimiter(LA99:Burmese)"},{"Value":"Central
+        American Indian languages","AddAction":"addlimiter(LA99:Central American Indian
+        languages)"},{"Value":"Chechen","AddAction":"addlimiter(LA99:Chechen)"},{"Value":"Coptic","AddAction":"addlimiter(LA99:Coptic)"},{"Value":"English,
+        Middle (1100-1500)","AddAction":"addlimiter(LA99:English\\, Middle \\(1100-1500\\))"},{"Value":"Esperanto","AddAction":"addlimiter(LA99:Esperanto)"},{"Value":"Faroese","AddAction":"addlimiter(LA99:Faroese)"},{"Value":"Fijian","AddAction":"addlimiter(LA99:Fijian)"},{"Value":"Germanic
+        languages","AddAction":"addlimiter(LA99:Germanic languages)"},{"Value":"Geez","AddAction":"addlimiter(LA99:Geez)"},{"Value":"Greek,
+        Ancient (to 1453)","AddAction":"addlimiter(LA99:Greek\\, Ancient \\(to 1453\\))"},{"Value":"Greek,
+        Modern (1453-)","AddAction":"addlimiter(LA99:Greek\\, Modern \\(1453-\\))"},{"Value":"Haitian;
+        Haitian Creole","AddAction":"addlimiter(LA99:Haitian; Haitian Creole)"},{"Value":"Ido","AddAction":"addlimiter(LA99:Ido)"},{"Value":"Interlingua
+        (International Auxiliary Language Association)","AddAction":"addlimiter(LA99:Interlingua
+        \\(International Auxiliary Language Association\\))"},{"Value":"Javanese","AddAction":"addlimiter(LA99:Javanese)"},{"Value":"Judeo-Arabic","AddAction":"addlimiter(LA99:Judeo-Arabic)"},{"Value":"Kannada","AddAction":"addlimiter(LA99:Kannada)"},{"Value":"Luxembourgish;
+        Letzeburgesch","AddAction":"addlimiter(LA99:Luxembourgish; Letzeburgesch)"},{"Value":"Malayalam","AddAction":"addlimiter(LA99:Malayalam)"},{"Value":"Austronesian
+        languages","AddAction":"addlimiter(LA99:Austronesian languages)"},{"Value":"Maltese","AddAction":"addlimiter(LA99:Maltese)"},{"Value":"Mongolian","AddAction":"addlimiter(LA99:Mongolian)"},{"Value":"Nahuatl
+        languages","AddAction":"addlimiter(LA99:Nahuatl languages)"},{"Value":"Neapolitan","AddAction":"addlimiter(LA99:Neapolitan)"},{"Value":"Bokmål,
+        Norwegian; Norwegian Bokmål","AddAction":"addlimiter(LA99:Bokmål\\, Norwegian;
+        Norwegian Bokmål)"},{"Value":"Norse, Old","AddAction":"addlimiter(LA99:Norse\\,
+        Old)"},{"Value":"Occitan (post 1500)","AddAction":"addlimiter(LA99:Occitan
+        \\(post 1500\\))"},{"Value":"Ojibwa","AddAction":"addlimiter(LA99:Ojibwa)"},{"Value":"Philippine
+        languages","AddAction":"addlimiter(LA99:Philippine languages)"},{"Value":"Romany","AddAction":"addlimiter(LA99:Romany)"},{"Value":"Samaritan
+        Aramaic","AddAction":"addlimiter(LA99:Samaritan Aramaic)"},{"Value":"Sanskrit","AddAction":"addlimiter(LA99:Sanskrit)"},{"Value":"Sinhala;
+        Sinhalese","AddAction":"addlimiter(LA99:Sinhala; Sinhalese)"},{"Value":"Sundanese","AddAction":"addlimiter(LA99:Sundanese)"},{"Value":"Sumerian","AddAction":"addlimiter(LA99:Sumerian)"},{"Value":"Classical
+        Syriac","AddAction":"addlimiter(LA99:Classical Syriac)"},{"Value":"Tibetan","AddAction":"addlimiter(LA99:Tibetan)"},{"Value":"Ugaritic","AddAction":"addlimiter(LA99:Ugaritic)"},{"Value":"Vietnamese","AddAction":"addlimiter(LA99:Vietnamese)"},{"Value":"Yiddish","AddAction":"addlimiter(LA99:Yiddish)"},{"Value":"Zapotec","AddAction":"addlimiter(LA99:Zapotec)"},{"Value":"Aromanian","AddAction":"addlimiter(LA99:Aromanian)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Bambara","AddAction":"addlimiter(LA99:Bambara)"},{"Value":"Filipino","AddAction":"addlimiter(LA99:Filipino)"},{"Value":"Flemish","AddAction":"addlimiter(LA99:Flemish)"},{"Value":"Gaelic","AddAction":"addlimiter(LA99:Gaelic)"},{"Value":"Gujarati","AddAction":"addlimiter(LA99:Gujarati)"},{"Value":"Hausa","AddAction":"addlimiter(LA99:Hausa)"},{"Value":"Hawaiian","AddAction":"addlimiter(LA99:Hawaiian)"},{"Value":"Hmong","AddAction":"addlimiter(LA99:Hmong)"},{"Value":"Igbo","AddAction":"addlimiter(LA99:Igbo)"},{"Value":"javanese","AddAction":"addlimiter(LA99:javanese)"},{"Value":"Kashmiri","AddAction":"addlimiter(LA99:Kashmiri)"},{"Value":"Kurdish","AddAction":"addlimiter(LA99:Kurdish)"},{"Value":"Lao","AddAction":"addlimiter(LA99:Lao)"},{"Value":"Lingala","AddAction":"addlimiter(LA99:Lingala)"},{"Value":"Malagasy","AddAction":"addlimiter(LA99:Malagasy)"},{"Value":"Marathi","AddAction":"addlimiter(LA99:Marathi)"},{"Value":"Mende","AddAction":"addlimiter(LA99:Mende)"},{"Value":"Moldovan","AddAction":"addlimiter(LA99:Moldovan)"},{"Value":"Nepali","AddAction":"addlimiter(LA99:Nepali)"},{"Value":"Oriya","AddAction":"addlimiter(LA99:Oriya)"},{"Value":"Oromo","AddAction":"addlimiter(LA99:Oromo)"},{"Value":"Pashto","AddAction":"addlimiter(LA99:Pashto)"},{"Value":"Pidgin
+        english","AddAction":"addlimiter(LA99:Pidgin english)"},{"Value":"Punjabi","AddAction":"addlimiter(LA99:Punjabi)"},{"Value":"Quechua","AddAction":"addlimiter(LA99:Quechua)"},{"Value":"Samoan","AddAction":"addlimiter(LA99:Samoan)"},{"Value":"Sango","AddAction":"addlimiter(LA99:Sango)"},{"Value":"Shona","AddAction":"addlimiter(LA99:Shona)"},{"Value":"Sinhala","AddAction":"addlimiter(LA99:Sinhala)"},{"Value":"Sotho","AddAction":"addlimiter(LA99:Sotho)"},{"Value":"Swati(swazi)","AddAction":"addlimiter(LA99:Swati\\(swazi\\))"},{"Value":"Swiss
+        german","AddAction":"addlimiter(LA99:Swiss german)"},{"Value":"Tamashek","AddAction":"addlimiter(LA99:Tamashek)"},{"Value":"Tamil","AddAction":"addlimiter(LA99:Tamil)"},{"Value":"Tatar","AddAction":"addlimiter(LA99:Tatar)"},{"Value":"Tetum","AddAction":"addlimiter(LA99:Tetum)"},{"Value":"Turkmen","AddAction":"addlimiter(LA99:Turkmen)"},{"Value":"Wolof","AddAction":"addlimiter(LA99:Wolof)"},{"Value":"Yoruba","AddAction":"addlimiter(LA99:Yoruba)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"FRENCH","AddAction":"addlimiter(LA99:FRENCH)"},{"Value":"PORTUGUESE","AddAction":"addlimiter(LA99:PORTUGUESE)"},{"Value":"RUSSIAN","AddAction":"addlimiter(LA99:RUSSIAN)"},{"Value":"SPANISH","AddAction":"addlimiter(LA99:SPANISH)"},{"Value":"GERMAN","AddAction":"addlimiter(LA99:GERMAN)"},{"Value":"ENGLISH","AddAction":"addlimiter(LA99:ENGLISH)"},{"Value":"CHINESE","AddAction":"addlimiter(LA99:CHINESE)"},{"Value":"Belorussian","AddAction":"addlimiter(LA99:Belorussian)"},{"Value":"Kazakh","AddAction":"addlimiter(LA99:Kazakh)"},{"Value":"Malayan","AddAction":"addlimiter(LA99:Malayan)"},{"Value":"Moldavian","AddAction":"addlimiter(LA99:Moldavian)"},{"Value":"Uzbek","AddAction":"addlimiter(LA99:Uzbek)"}],"DefaultOn":"n","Order":"10"},{"Id":"FC","Label":"Catalog
+        Only","Type":"select","AddAction":"addlimiter(FC:value)","DefaultOn":"n","Order":"11"}],"AvailableSearchModes":[{"Mode":"bool","Label":"Boolean\/Phrase","DefaultOn":"n","AddAction":"setsearchmode(bool)"},{"Mode":"all","Label":"Find
+        all my search terms","DefaultOn":"y","AddAction":"setsearchmode(all)"},{"Mode":"any","Label":"Find
+        any of my search terms","DefaultOn":"n","AddAction":"setsearchmode(any)"},{"Mode":"smart","Label":"SmartText
+        Searching","DefaultOn":"n","AddAction":"setsearchmode(smart)"}],"AvailableRelatedContent":[{"Type":"emp","Label":"Exact
+        Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
+        Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
+        You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:11:07 GMT
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
+    body:
+      encoding: UTF-8
+      string: '{"DbId":"cat00916a","An":"mit.001492509","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:11:05 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 8f2138ae-aef9-4347-a9e0-1948060b3852
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '1546235666'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '2823'
+    body:
+      encoding: UTF-8
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"cat00916a","DbLabel":"MIT
+        Barton Catalog","An":"mit.001492509","RelevancyScore":"1045","PubType":"Book","PubTypeId":"book"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330","ImageInfo":[{"Size":"thumb","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9781841958811"},{"Size":"medium","Target":"http:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9781841958811"}],"CustomLinks":[{"Url":"https:\/\/library.mit.edu\/item\/001492509?","Name":"MIT
+        Barton Catalog Full Record (cat00916a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"},{"Url":"https:\/\/mit.worldcat.org\/search?q=no%3A166367812","Name":"WorldCat
+        customlink","Category":"ill","Text":"Get it in the library","MouseOverText":"Get
+        items from MIT & non-MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Bananas
+        : how the United Fruit Company shaped the world \/ Peter Chapman."},{"Name":"Language","Label":"Language","Group":"Lang","Data":"English"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Chapman%2C+Peter%22&quot;&gt;Chapman,
+        Peter&lt;\/searchLink&gt;, 1948-"},{"Name":"PubInfo","Label":"Publication
+        Information","Group":"PubInfo","Data":"Edinburgh ; New York : Canongate ;
+        [Berkeley, Calif.?] : Distributed by Publishers Group West, c2007."},{"Name":"EditionInfo","Label":"Edition","Group":"PubInfo","Data":"1st
+        American ed."},{"Name":"DatePub","Label":"Publication Date","Group":"Date","Data":"2007"},{"Name":"PhysDesc","Label":"Physical
+        Description","Group":"PhysDesc","Data":"xv, 224 p. : map ; 21 cm."},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book"},{"Name":"TypeDocument","Label":"Document
+        Type","Group":"TypDoc","Data":"Bibliographies; Non-fiction"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Banana+trade+--+Central+America+--+History%22&quot;&gt;Banana
+        trade -- Central America -- History&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Bananas+--+Social+aspects%22&quot;&gt;Bananas
+        -- Social aspects&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22International+business+enterprises+--+Corrupt+practices%22&quot;&gt;International
+        business enterprises -- Corrupt practices&lt;\/searchLink&gt;"},{"Name":"SubjectGeographic","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Central+America+--+History+--+1951-1979%22&quot;&gt;Central
+        America -- History -- 1951-1979&lt;\/searchLink&gt;"},{"Name":"SubjectCompany","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22United+Fruit+Company+--+History%22&quot;&gt;United
+        Fruit Company -- History&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22United+Fruit+Company+--+Corrupt+practices%22&quot;&gt;United
+        Fruit Company -- Corrupt practices&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Summary:
+        In this exploration of corporate maneuvering and subterfuge, journalist Chapman
+        shows how the importer United Fruit set the precedent for the institutionalized
+        power and influence of today&#39;s multinational companies. This infamous
+        company was arguably the most controversial global corporation ever--from
+        the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from
+        an office on the 44th floor of the Pan Am building in New York City. From
+        the marketing of the banana as the first fast food, to the company&#39;s involvement
+        in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala,
+        Chapman weaves a tale of big business, political deceit, and outright violence
+        to show how one company wreaked havoc in the &quot;banana republics&quot;
+        of Central America, and how terrifyingly similar the age of United Fruit is
+        to our age of rapid globalization.--From publisher description."},{"Name":"TOC","Label":"Content
+        Notes","Group":"TOC","Data":"1. From the Memory of Men -- 2. Lament for a
+        Dying Fruit -- 3. Roots of Empire -- 4. Monopoly -- 5. The Banana Man -- 6.
+        Taming the Enclave -- 7. Banana Republics -- 8. On the Inside -- 9. Coup --
+        10. &#39;Betrayal&#39; -- 11. Decline and Fall -- 12. Old and Dark Forces
+        -- Epilogue: United Fruit World."},{"Name":"Note","Label":"Notes","Group":"Note","Data":"Originally
+        published as: Jungle capitalists.&lt;br \/&gt;Map on lining papers.&lt;br
+        \/&gt;Includes bibliographical references (p. 211-215) and index."},{"Name":"TitleAlt","Label":"Other
+        Titles","Group":"TiAlt","Data":"&lt;searchLink fieldCode=&quot;TI&quot; term=&quot;%22Jungle+capitalists%22&quot;&gt;Jungle
+        capitalists&lt;\/searchLink&gt;"},{"Name":"ISBN","Label":"ISBN","Group":"ISBN","Data":"9781841958811
+        :&lt;br \/&gt;1841958816 :"},{"Name":"NumberOther","Label":"OCLC","Group":"ID","Data":"166367812"},{"Name":"AN","Label":"Accession
+        Number","Group":"ID","Data":"mit.001492509"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"United
+        Fruit Company -- History","Type":"general"},{"SubjectFull":"United Fruit Company
+        -- Corrupt practices","Type":"general"},{"SubjectFull":"Banana trade -- Central
+        America -- History","Type":"general"},{"SubjectFull":"Bananas -- Social aspects","Type":"general"},{"SubjectFull":"International
+        business enterprises -- Corrupt practices","Type":"general"},{"SubjectFull":"Central
+        America -- History -- 1951-1979","Type":"general"}],"Titles":[{"TitleFull":"Bananas
+        : how the United Fruit Company shaped the world.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Chapman,
+        Peter"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2007"}],"Identifiers":[{"Type":"isbn-print","Value":"9781841958811"},{"Type":"isbn-print","Value":"1841958816"}],"Titles":[{"TitleFull":"Bananas
+        : how the United Fruit Company shaped the world \/ Peter Chapman.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"HD9259.B3.U523 2007b"}]}}]}}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:11:07 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

- adds caching for eds-api and aleph responses
- this uses ActionCaching
http://guides.rubyonrails.org/caching_with_rails.html#action-caching
While ActionCaching has been removed from Rails core, it is still a
valid and viable solution.

#### Helpful background context (if appropriate)

- the eds-api data changes infrequently so caching is likely to speed
up reloads and repeat searches
- the aleph data we really need to be "live" so we cache it with a
shorter expiration. However, most data doesn't change so live-live
is overkill and this will speed up refreshes.

#### How can a reviewer manually see the effects of these changes?

View a full record in the PR build from an on-campus IP. It should take a bit of time to load.
Reload the page and it should be super fast. Yay caching.

From a non-campus IP, reload the same record and it should be slower again the first time but fast again on the second load as we cache results dependent on guest status.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-500

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES
