### PR TITLE
631 on order books

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -157,6 +157,10 @@ class ButtonMaker
   end
 
   def make_button_for_ill
+    # It's possible to get this far but not be able to construct a valid ILL
+    # URL. This happens if the item is on order but we don't yet know its OCLC
+    # number.
+    return unless url_for_ill
     "<a class='btn button-secondary button-small' "\
       "href='#{url_for_ill}'>Request non-MIT copy (3-4 days)</a>"
   end

--- a/test/integration/aleph_test.rb
+++ b/test/integration/aleph_test.rb
@@ -116,4 +116,14 @@ class AlephTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'handling of books on order' do
+    VCR.use_cassette('record: book is on order', allow_playback_repeats: true) do
+      get full_item_status_path, params: { id: 'MIT01002579423' }
+      # Make sure the metadata for the book does exist and is displayed...
+      assert_select 'span.library', text: 'Rotch Library'
+      # ...but there still isn't an action item.
+      assert_select '#full-avail a.btn', count: 0
+    end
+  end
 end

--- a/test/models/button_maker_test.rb
+++ b/test/models/button_maker_test.rb
@@ -32,7 +32,6 @@ class ButtonMakerTest < ActiveSupport::TestCase
     assert_equal('Stacks', @ButtonMaker.instance_variable_get(:@collection))
   end
 
-  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ Test item properties ~~~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'doc_number' do
     assert_equal('001019412', @ButtonMaker.instance_variable_get(:@doc_number))
   end
@@ -308,5 +307,13 @@ class ButtonMakerTest < ActiveSupport::TestCase
   test 'url for ill' do
     assert_equal('https://mit.worldcat.org/search?q=no%3A123456789',
                  @ButtonMaker.url_for_ill)
+  end
+
+  test 'ill button returns nil if ill url cannot be constructed' do
+    buttonmaker = ButtonMaker.new(@item, '', @scan)
+    # Check assumption: url should be nil by reason of the OCLC number being
+    # blank.
+    assert buttonmaker.url_for_ill.nil?
+    assert buttonmaker.make_button_for_ill.nil?
   end
 end

