### PR TITLE
conditionally display sort note

### DIFF
--- a/app/views/aleph/full_item_status.html.erb
+++ b/app/views/aleph/full_item_status.html.erb
@@ -15,3 +15,7 @@
 </div>
 <script>Toggler();</script>
 <% end %>
+
+<% if @status.count > 1 %>
+  <script>$(".availability-sort-info").removeClass("is-hidden");</script>
+<% end %>

--- a/app/views/record/_availability.html.erb
+++ b/app/views/record/_availability.html.erb
@@ -30,7 +30,7 @@
 <% end %>
 
 <div class="wrap-availability">
-  <p class="availability-sort-info">items sorted by publication date</p>
+  <p class="availability-sort-info is-hidden">items sorted by publication date</p>
   <%# This div id is used by the javascript - don't move or change it.) %>
   <div id="full-avail" class="discovery-full-record-availability-info">
     <% if local_record? %>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

- hides sort note by default
- if we have more than 1 holdings item, unhides sort note

#### How can a reviewer manually see the effects of these changes?

Look at records in the PR build with a no local holdings, one local holding item, and more than one local holding item.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-688

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
