### PR TITLE
Suppress author display if we have no link text

### DIFF
--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -33,6 +33,7 @@
         <span class="sr">Authors: </span>
         <% result.truncated_authors.each do |author| %>
         <span class="result-author">
+          <% next if author[0] == nil %>
           <%= link_to(author[0], search_prefix + author[1], data: {type: "Author"} ) unless author == "et al" %>
           <%= author if author == "et al" %>
         </span>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Skip author display if we have no link text.

#### Helpful background context (if appropriate)

Ebsco made a change to their API that did something weird. This is just a band aid but it seems fine and returns us to the same behavior we had before.

#### How can a reviewer manually see the effects of these changes?

Search for `orange` in this PR view and the prod site. Prod has a weird author link. This PR does not.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-746

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO