### PR TITLE
Add DC.type mapping for meta tag

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -208,4 +208,30 @@ module RecordHelper
       'availability_check_online'
     end
   end
+
+  def map_record_type(record)
+    r_types = {
+      "Academic Journal" => "Journal Article",
+      "Magazines" => "Magazine Article",
+      "Trade Publications" => "Magazine Article",
+      "News" => "Newspaper Article",
+      "Books" => "Book",
+      "Reviews" => "Journal Article",
+      "Reports" => "Report",
+      "Conference Materials" => "Conference Paper",
+      "Dissertations/Theses" => "Thesis",
+      "Biographies" => "Book",
+      "Primary Source Documents" => "Manuscript",
+      "Government Documents" => "Report",
+      "Music Score" => "Document",
+      "Research Starters" => "Webpage",
+      "Electronic Resources" => "Webpage",
+      "Non-Print Resources" => "Webpage",
+      "Audio" => "Audio Recording",
+      "Videos" => "Video Recording",
+      "eBooks" => "Book",
+      "Maps" => "Map"
+    }
+    r_types[record.eds_publication_type] || record.eds_publication_type
+  end
 end

--- a/app/views/record/record.html.erb
+++ b/app/views/record/record.html.erb
@@ -39,8 +39,11 @@
   <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
 
   <meta name="DC.title" content="<%= @record.title %>" />
-  <meta name="DC.type" content="<%= @record.eds_publication_type %>" />
   <meta name="DC.date" content="<%= @record.eds_publication_year %>" />
+
+  <% if @record.eds_publication_type.present? %>
+    <meta name="DC.type" content="<%= map_record_type(@record) %>">
+  <% end %>
 
   <% @record.eds_authors.each do |author| %>
     <meta name="DC.creator" content="<%= author %>" />

--- a/test/helpers/record_helper_test.rb
+++ b/test/helpers/record_helper_test.rb
@@ -117,4 +117,14 @@ DOC
     assert_equal(true, scan?)
     ENV['SCAN_EXCLUSIONS'] = stored_env
   end
+
+  test 'maps EDS pub type to Zotero pub type' do
+    mock_record = stub(:eds_publication_type => 'Academic Journal')
+    assert_equal(map_record_type(mock_record), 'Journal Article')
+  end
+
+  test 'uses EDS pub type when no mapping exists' do
+    mock_record = stub(:eds_publication_type => 'Unhinged Lunacy')
+    assert_equal(map_record_type(mock_record), 'Unhinged Lunacy')
+  end
 end

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -339,4 +339,12 @@ class RecordTest < ActionDispatch::IntegrationTest
          text: 'View in BartonPlus'}
     end
   end
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ metatags ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  test 'DC.type is mapped' do
+    VCR.use_cassette('record: article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_select('meta[name="DC.type"][content="Journal Article"]')
+    end
+  end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This changes the content for the DC.type meta tag to be a mapped value
from the EDS publication type to the Zotero item type. If no match is
found then the EDS publication type is used.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Find an article with a mapped type like https://mit-bento-staging.herokuapp.com/record/edselp/S0925400517321858. View source and the DC.type should say Journal Article rather than Academic Journal.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-635

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
