### PR TITLE
658 processing status

### DIFF
--- a/app/helpers/aleph_helper.rb
+++ b/app/helpers/aleph_helper.rb
@@ -6,10 +6,6 @@ module AlephHelper
                             'DVD', 'DVDROM', 'USB DRIVE', 'VDISC', 'VIDEO')
   end
 
-  def reserve?(collection)
-    collection == 'Reserve Stacks'
-  end
-
   def archives?(library)
     library == 'Institute Archives'
   end

--- a/app/models/concerns/processing_labeler.rb
+++ b/app/models/concerns/processing_labeler.rb
@@ -1,0 +1,102 @@
+# Why does this module exist?
+# 1) We display processing status information in our record page.
+# 2) We can't just pass through that status information from Aleph, because
+#    sometimes it is not patron-readable
+# Therefore we need to be able to map what Aleph says to what we want to tell
+# people.
+#
+# Additional wrinkles:
+# 1) Some items have processing status codes (<z30-item-process-status-code>);
+#    some do not.
+# 2) The items in the <status> field are inconsistently spelled.
+#
+# In general, we want to use the processing status codes where available,
+# because they have the cleanest data. So we have a mapping of status codes to
+# our preferred display strings. However, when there isn't a status code, we
+# also need a function for inferring it from the <status> field.
+#
+# Occasionally, we actually *do* want to use the <status> as provided by Aleph.
+# (For instance, when the status is Claimed, the <status> is "Expected on
+# $date"; as $date varies by item we can only get it by passing along the
+# Aleph data.) In these cases, STATUS_MAP has nil for the code's value.
+module ProcessingLabeler
+  STATUS_MAP = {
+    "AP" => "Pending Approval",
+    "BO" => "Back Ordered",
+    "CA" => "Cancelled Order",
+    "CL" => nil,
+    "CR" => "Long Overdue",
+    "CS" => "Collections Support Unit",
+    "CT" => "In Cataloging",
+    "DW" => "Damaged/Withdrawn",
+    "EX" => "On Exhibit",
+    "IC" => "Improper Charge",
+    "IL" => "BLC/BD ILB Item",  # Not available in bento.
+    "IP" => "Ask for Assistance",
+    "LO" => "Declared Long Overdue",
+    "MM" => "Missing",
+    "MR" => nil,
+    "N/A" => "In Library",
+    "NA" => "Expected/Not Yet Arrived",
+    "NB" => "New Books Display",
+    "NR" => "Never Received",
+    "NT" => "Not Yet Published",
+    "NV" => "Never Published",
+    "OD" => "On Display",
+    "OI" => "Order Initiated",
+    "OO" => "On Order",
+    "OP" => "Out of Print",
+    "OS" => "On Search",
+    "PR" => "Ask for Assistance",
+    "RD" => "Received",
+    "RO" => "Replacement Copy On Order",
+    "SC" => "Offsite Reformatting/Scanning",
+    "SF" => "Review for Reorder",
+    "TS" => "Ask for Assistance",
+    "ZA" => "Missing",
+    "ZB" => "Missing",
+    "ZC" => "Missing",
+    "ZD" => "Missing",
+    "ZE" => "Missing",
+    "ZF" => "Missing",
+    "ZG" => "Missing",
+    "ZH" => "Missing",
+    "ZI" => "Missing",
+    "ZJ" => "Missing",
+    "ZK" => "Missing",
+    "ZL" => "Missing",
+    "ZM" => "Missing",
+    "ZN" => "Missing",
+    "ZO" => "Missing"
+  }
+
+  def checked_out?(status)
+    if %r(^due \d{2}/\d{2}/\d{4} \d{2}:\d{2} [a|p]m$).match(status.downcase)
+      true
+    else
+      false
+    end
+  end
+
+  # For statuses of the form "In Transit/Sublibrary; Due 03/26/2018 06:00 PM; Requested"
+  # we want to strip out the due date part.
+  def in_transit?(status)
+    status.include?('In Transit/Sublibrary') && status.include?('Requested')
+  end
+
+  # In the interface, after "Available" or "Not Available", we often display
+  # a string with additional information, in order to help users understand
+  # the next action they should take or the amount of delay they should
+  # expect. This string is based on the item status in Aleph, but we edit it
+  # for readability.
+  def processing_label(status, z30_item_process, reserve)
+    return 'On reserve (see desk)' if reserve
+    return 'Checked out' if checked_out?(status)
+    return 'In Transit/Sublibrary; Requested' if in_transit?(status)
+
+    mapped_status = STATUS_MAP[z30_item_process.upcase]
+    return mapped_status if mapped_status.present?
+
+    status
+  end
+end