--- a/test/vcr_cassettes/record_book_is_on_order.yml
+++ b/test/vcr_cassettes/record_book_is_on_order.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://fake_server.example.com/rest-dlf/record/MIT01002579423/items?key=FAKE_KEY&view=full
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 29 Jan 2018 19:54:10 GMT
+      Server:
+      - Apache/2.2.31 (Unix) mod_ssl/2.2.31 OpenSSL/1.0.2k mod_perl/2.0.8 Perl/v5.8.9
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 2000 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml
+    body:
+      encoding: UTF-8
+      string: '<?xml version = "1.0" encoding = "UTF-8"?><get-item-list><reply-text>ok</reply-text><reply-code>0000</reply-code><items><item
+        href="http://fake_server.example.com/rest-dlf/record/MIT01002579423/items/MIT50002579423000010"><z30-sub-library-code>RTC</z30-sub-library-code><z30-item-process-status-code>OO</z30-item-process-status-code><z30-item-status-code>01</z30-item-status-code><hol-library>MIT60</hol-library><z30-collection-code>REF</z30-collection-code><queue></queue><z30><translate-change-active-library>MIT50</translate-change-active-library><z30-doc-number>002579423</z30-doc-number><z30-item-sequence>000010</z30-item-sequence><z30-barcode>N11959028</z30-barcode><z30-sub-library>Rotch
+        Library</z30-sub-library><z30-material>Book</z30-material><z30-item-status>On
+        Order</z30-item-status><z30-open-date>20171215</z30-open-date><z30-update-date>20171215</z30-update-date><z30-cataloger>YBPSR</z30-cataloger><z30-date-last-return>00000000</z30-date-last-return><z30-hour-last-return>0000</z30-hour-last-return><z30-ip-last-return></z30-ip-last-return><z30-no-loans>000</z30-no-loans><z30-alpha>L</z30-alpha><z30-collection>Reference
+        Collection</z30-collection><z30-call-no-type></z30-call-no-type><z30-call-no></z30-call-no><z30-call-no-key></z30-call-no-key><z30-call-no-2-type></z30-call-no-2-type><z30-call-no-2></z30-call-no-2><z30-call-no-2-key></z30-call-no-2-key><z30-description></z30-description><z30-note-opac></z30-note-opac><z30-note-circulation></z30-note-circulation><z30-note-internal></z30-note-internal><z30-order-number>18-5181</z30-order-number><z30-inventory-number></z30-inventory-number><z30-inventory-number-date>00000000</z30-inventory-number-date><z30-last-shelf-report-date>00000000</z30-last-shelf-report-date><z30-price>167.70</z30-price><z30-shelf-report-number></z30-shelf-report-number><z30-on-shelf-date>00000000</z30-on-shelf-date><z30-on-shelf-seq>000000</z30-on-shelf-seq><z30-doc-number-2>000000000</z30-doc-number-2><z30-schedule-sequence-2>00000</z30-schedule-sequence-2><z30-copy-sequence-2>00000</z30-copy-sequence-2><z30-vendor-code></z30-vendor-code><z30-invoice-number></z30-invoice-number><z30-line-number>00000</z30-line-number><z30-pages></z30-pages><z30-issue-date>00000000</z30-issue-date><z30-expected-arrival-date>00000000</z30-expected-arrival-date><z30-arrival-date>00000000</z30-arrival-date><z30-item-statistic></z30-item-statistic><z30-item-process-status>On
+        Order</z30-item-process-status><z30-copy-id></z30-copy-id><z30-hol-doc-number>000000000</z30-hol-doc-number><z30-temp-location>No</z30-temp-location><z30-enumeration-a></z30-enumeration-a><z30-enumeration-b></z30-enumeration-b><z30-enumeration-c></z30-enumeration-c><z30-enumeration-d></z30-enumeration-d><z30-enumeration-e></z30-enumeration-e><z30-enumeration-f></z30-enumeration-f><z30-enumeration-g></z30-enumeration-g><z30-enumeration-h></z30-enumeration-h><z30-chronological-i></z30-chronological-i><z30-chronological-j></z30-chronological-j><z30-chronological-k></z30-chronological-k><z30-chronological-l></z30-chronological-l><z30-chronological-m></z30-chronological-m><z30-supp-index-o></z30-supp-index-o><z30-85x-type></z30-85x-type><z30-depository-id></z30-depository-id><z30-linking-number>000000000</z30-linking-number><z30-gap-indicator></z30-gap-indicator><z30-maintenance-count>000</z30-maintenance-count><z30-process-status-date>20171215</z30-process-status-date><z30-upd-time-stamp>201712150916116</z30-upd-time-stamp><z30-ip-last-return-v6></z30-ip-last-return-v6></z30><z13><translate-change-active-library>MIT50</translate-change-active-library><z13-doc-number>002579423</z13-doc-number><z13-year>2017</z13-year><z13-open-date>20171215</z13-open-date><z13-update-date>20171215</z13-update-date><z13-call-no-key></z13-call-no-key><z13-call-no-code>PST</z13-call-no-code><z13-call-no></z13-call-no><z13-author-code></z13-author-code><z13-author></z13-author><z13-title-code></z13-title-code><z13-title>The
+        Atlas of Furniture Design.</z13-title><z13-imprint-code>260</z13-imprint-code><z13-imprint>Vitra
+        Design Stiftung</z13-imprint><z13-isbn-issn-code>020</z13-isbn-issn-code><z13-isbn-issn>9783931936990</z13-isbn-issn><z13-upd-time-stamp>201712150839397</z13-upd-time-stamp></z13><status>On
+        Order</status></item></items></get-item-list> '
+    http_version: 
+  recorded_at: Mon, 29 Jan 2018 19:54:09 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Deal with books that are on order - these were displaying a nonfunctioning ILL-request button (because in this case we have enough of a record to construct the full record view, but we don't yet have an OCLC number, so the ILL URL is broken).

The decision (see ticket for discussion) was to do the following:
* remove the ILL button if the ILL URL can't be constructed
* test that the ILL buttonmaker function returns nil if the ILL URL function returns nil
* test that the record display doesn't include any buttons for this Rotch example

There's additional work around the text we should display (in lieu of the inaccurate "Checked out"), but that was split into another ticket.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.002579423 to the PR build (assuming the book in this record is still on order - if not you should read the tests and see if you feel reassured - I did capture a VCR cassette of this book while on order so we can continue to test it even though the status is transient).

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-631

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
