### PR TITLE
csv was not being treated as utf8

### DIFF
--- a/app/models/custom_hint.rb
+++ b/app/models/custom_hint.rb
@@ -45,7 +45,7 @@ class CustomHint
 
   # Load csv hint source.
   def csv
-    open(@url, 'rb', &:read)
+    open(@url, 'rb', &:read).force_encoding("UTF-8")
   end
 
   # Make sure the csv has the headers we expect. (More headers are fine - we'll


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Google Sheets exports as UTF8. We were not treating the file as UTF8.

I’m not sure why this worked before and didn’t anymore.

The failing record was for Encyclopædia Britannica online which loaded fine with this change on the staging server.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO