### PR TITLE
Make type listed in document type section match that's indicated up top

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -254,4 +254,18 @@ module RecordHelper
       note
     end
   end
+
+  # We could use @record.eds_publication_type, but that returns only one
+  # value even when there are several item types. In particular, we
+  # would end up displaying only 'eBook' when something is available in
+  # both electronic and print form. The TypePub element seems to provide a
+  # semicolon-delimited list of item types. However, it isn't always present,
+  # and when it isn't we should default to @record.eds_publication_type.
+  def publication_type(record)
+    if @record.get_item_data({name:'TypePub'}).present?
+      @record.get_item_data({name:'TypePub'})
+    else
+      @record.eds_publication_type
+    end
+  end
 end

--- a/app/views/record/_basic_info.html.erb
+++ b/app/views/record/_basic_info.html.erb
@@ -44,14 +44,9 @@
   <% end %>
 <%# Includes Books; is catchall for other types not specified in wireframes %>
 <% else %>
-  <% if @record.eds_publication_type.present? %>
+  <% if publication_type(@record).present? %>
     <span class="record-type"><span class="sr">Type: </span>
-      <%# We could use @record.eds_publication_type, but that returns only one
-          value even when there are several item types. In particular, we
-          would end up displaying only 'eBook' when something is available in
-          both electronic and print form. This seems to provide a semicolon-
-          delimited list of item types. %>
-      <%= @record.get_item_data({name:'TypePub'}) %>
+      <%= publication_type(@record) %>
     </span>
   <% end %>
   <% if @record.eds_publication_year.present? %>

--- a/app/views/record/_extended_info.html.erb
+++ b/app/views/record/_extended_info.html.erb
@@ -6,9 +6,9 @@
 
 <h3 class="section-title">More information</h3>
 <ul class="list-moreinfo">
-  <% if @record.eds_publication_type.present? %>
+  <% if publication_type(@record).present? %>
     <li>
-      <span class="label">Document type:</span> <%= @record.eds_publication_type %>
+      <span class="label">Document type:</span> <%= publication_type(@record) %>
     </li>
   <% end %>
 

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -320,6 +320,13 @@ class RecordTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'multiple item types can be shown in document info section' do
+    VCR.use_cassette('record: multiple item types', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.002379994' }
+      assert_select 'ul.list-moreinfo li', text: /Book; eBook/
+    end
+  end
+
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ sidebar ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'marc link is shown' do
     VCR.use_cassette('record: book', allow_playback_repeats: true) do


### PR DESCRIPTION
Testing this feature revealed that the TypePub strategy sometimes
returns nil, so we have a new helper function that uses TypePub info
when present, but falls back to the EDS-supplied publication type
when needed.

## Status
**READY**

#### What does this PR do?
(per commit message)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.001512948 to PR build version of same.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-681

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
