### PR TITLE
Safely display titles in full record view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    logger (1.2.8)
+    logger (1.3.0)
     lograge (0.10.0)
       actionpack (>= 4)
       activesupport (>= 4)

--- a/app/views/record/_basic_info.html.erb
+++ b/app/views/record/_basic_info.html.erb
@@ -13,7 +13,7 @@
 <h2 class="record-title">
   <span class="sr">Title: </span>
   <% if @record.title.present? %>
-    <%= @record.title %>
+    <%= safe_output(@record.title) %>
   <% else %>
     No title provided for this item.
   <% end %>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Flags titles as safe so ampersands are displayed properly.

#### How can a reviewer manually see the effects of these changes?

Prod:
https://lib.mit.edu/record/edshtl/hvd.32044079556437

Fixed:
https://mit-bento-staging-pr-495.herokuapp.com/record/edshtl/hvd.32044079556437

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-748

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
