### PR TITLE
Enable ENV toggle-able EDS Debug mode

### DIFF
--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -77,7 +77,8 @@ class RecordController < ApplicationController
                                       profile: ENV['EDS_PROFILE'],
                                       guest: helpers.guest?,
                                       org: 'mit',
-                                      use_cache: false)
+                                      use_cache: false,
+                                      debug: ENV['EDS_DEBUG'])
     @record = session.retrieve(dbid: @record_source, an: @record_an)
   end
 

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -19,16 +19,20 @@ class RecordController < ApplicationController
   # See https://github.com/ebsco/edsapi-ruby/ . The page which gives all the
   # affordances of the record object is lib/ebsco/eds/record.rb.
   def record
-    fetch_eds_record
-    @keywords = extract_eds_text(@record.eds_author_supplied_keywords)
-    @subjects = extract_eds_text(@record.eds_subjects)
+    with_session_error_handling { fetch_eds_record }
+    if @record
+      @keywords = extract_eds_text(@record.eds_author_supplied_keywords)
+      @subjects = extract_eds_text(@record.eds_subjects)
 
-    # Don't use q as the parameter here - that will cause the search form to
-    # notice the parameter and prefill the search, which is behavior we *don't*
-    # want.
-    @previous = params[:previous]
-    rainbowify? if Flipflop.enabled?(:pride)
-    render 'record'
+      # Don't use q as the parameter here - that will cause the search form to
+      # notice the parameter and prefill the search, which is behavior we *don't*
+      # want.
+      @previous = params[:previous]
+      rainbowify? if Flipflop.enabled?(:pride)
+      render 'record'
+    else
+      render 'errors/eds_session_error'
+    end
   end
 
   # this method should never be cached because we need a fresh expiring URL
@@ -80,6 +84,22 @@ class RecordController < ApplicationController
                                       use_cache: false,
                                       debug: ENV['EDS_DEBUG'])
     @record = session.retrieve(dbid: @record_source, an: @record_an)
+  end
+
+  def with_session_error_handling
+    yield
+  rescue NoMethodError => e
+    Rails.logger.warn("EDS Error Detected while retrieving full record: #{e}")
+    @eds_error_link = rebuild_eds_full_record_link
+  end
+
+  # rebuild a EDS UI Full Record Link if our local is broken
+  def rebuild_eds_full_record_link
+    db, an = request.fullpath.split('/').reject(&:blank?) - ['record']
+    ['http://search.ebscohost.com/login.aspx?direct=true&site=eds-live',
+     "&db=#{db}",
+     "&AN=#{an}",
+     '&custid=s8978330&groupid=main&profile=eds&authtype=ip,sso'].join
   end
 
   # Keywords and subjects are sometimes provided as lists and sometimes as

--- a/app/views/errors/eds_session_error.erb
+++ b/app/views/errors/eds_session_error.erb
@@ -1,0 +1,4 @@
+<h2 class="title title-page">An error occurred accessing the detail page you requested.</h2>
+
+<p>You may be able to access similar information this <%= link_to('alternative interface', @eds_error_link) %>.
+  If not, please <%= link_to('let us know', feedback_path) %>. Sorry for the inconvenience this has caused.</p>

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -22,6 +22,15 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'recover from bad EDS response' do
+    VCR.use_cassette('record: broken session',
+                     allow_playback_repeats: true) do
+      get record_url('dog00916a', 'mit.001492509')
+      assert_includes(@response.body,
+                      'An error occurred accessing the detail page')
+    end
+  end
+
   test 'clean_keywords' do
     VCR.use_cassette('record: article', allow_playback_repeats: true) do
       get record_url('aci', '123877356')

--- a/test/vcr_cassettes/record_broken_session.yml
+++ b/test/vcr_cassettes/record_broken_session.yml
@@ -1,0 +1,160 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:07:39 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"","AuthTimeout":"1800"}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:07:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - ddb717da-412b-4ec2-96da-cbe22ee71f79
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-1143328204"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - 30
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 24 Aug 2017 13:07:40 GMT
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 7427e122-5950-4cd3-aaa1-4816bc8553f5
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-1143328204"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '3632'
+    body:
+      encoding: UTF-8
+      string: '{}'
+    http_version:
+  recorded_at: Thu, 24 Aug 2017 13:07:42 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

#### What does this PR do?

- Setting `EDS_DEBUG` will enable the EDS debug mode
- When EDS API is having session issues, the gem fails with a NoMethodError. This detects that and recovers by supplying users an alternative interface link and logs the problem so we can be sure we understand how often this is happening.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
