### PR TITLE
cache auth token and session token

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development do
   gem 'annotate'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'dotenv-rails'
   gem 'listen'
   gem 'rubocop'
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
+      railties (>= 3.2, < 6.0)
     ebsco-eds (1.0.0)
       activesupport (~> 5.0)
       bibtex-ruby (~> 4.0)
@@ -380,6 +383,7 @@ DEPENDENCIES
   binding_of_caller
   coveralls
   dalli
+  dotenv-rails
   ebsco-eds
   flipflop
   google-api-client

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -87,15 +87,6 @@ class SearchTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'only retries once on bad EDS session' do
-    VCR.use_cassette('bad eds session', allow_playback_repeats: true) do
-      error = assert_raise RuntimeError do
-        get '/search?q=popcorn&target=articles&per_page=5'
-      end
-      assert_match(/Consecutive Session Token/, error.message)
-    end
-  end
-
   test 'local full_record_link when enabled' do
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do

--- a/test/models/search_eds_test.rb
+++ b/test/models/search_eds_test.rb
@@ -28,10 +28,12 @@ class SearchEdsTest < ActiveSupport::TestCase
   end
 
   test 'invalid credentials' do
-    VCR.use_cassette('invalid credentials') do
-      query = SearchEds.new.search('popcorn', 'apiwhatnot', '')
-      assert_equal('invalid credentials', query)
+    error = assert_raise RuntimeError do
+      VCR.use_cassette('invalid credentials') do
+        SearchEds.new.search('popcorn', 'apiwhatnot', '')
+      end
     end
+    assert_match(/unable to get credentials/, error.message)
   end
 
   test 'can change timeout value' do
@@ -48,24 +50,6 @@ class SearchEdsTest < ActiveSupport::TestCase
     VCR.use_cassette('custom timeout') do
       assert_equal(1, SearchEds.new.send(:http_timeout))
     end
-  end
-
-  # creating an appropriate cassette for this is difficult as we need to
-  # first show the failure state and then show the success state when issuing
-  # the exact same call to EDS. Showing that it does not loop infinitely in
-  # a related test is successful and thus is probably good enough for now.
-  test 'retries on bad EDS session' do
-    skip 'unable to create a cassette to replicate failure then success'
-  end
-
-  test 'only retries once on bad EDS session' do
-    error = assert_raise RuntimeError do
-      VCR.use_cassette('bad eds session', allow_playback_repeats: true) do
-        SearchEds.new.search('popcorn', 'apiwhatnot',
-                             ENV['EDS_ARTICLE_FACETS'])
-      end
-    end
-    assert_match(/Consecutive Session Token/, error.message)
   end
 
   test 'general eds error handling' do


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Reduces the number of API calls per search significantly by caching tokens.

#### Helpful background context (if appropriate)

We currently perform 8 API calls to EDS for every search on our site.

This reduces that number to 2 by caching the Auth Token (EDS Docs suggest caching this for 30 minutes) and session tokens (EDS Docs suggest caching this per user, but for our bento view we have no concept of users so this should be fine... for record view we use their gem and this logic is not in place).

With this we also don't call end session any more as we'll continue to use the session until close to it's expiration time on their end so we'll let them do their own clean up.

TLDR: Once every 25 minutes, a search will require up to 8 API calls like they all do now. Between those times, most searches will require 2 (one for books, one for articles).

The expectation is that by making fewer calls to the EDS API we will have fewer opportunities for timeouts in making calls to the EDS API and a net result of a better user experience while also putting less load on both our server and the EDS servers.

We also remove retry attempts (I'm not sure these were working at all based on logz reporting... if we need them after this work is complete, it'll be better to rethink them separately).

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES