### PR TITLE
Extracts summary holdings for note serial

### DIFF
--- a/app/assets/stylesheets/_shame.scss
+++ b/app/assets/stylesheets/_shame.scss
@@ -1,6 +1,1 @@
 // this file holds things we know are not great but need to exist until rainbows come
-
-
-  .discovery-full-record-holdings-info {
-    display: none; // remove once ebsco fixes TOC in Holdings
-  }

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -189,7 +189,6 @@ module RecordHelper
     elsif guest_and_restricted_link?
       'availability_restricted'
 
-
     # Restricted expiring link, but current user is allowed to access it.
     # We'll get a fresh version of the link and redirect them to it.
     elsif restricted_link?
@@ -233,5 +232,26 @@ module RecordHelper
       "Maps" => "Map"
     }
     r_types[record.eds_publication_type] || record.eds_publication_type
+  end
+
+  # Extract summary holdings from @record.eds_extras_NoteSerial
+  # see: https://mitlibraries.atlassian.net/browse/DI-547 for background.
+  # We need to handle cases where NoteSerial has no Summary Holdings, one
+  # summary holding after a Note, multiple summary holdings after a note,
+  # one or multiple summary holdings with no notes preceding.
+  # Summary Holdings are preceded by `[s_h]` in the string and may or may not
+  # exist.
+  def summary_holdings(note)
+    sh_count = note.scan('[s_h]').count
+    split_sh = note.split('[s_h]').map(&:strip)
+
+    if sh_count == split_sh.count
+      split_sh
+    elsif sh_count == split_sh.count - 1
+      split_sh.drop(1)
+    else
+      Rails.logger.warn("Summary Holdings concern: #{note}")
+      note
+    end
   end
 end

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -16,13 +16,16 @@
 
 <%# using try instead of .present? due to how edsapi dynamically adds this
     element. It's either there or a no method error. %>
-<% if @record.try(:eds_extras_TOC) %>
+<% if @record.try(:eds_extras_NoteSerial) &&
+      summary_holdings(@record.eds_extras_NoteSerial).present? %>
+
   <div id="full-holdings" class="discovery-full-record-holdings-info">
     <h3 class="subtitle3">Holdings</h3>
-    <%# todo: this will need updating once Ebsco resolves a data mapping
-        problem described here
-        https://mitlibraries.atlassian.net/browse/DI-547 %>
-    <div class="holdings"><%= safe_output(@record.eds_extras_TOC) %></div>
+    <div class="holdings">
+      <% summary_holdings(@record.eds_extras_NoteSerial).each do |sh| %>
+        <%= safe_output(sh) %><br />
+      <% end %>
+    </div>
   </div>
 <% end %>
 

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -127,4 +127,36 @@ DOC
     mock_record = stub(:eds_publication_type => 'Unhinged Lunacy')
     assert_equal(map_record_type(mock_record), 'Unhinged Lunacy')
   end
+
+  test 'no summary holdings in serial note' do
+    serial_note = 'yo I like yoyos yo.'
+    assert_equal([], summary_holdings(serial_note))
+  end
+
+  test 'just summary holdings in serial note' do
+    serial_note = '[s_h] do you like yoyos?'
+    assert_equal(['do you like yoyos?'], summary_holdings(serial_note))
+  end
+
+  test 'summary holdings and notes in serial note' do
+    serial_note = 'yo I like yoyos yo. [s_h] do you like yoyos?'
+    assert_equal(['do you like yoyos?'], summary_holdings(serial_note))
+  end
+
+  test 'mutiple summary holdings and notes in serial note' do
+    serial_note = 'yo I like yoyos yo. [s_h] do you like yoyos? [s_h] naptime'
+    assert_equal(['do you like yoyos?',
+                  'naptime'], summary_holdings(serial_note))
+  end
+
+  test 'mutiple summary holdings and no note in serial note' do
+    serial_note = '[s_h] do you like yoyos? [s_h] naptime'
+    assert_equal(['do you like yoyos?',
+                  'naptime'], summary_holdings(serial_note))
+  end
+
+  test 'nothing in serial note' do
+    serial_note = ''
+    assert_equal([], summary_holdings(serial_note))
+  end
 end

--- a/test/vcr_cassettes/record_journal.yml
+++ b/test/vcr_cassettes/record_journal.yml
@@ -323,7 +323,7 @@ http_interactions:
         Abbreviation","Group":"TiAlt","Data":"Blood"},{"Name":"TitleAlt","Label":"Other
         Titles","Group":"TiAlt","Data":"Blood"},{"Name":"ISSN","Label":"ISSN","Group":"ISSN","Data":"0006-4971"},{"Name":"NumberControlLC","Label":"LCCN","Group":"ID","Data":"a  50001900"},{"Name":"NumberOther","Label":"OCLC","Group":"ID","Data":"01536582&lt;br
         \/&gt;02302157"},{"Name":"NoteSerial","Label":"Serial Publication Dates","Group":"Note","Data":"v.
-        1-   Jan. 1946-"},{"Name":"PubInfo","Label":"Publication Frequency","Group":"PubInfo","Data":"Semimonthly,
+        1-   Jan. 1946- [s_h] Library Storage Annex Off Campus Collection RB.B655 v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete"},{"Name":"PubInfo","Label":"Publication Frequency","Group":"PubInfo","Data":"Semimonthly,
         1990-"},{"Name":"URL","Label":"Online Access","Group":"URL","Data":"&lt;link
         linkTarget=&quot;URL&quot; linkTerm=&quot;https:\/\/library.mit.edu\/F\/?func=service-sfx&amp;doc_number=000292123&amp;line_number=0000&amp;service_type=RECORD&quot;
         linkWindow=&quot;_blank&quot;&gt;Online Access v.1 (1946)-&lt;\/link&gt;"},{"Name":"AN","Label":"Accession


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

* extracts summary holdings if they exist

#### How can a reviewer manually see the effects of these changes?

I'll update the review app ENV to point at a test catalog and update info here in a bit.

Just summary holdings (i.e. first entry starts with s_h)
/record/cat01875a/mittest.000285628

Multiple summary holdings and something before it
/record/cat01875a/mittest.000294973

No summary holdings:
/record/cat01875a/mittest.002144417

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-547

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
