### PR TITLE
adjust holdings style in full record

### DIFF
--- a/app/assets/stylesheets/_aleph.scss
+++ b/app/assets/stylesheets/_aleph.scss
@@ -109,4 +109,9 @@
       margin-bottom: 0;
     }
   }
+
+  .holdings {
+    font-size: 1.2rem;
+    line-height: 1.3;
+  }
 }


### PR DESCRIPTION
## Status
**READY**

#### How can a reviewer manually see the effects of these changes?
Go to full record with holdings and see that the font and line height is adjusted for holdings: 
/record/cat00916a/mit.000294973

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-669
