### PR TITLE
Scan button bug fixes

### DIFF
--- a/app/concerns/sfx_handler.rb
+++ b/app/concerns/sfx_handler.rb
@@ -1,5 +1,4 @@
 class SFXHandler
-
   # The SFX server will do the best it can with whatever it has, so we will
   # initialize the SFXHandler with whatever data we happen to have. We're not
   # guaranteed to have all (or indeed any) of these objects; Aleph and EDS
@@ -11,13 +10,17 @@ class SFXHandler
                  collection: nil,
                  doc_number: nil,
                  library: nil,
-                 title: nil)
+                 title: nil,
+                 year: nil,
+                 volume: nil)
     @barcode = barcode
     @call_number = call_number
     @collection = collection
     @doc_number = doc_number
     @title = title
     @library = library
+    @year = year
+    @volume = volume
   end
 
   # Use this when you want to request a scan of an object.
@@ -33,12 +36,7 @@ class SFXHandler
   private
 
   def url_constructor(scan: false)
-    encoded_title = ERB::Util.url_encode(@title)
-
-    # Yes, sometimes we double-encode, so that when SFX passes parameters
-    # through its next step they end up as hoped.
     if scan
-      encoded_title = ERB::Util.url_encode(encoded_title)
       analytics = 'BENTO'
     else
       # Things with analytics=BENTO are automatically routed through scan &
@@ -54,15 +52,17 @@ class SFXHandler
     # for request items, but this ends up with scan requests for Technique
     # (the yearbook) being routed to a Polish land use journal. Call number
     # fixes this bug and does not seem to introduce new ones.
-    encoded_call_no = ERB::Util.url_encode(@call_number)
+    encoded_call_no = URI.encode_www_form_component(@call_number)
 
     url_parts = [
       sfx_host.to_s,
       "?sid=ALEPH:#{analytics}",
       "&amp;call_number=#{encoded_call_no}",
       "&amp;barcode=#{@barcode}",
-      "&amp;title=#{encoded_title}",
-      "&amp;location=#{encoded_location}"
+      "&amp;title=#{URI.encode_www_form_component(@title)}",
+      "&amp;location=#{encoded_location}",
+      "&amp;rft.date=#{@year}",
+      "&amp;rft.volume=#{@volume}"
     ]
 
     if @doc_number
@@ -71,10 +71,7 @@ class SFXHandler
       )
     end
 
-    if scan
-      url_parts.push('&amp;genre=journal')
-    end
-
+    url_parts.push('&amp;genre=journal') if scan
     url_parts.join('')
   end
 
@@ -84,7 +81,7 @@ class SFXHandler
                else
                  @library
                end
-    ERB::Util.url_encode(ERB::Util.url_encode(location))
+    URI.encode_www_form_component(location)
   end
 
   def sfx_host

--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -45,6 +45,8 @@ class ButtonMaker
     @z30status = @item.xpath('z30/z30-item-status').text
     # Yes, this excludes `z30/` on purpose.
     @z30status_code = @item.xpath('z30-item-status-code').text
+    @year = @item.xpath('z13/z13-year').text
+    @volume = @item.xpath('z30/z30-description').text
   end
 
   def all_buttons
@@ -189,7 +191,9 @@ class ButtonMaker
       call_number: @call_number,
       collection: @collection,
       library: @library,
-      title: @title
+      title: @title,
+      year: @year,
+      volume: @volume
     ).url_for_scan
   end
 

--- a/test/concerns/sfx_handler_test.rb
+++ b/test/concerns/sfx_handler_test.rb
@@ -7,15 +7,19 @@ class SFXHandlerConcernTest < MiniTest::Test
     collection = 'Stacks'
     library = 'Hayden Library'
     title = 'Parable of the sower'
+    year = 2010
+    volume = 10
     sfx_link = SFXHandler.new(
       barcode: barcode,
       call_number: call_number,
       collection: collection,
       library: library,
-      title: title
+      title: title,
+      year: year,
+      volume: volume
     ).url_for_scan
 
-    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO&amp;call_number=PS3552.U827.P37%202000&amp;barcode=39080014585712&amp;title=Parable%2520of%2520the%2520sower&amp;location=Hayden%2520Library&amp;genre=journal'
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO&amp;call_number=PS3552.U827.P37+2000&amp;barcode=39080014585712&amp;title=Parable+of+the+sower&amp;location=Hayden+Library&amp;rft.date=2010&amp;rft.volume=10&amp;genre=journal'
 
     assert_equal(expected_url, sfx_link)
   end
@@ -25,10 +29,10 @@ class SFXHandlerConcernTest < MiniTest::Test
     clean_an = '35819515'
     sfx_link = SFXHandler.new(
       title: title,
-      doc_number: clean_an,
+      doc_number: clean_an
     ).url_generic
 
-    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO_FALLBACK&amp;call_number=&amp;barcode=&amp;title=This%20is%20a%20title&amp;location=&amp;pid=DocNumber=35819515,Ip=library.mit.edu,Port=9909'
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO_FALLBACK&amp;call_number=&amp;barcode=&amp;title=This+is+a+title&amp;location=&amp;rft.date=&amp;rft.volume=&amp;pid=DocNumber=35819515,Ip=library.mit.edu,Port=9909'
 
     assert_equal(expected_url, sfx_link)
   end

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -266,11 +266,11 @@ class ButtonMakerTest < ActiveSupport::TestCase
       url =  [
         'https://sfx.mit.edu/sfx_test',
         '?sid=ALEPH:BENTO',
-        "&amp;call_number=PS3515.U274%202001",
+        "&amp;call_number=PS3515.U274+2001",
         '&amp;barcode=39080023421933',
-        '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-        '&amp;location=Hayden%2520Library',
-        '&amp;genre=journal'
+        '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
+        '&amp;location=Hayden+Library',
+        '&amp;rft.date=2001&amp;rft.volume=v.16&amp;genre=journal'
       ].join('')
       assert_equal(url, @ButtonMaker.url_for_scan)
     end
@@ -282,11 +282,11 @@ class ButtonMakerTest < ActiveSupport::TestCase
         url =  [
           'https://sfx.mit.edu/sfx_local',
           '?sid=ALEPH:BENTO',
-          "&amp;call_number=PS3515.U274%202001",
+          "&amp;call_number=PS3515.U274+2001",
           '&amp;barcode=39080023421933',
-          '&amp;title=The%2520collected%2520works%2520of%2520Langston%2520Hughes%2520%252F%2520edited%2520with%2520an%2520introduction%2520by%2520Arnold%2520Rampersad.',
-          '&amp;location=Hayden%2520Library',
-          '&amp;genre=journal'
+          '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
+          '&amp;location=Hayden+Library',
+          '&amp;rft.date=2001&amp;rft.volume=v.16&amp;genre=journal'
         ].join('')
         assert_equal(url, @ButtonMaker.url_for_scan)
       end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
- removes double encoding of passed title and changes to
`URI.encode_www_form_component`
- adds `rft.date` to populate year field
- adds `rft.volume` to populate volume field in the future (changes to
SFX script will be necessary to get this to pass through to Illiad)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

On the PR build, activate full record views.

Search for a local record and click "request scan".

The year should be populated and the title should not be encoded.

Confirm on the staging server the same record leads to no year being populated and the title being encoded.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-618
- https://mitlibraries.atlassian.net/browse/DI-619
- prep for https://mitlibraries.atlassian.net/browse/DI-623

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO