### PR TITLE
Add adv search links to bottom of books and articles boxes

### DIFF
--- a/app/assets/stylesheets/_bento.scss
+++ b/app/assets/stylesheets/_bento.scss
@@ -81,6 +81,12 @@
   .wc-link {
     display: block;
   }
+
+  .advsearch-desc {
+    font-size: $fs-smallish;
+    color: $gray;
+    margin: 1rem 0 0 0;
+  }
 }
 
 .results-more {

--- a/app/views/search/_placeholders.html.erb
+++ b/app/views/search/_placeholders.html.erb
@@ -1,8 +1,11 @@
 <div id="box-<%= id %>" class="wrap-results grid-item region" data-region="<%= heading %>">
   <h2 class="title"><%= heading %></h2>
-  <p class="results-desc"><%= sanitize(description) %></a></p>
+  <p class="results-desc"><%= sanitize(description) %></p>
   <div id="<%= id %>" class="<%= id %>">
     Loading results...
     <i class="fa fa-spinner fa-spin"></i>
+  </div>
+  <div class="advsearch">
+    <p class="advsearch-desc"><%= sanitize(advsearch) %></p>
   </div>
 </div>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -26,13 +26,13 @@
 <div id="hint"></div>
 
 <div class="gridband layout-2c">
-  <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand search to libraries around the world</a>" } %>
+  <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand search to libraries around the world</a>", advsearch: "<a href='https://mit.worldcat.org/search?qt=wc_org_mit&qt=affiliate&q=#{params[:q]}'>Expand your search to libraries around the world</a> or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
 
-  <%= render partial: "placeholders", locals: { heading: 'Articles and journals', id: 'articles_content', description: 'Articles from a variety of periodicals, including scholarly journals and magazines at MIT. <a href="https://libraries.mit.edu/search/">More search options</a>' } %>
+  <%= render partial: "placeholders", locals: { heading: 'Articles and journals', id: 'articles_content', description: 'Articles from a variety of periodicals, including scholarly journals and magazines at MIT. <a href="https://libraries.mit.edu/search/">More search options</a>', advsearch: "...or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
 </div>
 
 <div class="gridband layout-2c">
-  <%= render partial: "placeholders", locals: { heading: 'Library website and guides', id: 'website_content', description: 'MIT Libraries website and research guides.' } %>
+  <%= render partial: "placeholders", locals: { heading: 'Library website and guides', id: 'website_content', description: 'MIT Libraries website and research guides.', advsearch: '' } %>
 
   <%= render partial: "other_resources" %>
 </div>


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

#### What does this PR do?
Adds links to advanced search to the bottom of the Books and Articles boxes. 

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-699

#### Screenshots (if appropriate)
<img width="545" alt="screen shot 2018-05-08 at 5 03 53 pm" src="https://user-images.githubusercontent.com/4327102/39824869-65b91f56-537e-11e8-97f8-6c9cfb86602f.png">
<img width="560" alt="screen shot 2018-05-08 at 5 03 57 pm" src="https://user-images.githubusercontent.com/4327102/39824870-65cf9ed4-537e-11e8-9ed8-b22e624f0e5c.png">

#### Todo:
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
