### PR TITLE
Limit aleph holdings displayed

### DIFF
--- a/app/assets/stylesheets/_aleph.scss
+++ b/app/assets/stylesheets/_aleph.scss
@@ -22,6 +22,11 @@
 
 .discovery-full-record-availability-info {
 
+  .expand-collapse-wrap {
+    padding-bottom: 5rem;
+    font-size: 1.4rem;
+  }
+
   .list-local-locations {
     list-style-type: none;
     margin-top: 1rem;
@@ -53,7 +58,7 @@
     }
   }
 
-  .availability-status, 
+  .availability-status,
   .availability-actions .btn {
 
     @media (max-width: $bp-screen-sm) {
@@ -64,7 +69,7 @@
 
 
 
-  
+
   .location-actions {
 
     .btn {
@@ -80,6 +85,11 @@
       vertical-align: middle;
       font-size: 2rem;
     }
+  }
+
+  .show-even-more {
+    margin-top: 3rem;
+    font-weight: 600;
   }
 
 }

--- a/app/helpers/aleph_helper.rb
+++ b/app/helpers/aleph_helper.rb
@@ -32,4 +32,17 @@ module AlephHelper
       'https://libraries.mit.edu/locations/#!library-storage-annex'
     end
   end
+
+  # special case for direct to aleph record links when starting from aleph data
+  # and not EDS data (i.e. when we are dealing with realtime info).
+  # Use the RecordHelper#local_record_source_url for most use cases.
+  def aleph_source_record(id)
+    if id.start_with?('MIT01')
+      "https://library.mit.edu/item/#{id.gsub('MIT01', '')}"
+    elsif id.start_with?('MIT30')
+      "https://library.mit.edu/res/#{id.gsub('MIT30', '')}"
+    else
+      raise 'Invalid Aleph ID provided. Cannot construct URL to Aleph.'
+    end
+  end
 end

--- a/app/views/aleph/_list_local_locations.html.erb
+++ b/app/views/aleph/_list_local_locations.html.erb
@@ -1,6 +1,6 @@
 <p class="sr">Library locations: </p>
 <ul class="list-local-locations">
-  <% @status.each do |s| %>
+  <% @status.take(99).each do |s| %>
     <li class="result-local-location">
       <%# Begin location wrap %>
       <div class="location-wrap">
@@ -53,3 +53,9 @@
     </li>
   <% end %>
 </ul>
+
+<% if @status.count > 99 %>
+<div class="show-even-more">
+  <p>Want to see even more? <a href="<%= aleph_source_record(params[:id]) %>">View in the catalog to sort and filter <i class="fa fa-angle-double-right" aria-hidden="true"></i></a></p>
+</div>
+<% end %>

--- a/test/helpers/aleph_helper_test.rb
+++ b/test/helpers/aleph_helper_test.rb
@@ -17,4 +17,24 @@ class AlephHelperTest < ActionView::TestCase
     refute(controller.archives?('POPCORN'))
     assert(controller.archives?('Institute Archives'))
   end
+
+  test 'aleph_source_record with MIT01 id' do
+    assert_equal('https://library.mit.edu/item/123456789',
+                 controller.aleph_source_record('MIT01123456789'))
+  end
+
+  test 'aleph_source_record with MIT30 id' do
+    assert_equal('https://library.mit.edu/res/123456789',
+                 controller.aleph_source_record('MIT30123456789'))
+  end
+
+  test 'aleph_source_record with bad id' do
+    msg = assert_raises do
+      controller.aleph_source_record('YO123456789')
+    end
+    assert_equal(
+      'Invalid Aleph ID provided. Cannot construct URL to Aleph.',
+      msg.message
+    )
+  end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Limit display of holdings to 99 items and provide link to source for viewing additional records.

#### How can a reviewer manually see the effects of these changes?

A journal record with print holdings is the best example. ex: jama

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-650

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
