### PR TITLE
Remove ineligible statuses from hold/recall availability

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -302,7 +302,7 @@ class ButtonMaker
     [
       # Items with these status codes may be requested from any library,
       # except the Annex.
-      %w(01 03 04 05 06 07 08 09 11 12 19 20 21).include?(@z30status_code) &&
+      %w(01 03 05 12 19 21).include?(@z30status_code) &&
         @library != 'Library Storage Annex',
 
       # Items with status code 23 may be requested from only some libraries.

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -76,6 +76,7 @@ class ButtonMakerTest < ActiveSupport::TestCase
   test 'z30status_code' do
     assert_equal('01', @ButtonMaker.instance_variable_get(:@z30status_code))
   end
+
   # ~~~~~~~~~~~~~~~~~ Test eligibility determination functions ~~~~~~~~~~~~~~~~~
   test 'eligible for scan' do
     # If any subcondition is false, it is ineligible.
@@ -190,6 +191,81 @@ class ButtonMakerTest < ActiveSupport::TestCase
     maker.instance_variable_set(:@status, 'In Library')
     maker.instance_variable_set(:@z30status, 'Room Use Only')
     assert maker.eligible_for_special_ill?
+  end
+
+  test 'hold ineligibility by reason of z30 status code' do
+    maker = ButtonMaker.new(@item, @oclc, @scan)
+
+    # Check our assumption that the default ButtonMaker can be held/recalled.
+    assert maker.eligible_for_hold?
+
+    # Now test z30 status codes that should yield ineligibility.
+    maker.instance_variable_set(:@z30status_code, '04')
+    # We need to reset @requestable as it was set on object initialization, but
+    # the change to the z30 status will alter its expected value.
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '06')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '07')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '08')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '09')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '11')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+
+    maker.instance_variable_set(:@z30status_code, '20')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_hold?
+  end
+
+  test 'recall ineligibility by reason of z30 status code' do
+    maker = ButtonMaker.new(@item, @oclc, @scan)
+    maker.instance_variable_set(:@status, 'Due sometime')
+
+    # Check our assumption that the default ButtonMaker can be held/recalled.
+    assert maker.eligible_for_recall?
+
+    # Now test z30 status codes that should yield ineligibility.
+    maker.instance_variable_set(:@z30status_code, '04')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '06')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '07')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '08')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '09')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '11')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
+
+    maker.instance_variable_set(:@z30status_code, '20')
+    maker.instance_variable_set(:@requestable, maker.requestable?)
+    refute maker.eligible_for_recall?
   end
 
   # ~~~~~~~~~~~~~~~~~ Test URLs for availability action buttons ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
User testing revealed that our circ rules are not the same as the ones that had been encoded in bento.

#### How can a reviewer manually see the effects of these changes?
Check the records in the ticket on staging and the PR build. Lo, holds/recalls should be disallowed now.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-625

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
