### PR TITLE
660 buttons are the worst

### DIFF
--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -95,7 +95,8 @@ class ButtonMaker
       'Music CD/DVD',
       'Pass',
       'See Note Above',
-      'Two Week Loan'
+      'Two Week Loan',
+      'One Week Loan'
     ]
 
     # If it has a disqualifying status, you can't ILL it. If it doesn't, you're


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This adds the z30status of the items that had a button we didn't want to the badz30 status. I'm not entirely sure this is a good idea. It fixed the problem for the sample records but I would like a solid opinion on whether this was a good idea from the great ButtonMaker perspective.

#### Helpful background context (if appropriate)

Putting so much questionable business logic into these buttons was probably not the best idea we ever had.

#### How can a reviewer manually see the effects of these changes?

Check the records noted in the ticket in staging and the PR build

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-660

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO