### PR TITLE
Scan button bug fixes

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -45,6 +45,8 @@ class ButtonMaker
     @z30status = @item.xpath('z30/z30-item-status').text
     # Yes, this excludes `z30/` on purpose.
     @z30status_code = @item.xpath('z30-item-status-code').text
+    @year = @item.xpath('z13/z13-year').text
+    @volume = @item.xpath('z30/z30-description').text
   end
 
   def all_buttons
@@ -211,22 +213,25 @@ class ButtonMaker
 
   def url_for_scan
     analytics = 'BENTO'
-    encoded_title = ERB::Util.url_encode(ERB::Util.url_encode(@title))
+    encoded_title = URI.encode_www_form_component(@title)
 
     # The call number is important! In Barton we use different URL parameters
     # for request items, but this ends up with scan requests for Technique
     # (the yearbook) being routed to a Polish land use journal. Call number
     # fixes this bug and does not seem to introduce new ones.
-    encoded_call_no = ERB::Util.url_encode(@call_number)
+    encoded_call_no = URI.encode_www_form_component(@call_number)
 
     [
       sfx_host.to_s,
       "?sid=ALEPH:#{analytics}",
       "&amp;call_number=#{encoded_call_no}",
       '&amp;genre=journal',
+      "&amp;pid=Docnumber=#{@doc_number},Ip=library.mit.edu,Port=9909",
       "&amp;barcode=#{@barcode}",
       "&amp;title=#{encoded_title}",
-      "&amp;location=#{encoded_location}"
+      "&amp;location=#{encoded_location}",
+      "&amp;rft.date=#{@year}",
+      "&amp;rft.volume=#{@volume}"
     ].join('')
   end
 

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -195,14 +195,16 @@ class ButtonMakerTest < ActiveSupport::TestCase
   # ~~~~~~~~~~~~~~~~~ Test URLs for availability action buttons ~~~~~~~~~~~~~~~~
   test 'pdf scan URL in test env' do
     @ButtonMaker.stub :eligible_for_scan?, true do
-      url =  [
+      url = [
         'https://sfx.mit.edu/sfx_test',
         '?sid=ALEPH:BENTO',
-        "&amp;call_number=PS3515.U274%202001",
+        '&amp;call_number=PS3515.U274+2001',
         '&amp;genre=journal',
+        '&amp;pid=Docnumber=001019412,Ip=library.mit.edu,Port=9909',
         '&amp;barcode=39080023421933',
-        '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-        '&amp;location=Hayden%2520Library'
+        '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
+        '&amp;location=Hayden%2520Library',
+        '&amp;rft.date=2001&amp;rft.volume=v.16'
       ].join('')
       assert_equal(url, @ButtonMaker.url_for_scan)
     end
@@ -211,14 +213,16 @@ class ButtonMakerTest < ActiveSupport::TestCase
   test 'pdf scan URL in production env' do
     Rails.stub :env, ActiveSupport::StringInquirer.new('production') do
       @ButtonMaker.stub :eligible_for_scan?, true do
-        url =  [
+        url = [
           'https://sfx.mit.edu/sfx_local',
           '?sid=ALEPH:BENTO',
-          "&amp;call_number=PS3515.U274%202001",
+          '&amp;call_number=PS3515.U274+2001',
           '&amp;genre=journal',
+          '&amp;pid=Docnumber=001019412,Ip=library.mit.edu,Port=9909',
           '&amp;barcode=39080023421933',
-          '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-          '&amp;location=Hayden%2520Library'
+          '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
+          '&amp;location=Hayden%2520Library',
+          '&amp;rft.date=2001&amp;rft.volume=v.16'
         ].join('')
         assert_equal(url, @ButtonMaker.url_for_scan)
       end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

- removes double encoding of passed title and changes to
`URI.encode_www_form_component`
- adds `rft.date` to populate year field
- adds `rft.volume` to populate volume field in the future (changes to
SFX script will be necessary to get this to pass through to Illiad)
- adds `&amp;pid=Docnumber=#{@doc_number},Ip=library.mit.edu,Port=9909`
to match how Aleph requests look

#### How can a reviewer manually see the effects of these changes?

On the PR build, activate full record views.

Search for a local record and click "request scan".

The year should be populated and the title should not be encoded.

Confirm on the staging server the same record leads to no year being populated and the title being encoded.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-618
- https://mitlibraries.atlassian.net/browse/DI-619

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO