### PR TITLE
Provides fallback link to SFX menu if we don't know what else to do

### DIFF
--- a/app/concerns/sfx_handler.rb
+++ b/app/concerns/sfx_handler.rb
@@ -1,7 +1,11 @@
 class SFXHandler
 
-  # Start with whatever metadata we've got. It's OK if these are blank - the
-  # SFX server will do the best it can with whatever it has.
+  # The SFX server will do the best it can with whatever it has, so we will
+  # initialize the SFXHandler with whatever data we happen to have. We're not
+  # guaranteed to have all (or indeed any) of these objects; Aleph and EDS
+  # provide different subsets of them. We provide default nil values so that
+  # we don't have to pass parameters in when we don't have the corresponding
+  # data.
   def initialize(barcode: nil,
                  call_number: nil,
                  collection: nil,

--- a/app/concerns/sfx_handler.rb
+++ b/app/concerns/sfx_handler.rb
@@ -1,0 +1,93 @@
+class SFXHandler
+
+  # Start with whatever metadata we've got. It's OK if these are blank - the
+  # SFX server will do the best it can with whatever it has.
+  def initialize(barcode: nil,
+                 call_number: nil,
+                 collection: nil,
+                 doc_number: nil,
+                 library: nil,
+                 title: nil)
+    @barcode = barcode
+    @call_number = call_number
+    @collection = collection
+    @doc_number = doc_number
+    @title = title
+    @library = library
+  end
+
+  # Use this when you want to request a scan of an object.
+  def url_for_scan
+    url_constructor(scan: true)
+  end
+
+  # Use this when you just want SFX to make its best guess.
+  def url_generic
+    url_constructor
+  end
+
+  private
+
+  def url_constructor(scan: false)
+    encoded_title = ERB::Util.url_encode(@title)
+
+    # Yes, sometimes we double-encode, so that when SFX passes parameters
+    # through its next step they end up as hoped.
+    if scan
+      encoded_title = ERB::Util.url_encode(encoded_title)
+      analytics = 'BENTO'
+    else
+      # Things with analytics=BENTO are automatically routed through scan &
+      # deliver by SFX. That's great if we want to scan, but not great if we
+      # don't. Since this URL is used as a fallback - when all other options
+      # have failed - we have no idea what we're dealing with and it could be
+      # an object unsuitable for scan (e.g. audiotape, large-format map,
+      # entire book).
+      analytics = 'BENTO_FALLBACK'
+    end
+
+    # The call number is important! In Barton we use different URL parameters
+    # for request items, but this ends up with scan requests for Technique
+    # (the yearbook) being routed to a Polish land use journal. Call number
+    # fixes this bug and does not seem to introduce new ones.
+    encoded_call_no = ERB::Util.url_encode(@call_number)
+
+    url_parts = [
+      sfx_host.to_s,
+      "?sid=ALEPH:#{analytics}",
+      "&amp;call_number=#{encoded_call_no}",
+      "&amp;barcode=#{@barcode}",
+      "&amp;title=#{encoded_title}",
+      "&amp;location=#{encoded_location}"
+    ]
+
+    if @doc_number
+      url_parts.push(
+        "&amp;pid=DocNumber=#{@doc_number},Ip=library.mit.edu,Port=9909"
+      )
+    end
+
+    if scan
+      url_parts.push('&amp;genre=journal')
+    end
+
+    url_parts.join('')
+  end
+
+  def encoded_location
+    location = if @collection == 'Off Campus Collection'
+                 'OCC'
+               else
+                 @library
+               end
+    ERB::Util.url_encode(ERB::Util.url_encode(location))
+  end
+
+  def sfx_host
+    if Rails.env.production?
+      'https://sfx.mit.edu/sfx_local'
+    else
+      'https://sfx.mit.edu/sfx_test'
+    end
+  end
+end

--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -210,24 +210,13 @@ class ButtonMaker
   end
 
   def url_for_scan
-    analytics = 'BENTO'
-    encoded_title = ERB::Util.url_encode(ERB::Util.url_encode(@title))
-
-    # The call number is important! In Barton we use different URL parameters
-    # for request items, but this ends up with scan requests for Technique
-    # (the yearbook) being routed to a Polish land use journal. Call number
-    # fixes this bug and does not seem to introduce new ones.
-    encoded_call_no = ERB::Util.url_encode(@call_number)
-
-    [
-      sfx_host.to_s,
-      "?sid=ALEPH:#{analytics}",
-      "&amp;call_number=#{encoded_call_no}",
-      '&amp;genre=journal',
-      "&amp;barcode=#{@barcode}",
-      "&amp;title=#{encoded_title}",
-      "&amp;location=#{encoded_location}"
-    ].join('')
+    SFXHandler.new(
+      barcode: @barcode,
+      call_number: @call_number,
+      collection: @collection,
+      library: @library,
+      title: @title
+    ).url_for_scan
   end
 
   def url_for_ill
@@ -326,23 +315,6 @@ class ButtonMaker
     [
       'In Library', 'MIT Reads', 'New Books Displ', 'On Display'
     ].include?(@status) && @requestable
-  end
-
-  def sfx_host
-    if Rails.env.production?
-      'https://sfx.mit.edu/sfx_local'
-    else
-      'https://sfx.mit.edu/sfx_test'
-    end
-  end
-
-  def encoded_location
-    location = if @collection == 'Off Campus Collection'
-                 'OCC'
-               else
-                 @library
-               end
-    ERB::Util.url_encode(ERB::Util.url_encode(location))
   end
 
   def clean_oclc

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -1,29 +1,7 @@
 <h3 class="section-title">Availability</h3>
 <% if @record.fulltext_link.present? %>
   <div class="link-fulltext">
-
-    <%# SFX links that we don't know for sure if we own; auth happens at SFX %>
-    <% if check_online? %>
-      <a class="button button-secondary" href="<%= @record.fulltext_link[:url] %>">Check for online copy</a>
-
-    <%# Links is expiring / restricted so we can only show to affiliates %>
-    <% elsif guest_and_restricted_link? %>
-      <div class="inline-action well signin-fulltext">
-        <p class="message">Full text available</p>
-        <div class="actions">
-          <a class="button button-secondary" href="<%= login_url %>">Sign in for access</a>
-        </div>
-      </div>
-
-    <%# Restricted expiring link, but current user is allowed to access it.
-        We'll get a fresh version of the link and redirect them to it %>
-    <% elsif restricted_link? %>
-      <%= link_to('View online', record_direct_link_path(params[:db_source], params[:an]), class: 'button button-primary green') %>
-
-    <%# Non restricted full text link (usually authenticated through SFX) %>
-    <% elsif relevant_fulltext_link?(@record.fulltext_link) %>
-      <a class="button button-primary green" href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>
-    <% end %>
+    <%= render partial: availability_action %>
   </div>
 <% end %>
 

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -1,6 +1,15 @@
 <h3 class="section-title">Availability</h3>
 <% if @record.fulltext_link.present? %>
   <div class="link-fulltext">
+    <%# We used to have logic here that decided which HTML to display. However,
+        there are at least 5 different availability situations, requiring 4
+        different HTML chunks, which got to be too heavy for a view. So the
+        complicated logic for picking which HTML to display is now in the
+        helper. The output of that logic is the name of the partial to use;
+        it also sets any instance variables that may be required to render
+        said partial. This leads to the somewhat odd situation of having a
+        variable name rather than a string in this render: call, because we
+        don't know which HTML chunk we want to render until runtime. %>
     <%= render partial: availability_action %>
   </div>
 <% end %>

--- a/app/views/record/_availability_check_online.html.erb
+++ b/app/views/record/_availability_check_online.html.erb
@@ -1,0 +1,2 @@
+<%# Make sure to set an @sfx_link value if using this partial! %>
+<a class="button button-secondary" href="<%= @sfx_link %>">Check for online copy</a>

--- a/app/views/record/_availability_expiring.html.erb
+++ b/app/views/record/_availability_expiring.html.erb
@@ -1,0 +1,1 @@
+<%= link_to('View online', record_direct_link_path(params[:db_source], params[:an]), class: 'button button-primary green') %>

--- a/app/views/record/_availability_full.html.erb
+++ b/app/views/record/_availability_full.html.erb
@@ -1,0 +1,1 @@
+<a class="button button-primary green" href="<%= @record.fulltext_link[:url] %>" class="btn button-primary">View online</a>

--- a/app/views/record/_availability_restricted.html.erb
+++ b/app/views/record/_availability_restricted.html.erb
@@ -1,0 +1,6 @@
+<div class="inline-action well signin-fulltext">
+  <p class="message">Full text available</p>
+  <div class="actions">
+    <a class="button button-secondary" href="<%= login_url %>">Sign in for access</a>
+  </div>
+</div>

--- a/test/concerns/sfx_handler_test.rb
+++ b/test/concerns/sfx_handler_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class SFXHandlerConcernTest < MiniTest::Test
+  def test_eds_like_params_scan_url
+    barcode = '39080014585712'
+    call_number = 'PS3552.U827.P37 2000'
+    collection = 'Stacks'
+    library = 'Hayden Library'
+    title = 'Parable of the sower'
+    sfx_link = SFXHandler.new(
+      barcode: barcode,
+      call_number: call_number,
+      collection: collection,
+      library: library,
+      title: title
+    ).url_for_scan
+
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO&amp;call_number=PS3552.U827.P37%202000&amp;barcode=39080014585712&amp;title=Parable%2520of%2520the%2520sower&amp;location=Hayden%2520Library&amp;genre=journal'
+
+    assert_equal(expected_url, sfx_link)
+  end
+
+  def test_aleph_like_params_generic_url
+    title = 'This is a title'
+    clean_an = '35819515'
+    sfx_link = SFXHandler.new(
+      title: title,
+      doc_number: clean_an,
+    ).url_generic
+
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO_FALLBACK&amp;call_number=&amp;barcode=&amp;title=This%20is%20a%20title&amp;location=&amp;pid=DocNumber=35819515,Ip=library.mit.edu,Port=9909'
+
+    assert_equal(expected_url, sfx_link)
+  end
+end

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -60,7 +60,7 @@ DOC
 
   end
 
-  test 'link with a domain in relavent links' do
+  test 'link with a domain in relevant links' do
     link = { url: 'https://libraries.mit.edu/F/stuff' }
     assert(relevant_fulltext_link?(link))
   end

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -97,6 +97,15 @@ class RecordTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'emergency backup SFX link shown when we do not know what to do' do
+    VCR.use_cassette('record: omgwtfbbq', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'edsasp', an: 'edsasp.ASP2223378.CLMU' }
+      assert_response :success
+      assert_select 'a.button-primary', text: 'View online', count: 0
+      assert_select 'a', text: 'Check for online copy'
+    end
+  end
+
   test 'summary holdings are shown when available' do
     VCR.use_cassette('record: journal', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.000292123' }

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -275,10 +275,10 @@ class ButtonMakerTest < ActiveSupport::TestCase
         'https://sfx.mit.edu/sfx_test',
         '?sid=ALEPH:BENTO',
         "&amp;call_number=PS3515.U274%202001",
-        '&amp;genre=journal',
         '&amp;barcode=39080023421933',
         '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-        '&amp;location=Hayden%2520Library'
+        '&amp;location=Hayden%2520Library',
+        '&amp;genre=journal'
       ].join('')
       assert_equal(url, @ButtonMaker.url_for_scan)
     end
@@ -291,10 +291,10 @@ class ButtonMakerTest < ActiveSupport::TestCase
           'https://sfx.mit.edu/sfx_local',
           '?sid=ALEPH:BENTO',
           "&amp;call_number=PS3515.U274%202001",
-          '&amp;genre=journal',
           '&amp;barcode=39080023421933',
           '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-          '&amp;location=Hayden%2520Library'
+          '&amp;location=Hayden%2520Library',
+          '&amp;genre=journal'
         ].join('')
         assert_equal(url, @ButtonMaker.url_for_scan)
       end

--- a/test/vcr_cassettes/record_omgwtfbbq.yml
+++ b/test/vcr_cassettes/record_omgwtfbbq.yml
@@ -1,0 +1,333 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2017 17:56:57 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Tue, 12 Dec 2017 17:43:50 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2017 17:56:56 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 5b5bf7fa-b571-401f-9e56-19a77c266ff9
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-971086910"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"74b876bb-76a2-4bbc-9e07-d477b7da09cd.MvUO63laXz\/OOZAWVKWQw1fS4YeOk+D4VZhe77iNJhw="}'
+    http_version:
+  recorded_at: Tue, 12 Dec 2017 17:43:51 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2017 17:56:57 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 99a3426e-febd-4624-b0d2-c5b002e88155
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-971086910"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '3692'
+    body:
+      encoding: UTF-8
+      string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"date","Label":"Date
+        Newest","AddAction":"setsort(date)"},{"Id":"date2","Label":"Date Oldest","AddAction":"setsort(date2)"},{"Id":"relevance","Label":"Relevance","AddAction":"setsort(relevance)"}],"AvailableSearchFields":[{"FieldCode":"TX","Label":"All
+        Text"},{"FieldCode":"AU","Label":"Author"},{"FieldCode":"TI","Label":"Title"},{"FieldCode":"SU","Label":"Subject
+        Terms"},{"FieldCode":"SO","Label":"Source"},{"FieldCode":"AB","Label":"Abstract"},{"FieldCode":"IS","Label":"ISSN"},{"FieldCode":"IB","Label":"ISBN"}],"AvailableExpanders":[{"Id":"relatedsubjects","Label":"Apply
+        equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"},{"Id":"thesaurus","Label":"Apply
+        related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
+        search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"2"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
+        Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
+        Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
+        Barton Catalog","AddAction":"addlimiter(LB:MIT Barton Catalog)","LimiterValues":[{"Value":"Barker
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Barker Library)"},{"Value":"Dewey
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Dewey Library)"},{"Value":"Hayden
+        Library - Humanities","AddAction":"addlimiter(LB:MIT Barton Catalog-Hayden
+        Library - Humanities)"},{"Value":"Hayden Library - Science","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Library - Science)"},{"Value":"Hayden Reserves","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Reserves)"},{"Value":"Institute Archives","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Institute Archives)"},{"Value":"Internet Resource","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Internet Resource)"},{"Value":"Lewis Music Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Lewis Music Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Visual Collections)"}]},{"Value":"MIT Course Reserves","AddAction":"addlimiter(LB:MIT
+        Course Reserves)","LimiterValues":[{"Value":"Barker Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Barker Library)"},{"Value":"Dewey Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Dewey Library)"},{"Value":"Hayden Library - Humanities","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Hayden Library - Humanities)"},{"Value":"Hayden Library -
+        Science","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Library - Science)"},{"Value":"Hayden
+        Reserves","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Reserves)"},{"Value":"Institute
+        Archives","AddAction":"addlimiter(LB:MIT Course Reserves-Institute Archives)"},{"Value":"Internet
+        Resource","AddAction":"addlimiter(LB:MIT Course Reserves-Internet Resource)"},{"Value":"Lewis
+        Music Library","AddAction":"addlimiter(LB:MIT Course Reserves-Lewis Music
+        Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Visual Collections)"}]}],"DefaultOn":"n","Order":"8"},{"Id":"FT1","Label":"Available
+        in Library Collection","Type":"select","AddAction":"addlimiter(FT1:value)","DefaultOn":"n","Order":"9"},{"Id":"LA99","Label":"Language","Type":"multiselectvalue","LimiterValues":[{"Value":"Catalan","AddAction":"addlimiter(LA99:Catalan)"},{"Value":"Chinese","AddAction":"addlimiter(LA99:Chinese)"},{"Value":"Croatian","AddAction":"addlimiter(LA99:Croatian)"},{"Value":"Dutch\/Flemish","AddAction":"addlimiter(LA99:Dutch\/Flemish)"},{"Value":"English","AddAction":"addlimiter(LA99:English)"},{"Value":"French","AddAction":"addlimiter(LA99:French)"},{"Value":"German","AddAction":"addlimiter(LA99:German)"},{"Value":"Italian","AddAction":"addlimiter(LA99:Italian)"},{"Value":"Lithuanian","AddAction":"addlimiter(LA99:Lithuanian)"},{"Value":"Portuguese","AddAction":"addlimiter(LA99:Portuguese)"},{"Value":"Romanian","AddAction":"addlimiter(LA99:Romanian)"},{"Value":"Russian","AddAction":"addlimiter(LA99:Russian)"},{"Value":"Spanish","AddAction":"addlimiter(LA99:Spanish)"},{"Value":"Turkish","AddAction":"addlimiter(LA99:Turkish)"},{"Value":"Japanese","AddAction":"addlimiter(LA99:Japanese)"},{"Value":"Afrikaans","AddAction":"addlimiter(LA99:Afrikaans)"},{"Value":"Albanian","AddAction":"addlimiter(LA99:Albanian)"},{"Value":"Amharic","AddAction":"addlimiter(LA99:Amharic)"},{"Value":"Arabic","AddAction":"addlimiter(LA99:Arabic)"},{"Value":"Armenian","AddAction":"addlimiter(LA99:Armenian)"},{"Value":"Aromanian","AddAction":"addlimiter(LA99:Aromanian)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Bambara","AddAction":"addlimiter(LA99:Bambara)"},{"Value":"Bengali","AddAction":"addlimiter(LA99:Bengali)"},{"Value":"Bosnian","AddAction":"addlimiter(LA99:Bosnian)"},{"Value":"Bulgarian","AddAction":"addlimiter(LA99:Bulgarian)"},{"Value":"Czech","AddAction":"addlimiter(LA99:Czech)"},{"Value":"Danish","AddAction":"addlimiter(LA99:Danish)"},{"Value":"Dutch","AddAction":"addlimiter(LA99:Dutch)"},{"Value":"Filipino","AddAction":"addlimiter(LA99:Filipino)"},{"Value":"Finnish","AddAction":"addlimiter(LA99:Finnish)"},{"Value":"Flemish","AddAction":"addlimiter(LA99:Flemish)"},{"Value":"Gaelic","AddAction":"addlimiter(LA99:Gaelic)"},{"Value":"Greek","AddAction":"addlimiter(LA99:Greek)"},{"Value":"Gujarati","AddAction":"addlimiter(LA99:Gujarati)"},{"Value":"Hausa","AddAction":"addlimiter(LA99:Hausa)"},{"Value":"Hawaiian","AddAction":"addlimiter(LA99:Hawaiian)"},{"Value":"Hebrew","AddAction":"addlimiter(LA99:Hebrew)"},{"Value":"Hindi","AddAction":"addlimiter(LA99:Hindi)"},{"Value":"Hmong","AddAction":"addlimiter(LA99:Hmong)"},{"Value":"Hungarian","AddAction":"addlimiter(LA99:Hungarian)"},{"Value":"Igbo","AddAction":"addlimiter(LA99:Igbo)"},{"Value":"Indonesian","AddAction":"addlimiter(LA99:Indonesian)"},{"Value":"javanese","AddAction":"addlimiter(LA99:javanese)"},{"Value":"Kashmiri","AddAction":"addlimiter(LA99:Kashmiri)"},{"Value":"Korean","AddAction":"addlimiter(LA99:Korean)"},{"Value":"Kurdish","AddAction":"addlimiter(LA99:Kurdish)"},{"Value":"Lao","AddAction":"addlimiter(LA99:Lao)"},{"Value":"Latin","AddAction":"addlimiter(LA99:Latin)"},{"Value":"Latvian","AddAction":"addlimiter(LA99:Latvian)"},{"Value":"Lingala","AddAction":"addlimiter(LA99:Lingala)"},{"Value":"Macedonian","AddAction":"addlimiter(LA99:Macedonian)"},{"Value":"Malagasy","AddAction":"addlimiter(LA99:Malagasy)"},{"Value":"Marathi","AddAction":"addlimiter(LA99:Marathi)"},{"Value":"Mende","AddAction":"addlimiter(LA99:Mende)"},{"Value":"Moldovan","AddAction":"addlimiter(LA99:Moldovan)"},{"Value":"Mongolian","AddAction":"addlimiter(LA99:Mongolian)"},{"Value":"Nepali","AddAction":"addlimiter(LA99:Nepali)"},{"Value":"Norwegian","AddAction":"addlimiter(LA99:Norwegian)"},{"Value":"Oriya","AddAction":"addlimiter(LA99:Oriya)"},{"Value":"Oromo","AddAction":"addlimiter(LA99:Oromo)"},{"Value":"Pashto","AddAction":"addlimiter(LA99:Pashto)"},{"Value":"Persian","AddAction":"addlimiter(LA99:Persian)"},{"Value":"Pidgin
+        english","AddAction":"addlimiter(LA99:Pidgin english)"},{"Value":"Polish","AddAction":"addlimiter(LA99:Polish)"},{"Value":"Punjabi","AddAction":"addlimiter(LA99:Punjabi)"},{"Value":"Quechua","AddAction":"addlimiter(LA99:Quechua)"},{"Value":"Romany","AddAction":"addlimiter(LA99:Romany)"},{"Value":"Samoan","AddAction":"addlimiter(LA99:Samoan)"},{"Value":"Sango","AddAction":"addlimiter(LA99:Sango)"},{"Value":"Sanskrit","AddAction":"addlimiter(LA99:Sanskrit)"},{"Value":"Serbian","AddAction":"addlimiter(LA99:Serbian)"},{"Value":"Shona","AddAction":"addlimiter(LA99:Shona)"},{"Value":"Sinhala","AddAction":"addlimiter(LA99:Sinhala)"},{"Value":"Slovak","AddAction":"addlimiter(LA99:Slovak)"},{"Value":"Slovenian","AddAction":"addlimiter(LA99:Slovenian)"},{"Value":"Sotho","AddAction":"addlimiter(LA99:Sotho)"},{"Value":"Swahili","AddAction":"addlimiter(LA99:Swahili)"},{"Value":"Swati(swazi)","AddAction":"addlimiter(LA99:Swati\\(swazi\\))"},{"Value":"Swedish","AddAction":"addlimiter(LA99:Swedish)"},{"Value":"Swiss
+        german","AddAction":"addlimiter(LA99:Swiss german)"},{"Value":"Tagalog","AddAction":"addlimiter(LA99:Tagalog)"},{"Value":"Tamashek","AddAction":"addlimiter(LA99:Tamashek)"},{"Value":"Tamil","AddAction":"addlimiter(LA99:Tamil)"},{"Value":"Tatar","AddAction":"addlimiter(LA99:Tatar)"},{"Value":"Tetum","AddAction":"addlimiter(LA99:Tetum)"},{"Value":"Thai","AddAction":"addlimiter(LA99:Thai)"},{"Value":"Tibetan","AddAction":"addlimiter(LA99:Tibetan)"},{"Value":"Turkmen","AddAction":"addlimiter(LA99:Turkmen)"},{"Value":"Urdu","AddAction":"addlimiter(LA99:Urdu)"},{"Value":"Vietnamese","AddAction":"addlimiter(LA99:Vietnamese)"},{"Value":"Wolof","AddAction":"addlimiter(LA99:Wolof)"},{"Value":"Xhosa","AddAction":"addlimiter(LA99:Xhosa)"},{"Value":"Yoruba","AddAction":"addlimiter(LA99:Yoruba)"},{"Value":"Zulu","AddAction":"addlimiter(LA99:Zulu)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Abkhazian","AddAction":"addlimiter(LA99:Abkhazian)"},{"Value":"Mapudungun;
+        Mapuche","AddAction":"addlimiter(LA99:Mapudungun; Mapuche)"},{"Value":"Asturian;
+        Bable; Leonese; Asturleonese","AddAction":"addlimiter(LA99:Asturian; Bable;
+        Leonese; Asturleonese)"},{"Value":"Australian languages","AddAction":"addlimiter(LA99:Australian
+        languages)"},{"Value":"Basque","AddAction":"addlimiter(LA99:Basque)"},{"Value":"Breton","AddAction":"addlimiter(LA99:Breton)"},{"Value":"Burmese","AddAction":"addlimiter(LA99:Burmese)"},{"Value":"Central
+        American Indian languages","AddAction":"addlimiter(LA99:Central American Indian
+        languages)"},{"Value":"Catalan; Valencian","AddAction":"addlimiter(LA99:Catalan;
+        Valencian)"},{"Value":"Chechen","AddAction":"addlimiter(LA99:Chechen)"},{"Value":"Coptic","AddAction":"addlimiter(LA99:Coptic)"},{"Value":"Dutch;
+        Flemish","AddAction":"addlimiter(LA99:Dutch; Flemish)"},{"Value":"English,
+        Middle (1100-1500)","AddAction":"addlimiter(LA99:English\\, Middle \\(1100-1500\\))"},{"Value":"Esperanto","AddAction":"addlimiter(LA99:Esperanto)"},{"Value":"Estonian","AddAction":"addlimiter(LA99:Estonian)"},{"Value":"Faroese","AddAction":"addlimiter(LA99:Faroese)"},{"Value":"Fijian","AddAction":"addlimiter(LA99:Fijian)"},{"Value":"Germanic
+        languages","AddAction":"addlimiter(LA99:Germanic languages)"},{"Value":"Geez","AddAction":"addlimiter(LA99:Geez)"},{"Value":"Irish","AddAction":"addlimiter(LA99:Irish)"},{"Value":"Galician","AddAction":"addlimiter(LA99:Galician)"},{"Value":"Greek,
+        Ancient (to 1453)","AddAction":"addlimiter(LA99:Greek\\, Ancient \\(to 1453\\))"},{"Value":"Greek,
+        Modern (1453-)","AddAction":"addlimiter(LA99:Greek\\, Modern \\(1453-\\))"},{"Value":"Haitian;
+        Haitian Creole","AddAction":"addlimiter(LA99:Haitian; Haitian Creole)"},{"Value":"Icelandic","AddAction":"addlimiter(LA99:Icelandic)"},{"Value":"Ido","AddAction":"addlimiter(LA99:Ido)"},{"Value":"Interlingua
+        (International Auxiliary Language Association)","AddAction":"addlimiter(LA99:Interlingua
+        \\(International Auxiliary Language Association\\))"},{"Value":"Javanese","AddAction":"addlimiter(LA99:Javanese)"},{"Value":"Judeo-Arabic","AddAction":"addlimiter(LA99:Judeo-Arabic)"},{"Value":"Kannada","AddAction":"addlimiter(LA99:Kannada)"},{"Value":"Luxembourgish;
+        Letzeburgesch","AddAction":"addlimiter(LA99:Luxembourgish; Letzeburgesch)"},{"Value":"Malayalam","AddAction":"addlimiter(LA99:Malayalam)"},{"Value":"Austronesian
+        languages","AddAction":"addlimiter(LA99:Austronesian languages)"},{"Value":"Malay","AddAction":"addlimiter(LA99:Malay)"},{"Value":"Maltese","AddAction":"addlimiter(LA99:Maltese)"},{"Value":"Nahuatl
+        languages","AddAction":"addlimiter(LA99:Nahuatl languages)"},{"Value":"Neapolitan","AddAction":"addlimiter(LA99:Neapolitan)"},{"Value":"Bokmål,
+        Norwegian; Norwegian Bokmål","AddAction":"addlimiter(LA99:Bokmål\\, Norwegian;
+        Norwegian Bokmål)"},{"Value":"Norse, Old","AddAction":"addlimiter(LA99:Norse\\,
+        Old)"},{"Value":"Occitan (post 1500)","AddAction":"addlimiter(LA99:Occitan
+        \\(post 1500\\))"},{"Value":"Ojibwa","AddAction":"addlimiter(LA99:Ojibwa)"},{"Value":"Philippine
+        languages","AddAction":"addlimiter(LA99:Philippine languages)"},{"Value":"Romanian;
+        Moldavian; Moldovan","AddAction":"addlimiter(LA99:Romanian; Moldavian; Moldovan)"},{"Value":"Samaritan
+        Aramaic","AddAction":"addlimiter(LA99:Samaritan Aramaic)"},{"Value":"Sinhala;
+        Sinhalese","AddAction":"addlimiter(LA99:Sinhala; Sinhalese)"},{"Value":"Spanish;
+        Castilian","AddAction":"addlimiter(LA99:Spanish; Castilian)"},{"Value":"Sundanese","AddAction":"addlimiter(LA99:Sundanese)"},{"Value":"Sumerian","AddAction":"addlimiter(LA99:Sumerian)"},{"Value":"Classical
+        Syriac","AddAction":"addlimiter(LA99:Classical Syriac)"},{"Value":"Ugaritic","AddAction":"addlimiter(LA99:Ugaritic)"},{"Value":"Welsh","AddAction":"addlimiter(LA99:Welsh)"},{"Value":"Yiddish","AddAction":"addlimiter(LA99:Yiddish)"},{"Value":"Zapotec","AddAction":"addlimiter(LA99:Zapotec)"},{"Value":"Belarusian","AddAction":"addlimiter(LA99:Belarusian)"},{"Value":"Georgian","AddAction":"addlimiter(LA99:Georgian)"},{"Value":"Modern
+        Greek","AddAction":"addlimiter(LA99:Modern Greek)"},{"Value":"Ukranian","AddAction":"addlimiter(LA99:Ukranian)"},{"Value":"Ukrainian","AddAction":"addlimiter(LA99:Ukrainian)"},{"Value":"Azerbaijani","AddAction":"addlimiter(LA99:Azerbaijani)"},{"Value":"Serbo-Croatian","AddAction":"addlimiter(LA99:Serbo-Croatian)"},{"Value":"Greek,
+        Modern","AddAction":"addlimiter(LA99:Greek\\, Modern)"},{"Value":"Sotho, Southern","AddAction":"addlimiter(LA99:Sotho\\,
+        Southern)"},{"Value":"Venda","AddAction":"addlimiter(LA99:Venda)"},{"Value":"Aragonese","AddAction":"addlimiter(LA99:Aragonese)"},{"Value":"Greek,
+        Ancient","AddAction":"addlimiter(LA99:Greek\\, Ancient)"},{"Value":"Occitan","AddAction":"addlimiter(LA99:Occitan)"},{"Value":"FRENCH","AddAction":"addlimiter(LA99:FRENCH)"},{"Value":"PORTUGUESE","AddAction":"addlimiter(LA99:PORTUGUESE)"},{"Value":"RUSSIAN","AddAction":"addlimiter(LA99:RUSSIAN)"},{"Value":"SPANISH","AddAction":"addlimiter(LA99:SPANISH)"},{"Value":"GERMAN","AddAction":"addlimiter(LA99:GERMAN)"},{"Value":"ENGLISH","AddAction":"addlimiter(LA99:ENGLISH)"},{"Value":"CHINESE","AddAction":"addlimiter(LA99:CHINESE)"},{"Value":"Belorussian","AddAction":"addlimiter(LA99:Belorussian)"},{"Value":"Kazakh","AddAction":"addlimiter(LA99:Kazakh)"},{"Value":"Malayan","AddAction":"addlimiter(LA99:Malayan)"},{"Value":"Moldavian","AddAction":"addlimiter(LA99:Moldavian)"},{"Value":"Uzbek","AddAction":"addlimiter(LA99:Uzbek)"},{"Value":"Iranian
+        languages","AddAction":"addlimiter(LA99:Iranian languages)"},{"Value":"Marshallese","AddAction":"addlimiter(LA99:Marshallese)"},{"Value":"Nepal
+        Bhasa; Newari","AddAction":"addlimiter(LA99:Nepal Bhasa; Newari)"}],"DefaultOn":"n","Order":"10"},{"Id":"FC","Label":"Catalog
+        Only","Type":"select","AddAction":"addlimiter(FC:value)","DefaultOn":"n","Order":"11"}],"AvailableSearchModes":[{"Mode":"bool","Label":"Boolean\/Phrase","DefaultOn":"n","AddAction":"setsearchmode(bool)"},{"Mode":"all","Label":"Find
+        all my search terms","DefaultOn":"y","AddAction":"setsearchmode(all)"},{"Mode":"any","Label":"Find
+        any of my search terms","DefaultOn":"n","AddAction":"setsearchmode(any)"},{"Mode":"smart","Label":"SmartText
+        Searching","DefaultOn":"n","AddAction":"setsearchmode(smart)"}],"AvailableRelatedContent":[{"Type":"emp","Label":"Exact
+        Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
+        Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
+        You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief"},"ApplicationSettings":{"SessionTimeout":"480"},"ApiSettings":{"MaxRecordJumpAhead":"250"}}'
+    http_version:
+  recorded_at: Tue, 12 Dec 2017 17:43:51 GMT
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
+    body:
+      encoding: UTF-8
+      string: '{"DbId":"edsasp","An":"edsasp.ASP2223378.CLMU","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Dec 2017 17:56:58 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 4d3ec898-d690-40c1-8713-aed9c5f884f5
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-971086910"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '1530'
+    body:
+      encoding: UTF-8
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"edsasp","DbLabel":"Alexander
+        Street Press","An":"edsasp.ASP2223378.CLMU","PubType":"Audio","PubTypeId":"audio"},"PLink":"http:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=edsasp&AN=edsasp.ASP2223378.CLMU&authtype=sso&custid=s8978330","FullText":{"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/www.aspresolver.com\/aspresolver.asp?CLMU;2223378;?","Name":"EDS
+        - Alexander Street Press","Category":"fullText","Text":"Full Text from Alexander
+        Street Press","MouseOverText":"Full Text from Alexander Street Press"},{"Url":"https:\/\/sfx.mit.edu\/sfx_local?genre=book&atitle=&title=Philadelphia%20Chickens%20%28Boynton%29%20%5Belectronic%20resource%5D.&issn=edsasp.e7cb&isbn=1166181222&volume=&issue=&date=20040101&aulast=Boynton,
+        Sandra&spage=&pages=&sid=EBSCO:Alexander%20Street%20Press:edsasp.ASP2223378.CLMU","Name":"SFX
+        link (not subscribed resources)","Category":"fullText","Text":"Check SFX for
+        availability","MouseOverText":"Check SFX for availability."}]},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Philadelphia
+        Chickens (Boynton) [electronic resource]."},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Boynton%2C+Sandra%22&quot;&gt;Boynton,
+        Sandra&lt;\/searchLink&gt;"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Rounder+Records%22&quot;&gt;Rounder
+        Records&lt;\/searchLink&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"philadelphia
+        chickens&lt;br \/&gt;[S.l: s.n.], 2004."},{"Name":"PhysDesc","Label":"Physical
+        Description","Group":"PhysDesc","Data":"1 online resource (4 min.)"},{"Name":"DatePubCY","Label":"Publication
+        Date","Group":"Date","Data":"2004"},{"Name":"Subject","Label":"Subject Terms","Group":"Su","Data":"&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Music+%26+Performing+Arts+--+American+Music+--+Stage+%2B+Screen%22&quot;&gt;Music
+        &amp; Performing Arts -- American Music -- Stage + Screen&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22American+Studies+--+American+Music+--+Stage+%2B+Screen%22&quot;&gt;American
+        Studies -- American Music -- Stage + Screen&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Voice%22&quot;&gt;Voice&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Saxophone%2C+Alto%22&quot;&gt;Saxophone,
+        Alto&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Whistle%22&quot;&gt;Whistle&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Music+recording%22&quot;&gt;Music recording&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Children&#39;s+--+Children&#39;s%22&quot;&gt;Children&#39;s
+        -- Children&#39;s&lt;\/searchLink&gt;"},{"Name":"TypeDocument","Label":"Document
+        Type","Group":"TypDoc","Data":"Audio"},{"Name":"AN","Label":"Accession Number","Group":"ID","Data":"edsasp.ASP2223378.CLMU"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Subjects":[{"SubjectFull":"Music
+        & Performing Arts -- American Music -- Stage + Screen","Type":"general"},{"SubjectFull":"American
+        Studies -- American Music -- Stage + Screen","Type":"general"},{"SubjectFull":"Voice","Type":"general"},{"SubjectFull":"Saxophone,
+        Alto","Type":"general"},{"SubjectFull":"Whistle","Type":"general"},{"SubjectFull":"Music
+        recording","Type":"general"},{"SubjectFull":"Children''s -- Children''s","Type":"general"}],"Titles":[{"TitleFull":"Philadelphia
+        Chickens (Boynton)","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Boynton,
+        Sandra"}}},{"PersonEntity":{"Name":{"NameFull":"Rounder Records"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2004"}],"Identifiers":[{"Type":"isbn-print","Value":"1166181222"},{"Type":"issn-other","Value":"edsasp.e7cb"},{"Type":"issn-other","Value":"edsasp.d67a"},{"Type":"issn-other","Value":"edsasp.b5fd"},{"Type":"issn-other","Value":"edsasp.99ca"},{"Type":"issn-other","Value":"edsasp.5bd2"}],"Titles":[{"TitleFull":"philadelphia
+        chickens","Type":"main"},{"TitleFull":"Philadelphia Chickens (Boynton) [electronic
+        resource].","Type":"main"}]}}]}}}}}'
+    http_version:
+  recorded_at: Tue, 12 Dec 2017 17:43:51 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
* Refactors availability section.

There's already a lot of logic going on in the view to decide what to
show the user under Availability, and DI-607 requires additional logic.
This is too heavy to belong in a view and now lives in the helper.

* Refactors SFX URL generation out of ButtonMaker

We'll need to also access SFX URL generation in record_helper.rb, so it
needs to live in a shared place that understands SFX URL construction
more generally.

* Adds generic SFX link when all other, better-specified, options fail.

* Adds test coverage

## Status
**READY**

I'm waiting for Rich to sign off on the format of the generic SFX URLs, but this is ready for code review.

#### What does this PR do?
It's theoretically possible that we don't really know if the object is available online. This gives us a fallback option if we are missing a fulltext link (basically, "toss our hands in the air and let SFX sort it out").

#### How can a reviewer manually see the effects of these changes?
Check `/record/edsasp/edsasp.ASP2223378.CLMU` on staging vs PR build

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-607

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
