### PR TITLE
Enable barnes gem to allow for language metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 ruby '2.5.1'
 
 gem 'actionpack-action_caching'
+gem 'barnes'
 gem 'ebsco-eds'
 gem 'flipflop'
 gem 'google-api-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,9 @@ GEM
       rake (>= 10.4, < 13.0)
     arel (8.0.0)
     ast (2.4.0)
+    barnes (0.0.7)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     better_errors (2.4.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -330,6 +333,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     staccato (0.5.1)
+    statsd-ruby (1.4.0)
     stringex (2.8.4)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
@@ -371,6 +375,7 @@ PLATFORMS
 DEPENDENCIES
   actionpack-action_caching
   annotate
+  barnes
   better_errors
   binding_of_caller
   coveralls

--- a/app.json
+++ b/app.json
@@ -112,7 +112,8 @@
   ],
   "buildpacks": [
     {
-      "url": "heroku/ruby"
+      "url": "heroku/ruby",
+      "url": "heroku/metrics"
     }
   ]
 }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -47,10 +47,10 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, as Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
-#
+on_worker_boot do
+  # ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+  Barnes.start
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Status

READY

What does this PR do?

This will enables the Barnes gem to allow the Heroku beta language metrics.

It also enables the metrics buildpack in PR builds. To benefit from that, we would need to manually change individual PR builds to use paid dynos as metrics are only available in paid dynos.

Helpful background context (if appropriate)

https://devcenter.heroku.com/articles/language-runtime-metrics-ruby

Requires Database Migrations?

NO

Includes new or updated dependencies?

YES