--- a/app/views/aleph/_list_local_locations.html.erb
+++ b/app/views/aleph/_list_local_locations.html.erb
@@ -30,14 +30,14 @@
 
           <span class="availability-status">
             <i class="fa fa-check" aria-hidden="true"></i>
-            Available
+            <%= s[:label] %>
           </span>
 
         <% else %>
 
           <span class="availability-status">
             <i class="fa fa-times" aria-hidden="true"></i>
-            Checked out
+            <%= s[:label] %>
           </span>
 
         <% end %>

--- a/test/helpers/aleph_helper_test.rb
+++ b/test/helpers/aleph_helper_test.rb
@@ -8,11 +8,6 @@ class AlephHelperTest < ActionView::TestCase
     assert(controller.media?('DVD'))
   end
 
-  test 'reserve?' do
-    refute(controller.reserve?('POPCORN'))
-    assert(controller.reserve?('Reserve Stacks'))
-  end
-
   test 'archives?' do
     refute(controller.archives?('POPCORN'))
     assert(controller.archives?('Institute Archives'))

--- a/test/models/aleph_item_test.rb
+++ b/test/models/aleph_item_test.rb
@@ -23,7 +23,7 @@ class AlephItemTest < ActiveSupport::TestCase
       assert_equal('Stacks', status[0][:collection])
       assert_equal('PN1995.9.M86 M855 2010', status[0][:call_number])
       assert_equal(true, status[0][:available?])
-      assert_equal('Available', status[0][:label])
+      assert_equal('Available - In Library', status[0][:label])
       assert_equal('', status[0][:description])
     end
   end
@@ -35,7 +35,7 @@ class AlephItemTest < ActiveSupport::TestCase
       assert_equal('Service Desk', status[5][:collection])
       assert_equal('QA27.5.L44 2016a', status[5][:call_number])
       assert_equal(false, status[5][:available?])
-      assert_equal('Checked out', status[5][:label])
+      assert_equal('Not available - 03/02/2017 11:59 PM', status[5][:label])
       assert_equal('', status[5][:description])
     end
   end
@@ -47,7 +47,7 @@ class AlephItemTest < ActiveSupport::TestCase
       assert_equal('Stacks', status[0][:collection])
       assert_equal('PS3515.U274 2001', status[0][:call_number])
       assert_equal(true, status[0][:available?])
-      assert_equal('Available', status[0][:label])
+      assert_equal('Available - In Library', status[0][:label])
       assert_equal('v.16', status[0][:description])
     end
   end
@@ -92,7 +92,7 @@ class AlephItemTest < ActiveSupport::TestCase
   end
 
   test 'label' do
-    assert_equal('Available', @AlephTester.label(@item))
+    assert_equal('Available - In Library', @AlephTester.label(@item))
   end
 
   test 'library' do
@@ -110,5 +110,15 @@ class AlephItemTest < ActiveSupport::TestCase
       status = AlephItem.new.items('MIT01000296523', '02187052', 'false')
       assert_equal status.count, 990
     end
+  end
+
+  test 'reserve? for item not on reserve' do
+    refute @AlephTester.reserve?(@item)
+  end
+
+  test 'reserve? for item on reserve' do
+    collection = @item.at('z30/z30-collection')
+    collection.content = 'Reserve Stacks'
+    assert @AlephTester.reserve?(@item)
   end
 end


### PR DESCRIPTION
## Status
**READY**

There may still be some UX review going on, but this is now ready for code review.

#### What does this PR do?
Adds status information to "available" / "checked out" indicators to aid decisionmaking. Changes "checked out" to "not available" as there are many reasons items could be unavailable, not just checkouts. Massages the status labels we get from Aleph to improve consistency and readability.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Look at the availability section of your favorite stuff on the PR build. There's a Google doc with examples of stuff with various processing statuses - DM me for the link.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-658
- https://mitlibraries.atlassian.net/browse/DI-675
- https://mitlibraries.atlassian.net/browse/DI-689
- https://mitlibraries.atlassian.net/browse/DI-690

(All of these tickets involve label text, so it makes sense to handle them all together.)

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
