### PR TITLE
Adds DC metatags for use by Zotero

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -1,6 +1,9 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<%= yield(:head) %>
+
 <title><%= content_for?(:title) ? yield(:title) : " Search | MIT Libraries" %></title>
 <%= csrf_meta_tags %>
 

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -33,3 +33,29 @@
     <%= render partial: "sidebar" %>
   </div>
 </div>
+
+<% content_for(:head) do %>
+  <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+  <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
+
+  <meta name="DC.title" content="<%= @record.title %>" />
+  <meta name="DC.type" content="<%= @record.eds_publication_type %>" />
+  <meta name="DC.date" content="<%= @record.eds_publication_year %>" />
+
+  <% @record.eds_authors.each do |author| %>
+    <meta name="DC.creator" content="<%= author %>" />
+  <% end %>
+
+  <% if @record.eds_abstract.present? %>
+    <meta name="DCTERMS.abstract" content="<%= @record.eds_abstract %>" />
+  <% end %>
+
+  <% if @record.eds_source_title.present? %>
+    <meta name="DC.source" content="<%= @record.eds_source_title %>" />
+  <% end %>
+
+  <% if @record.eds_document_doi.present? %>
+    <meta name="DC.identifier" content="info:doi/<%= @record.eds_document_doi %>" />
+  <% end %>
+
+<% end %>


### PR DESCRIPTION
## Status
**NEEDS REVIEW**

#### What does this PR do?
This attempts to allow users to save full records to their Zotero account by adding DC metadata to the head element.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Enable full record, and try to save a full record view via Zotero. This will require you to install the Zotero standalone application and the Zotero extension in the browser of your choice.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-476

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
