### PR TITLE
Maybe querystrings don't work as cache keys

### DIFF
--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -43,13 +43,13 @@ class RecordController < ApplicationController
   # record cache is guest dependent because it stores rendered HTML, and some
   # of that rendered HTML is different for guests.
   def cache_path
-    url_for(
-      guest: helpers.guest?,
+    base = url_for(
       action: action_name,
       an: @record_an,
-      source: @record_source,
-      pride: Flipflop.enabled?(:pride)
+      db_source: @record_source,
     )
+
+    "#{base}/#{helpers.guest?}/#{Flipflop.enabled?(:pride)}"
   end
 
   private


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
I think, though I cannot prove, that querystrings are ignored in cache keys and therefore `cache_path` based on `url_for` is producing weird behavior. I am trying a version of `cache_path` that does not include querystrings, but still includes all the data we need. What do you think?

#### Helpful background context (if appropriate)
There are two hard things in computer science...

#### How can a reviewer manually see the effects of these changes?
keep toggling the pride feature on the PR build and checking target records until you have adequately convinced yourself it is not :dumpster_fire:

#### What are the relevant tickets?
lol
#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
