### PR TITLE
Removes special ILL logic

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -21,7 +21,7 @@ class ButtonMaker
     @oclc = oclc
     @scan = scan
     # The order of this list controls the order in which buttons will display.
-    @options = %w(contact hold recall ill scan special_ill)
+    @options = %w(contact hold recall ill scan)
 
     # Properties of items. This must go *after* setting @item and @oclc, but
     # *before* setting @requestable.
@@ -136,27 +136,6 @@ class ButtonMaker
     ].all?
   end
 
-  # Some items are eligible for BorrowDirect even though they are not eligible
-  # for ILL. These are items that are in the library (which is why we do not
-  # ILL them) but whose loan terms are too short for some patrons' needs.
-  # Unfortunately we don't know if these items are actually *available* in BD;
-  # we will send them to BD to check. If they're not available there, BD will
-  # send them to ILL and MIT circ staff will end up cancelling the result.
-  # This is mildly annoying but it is the pre-bento status quo, as users
-  # already find BD on their own.
-  def eligible_for_special_ill?
-    return false if eligible_for_ill? # We don't want to display both buttons.
-    [
-      'Room Use Only',
-      '4 Hour Reserves',
-      '2 Hour Loan',
-      'Fall 2 Hours',
-      'Spring 2 Hours',
-      'IAP 2 Hours',
-      'Summer 2 Hours'
-    ].include?(@z30status)
-  end
-
   # ~~~~~~~~ Functions which return HTML for availability action buttons ~~~~~~~
 
   # The following functions construct URLs needed for item availability actions.
@@ -191,11 +170,6 @@ class ButtonMaker
       " href='#{url_for_scan}'>Request scan (2-3 days)</a>"
   end
 
-  def make_button_for_special_ill
-    "<a class='btn button-secondary button-small' "\
-      "href='#{url_for_special_ill}'>Get it with ILL (3-4 days)</a>"
-  end
-
   # ~~~~~~~~ Functions which create URLs for availability action buttons ~~~~~~~
   def url_for_hold
     queryarray = { func: 'item-hold-request',
@@ -222,14 +196,6 @@ class ButtonMaker
   def url_for_ill
     return unless @oclc_number.present?
     "https://mit.worldcat.org/search?q=no%3A#{@oclc_number}"
-  end
-
-  # special_ill items are only eligible via BorrowDirect.
-  def url_for_special_ill
-    # @identifier may be an ISBN or the ISSN, but either one works in the BD
-    # ISBN parameter.
-    'https://library.mit.edu/shib/bd.cgi?url_ver=Z39.88-2004' \
-      "&amp;rft.isbn=#{@identifier}"
   end
 
   # ~~~~~~~~ Utility functions needed to determine PDF scan eligibility ~~~~~~~~

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -17,7 +17,6 @@ class ButtonMakerTest < ActiveSupport::TestCase
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_contact
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_ill
     refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_recall
-    refute @ButtonMaker.all_buttons.include? @ButtonMaker.make_button_for_special_ill
   end
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Test item properties ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -186,13 +185,6 @@ class ButtonMakerTest < ActiveSupport::TestCase
     refute maker.eligible_for_recall?
   end
 
-  test 'eligible for special ill' do
-    maker = ButtonMaker.new(@item, @oclc, @scan)
-    maker.instance_variable_set(:@status, 'In Library')
-    maker.instance_variable_set(:@z30status, 'Room Use Only')
-    assert maker.eligible_for_special_ill?
-  end
-
   test 'hold ineligibility by reason of z30 status code' do
     maker = ButtonMaker.new(@item, @oclc, @scan)
 
@@ -316,10 +308,5 @@ class ButtonMakerTest < ActiveSupport::TestCase
   test 'url for ill' do
     assert_equal('https://mit.worldcat.org/search?q=no%3A123456789',
                  @ButtonMaker.url_for_ill)
-  end
-
-  test 'url for special ill' do
-    assert_equal('https://library.mit.edu/shib/bd.cgi?url_ver=Z39.88-2004&amp;rft.isbn=0826213391',
-                 @ButtonMaker.url_for_special_ill)
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Removes special ILL logic.

#### Helpful background context (if appropriate)

There was a time when we felt it was appropriate to try to send people directly to BorrowDirect. It has now been determined that we should always send people to WorldCat where BorrowDirect is one option.

#### How can a reviewer manually see the effects of these changes?

In the ticket there is an example that doesn't actually show the problem anymore so I'm not sure. I suspect the recently merged code that restricted some statuses from ILL prevented the sample record from remaining relevant.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-628

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO