### PR TITLE
Fix super seekrit rainbows feature

### DIFF
--- a/app/assets/stylesheets/libraries-global.scss
+++ b/app/assets/stylesheets/libraries-global.scss
@@ -187,6 +187,10 @@ hr {
   /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f23074', endColorstr='#544b8c',GradientType=1 );
   /* IE6-9 fallback on horizontal gradient */
+
+  .wrap-header {
+    background: none;
+  }
 }
 
 .hd-1, .wrap-content h1,


### PR DESCRIPTION
With the new branding, the MIT logo background covered up the rainbows
and then there was no Pride easter egg and all was woe.

## Status
**READY**

#### What does this PR do?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare https://mit-bento-staging.herokuapp.com/record/cat00916a/mit.002510332 to the same record on the PR build.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
