### PR TITLE
Update text for session errors on full record views

### DIFF
--- a/app/views/errors/eds_session_error.erb
+++ b/app/views/errors/eds_session_error.erb
@@ -1,4 +1,3 @@
-<h2 class="title title-page">An error occurred accessing the detail page you requested.</h2>
+<h2 class="title title-page">An error occurred accessing this record</h2>
 
-<p>You may be able to access similar information this <%= link_to('alternative interface', @eds_error_link) %>.
-  If not, please <%= link_to('let us know', feedback_path) %>. Sorry for the inconvenience this has caused.</p>
+<p>We’re experiencing temporary system issues. You may be able to access the record you’re looking for directly in the <%= link_to('BartonPlus interface', @eds_error_link) %>. If not, please <%= link_to('let us know', 'https://libraries.mit.edu/ask') %>. Sorry for the inconvenience this has caused.</p>

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -27,7 +27,7 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
                      allow_playback_repeats: true) do
       get record_url('dog00916a', 'mit.001492509')
       assert_includes(@response.body,
-                      'An error occurred accessing the detail page')
+                      'An error occurred accessing this record')
     end
   end
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Updates some text for a specific failure state on our full records.

#### How can a reviewer manually see the effects of these changes?

The easiest way is to run this locally and change the rescue to a NameError and put a fake variable before it such as `asdf`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-720

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
