### PR TITLE
Prefer custom links to constructed links and improve contructed links

### DIFF
--- a/app/concerns/sfx_handler.rb
+++ b/app/concerns/sfx_handler.rb
@@ -12,7 +12,8 @@ class SFXHandler
                  library: nil,
                  title: nil,
                  year: nil,
-                 volume: nil)
+                 volume: nil,
+                 source_title: nil)
     @barcode = barcode
     @call_number = call_number
     @collection = collection
@@ -21,6 +22,7 @@ class SFXHandler
     @library = library
     @year = year
     @volume = volume
+    @source_title = source_title
   end
 
   # Use this when you want to request a scan of an object.
@@ -44,7 +46,8 @@ class SFXHandler
       "&amp;title=#{encoded_title}",
       "&amp;location=#{encoded_location}",
       "&amp;rft.date=#{@year}",
-      "&amp;rft.volume=#{@volume}"
+      "&amp;rft.volume=#{@volume}",
+      "&amp;rft.stitle=#{@source_title}"
     ]
 
     url_parts.push(pid) if @doc_number

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -67,6 +67,17 @@ module RecordHelper
     )
   end
 
+  # If there are relevant custom links, use one.
+  def check_custom_link?
+    return false unless @record.fulltext_links.present?
+    @record.fulltext_links.each do |ftl|
+      if relevant_fulltext_link?(ftl)
+        @sfx_link = ftl[:url]
+      end
+    end
+    @sfx_link
+  end
+
   # domains we consider relevant when evaluating links
   def relevant_links
     ['libproxy.mit.edu', 'library.mit.edu', 'sfx.mit.edu', 'owens.mit.edu',
@@ -190,11 +201,18 @@ module RecordHelper
     elsif relevant_fulltext_link?(@record.fulltext_link)
       'availability_full'
 
+    # Sometimes sfx links show up elsewhere and are really good links.
+    elsif check_custom_link?
+      'availability_check_online'
+
     # When all else fails, make SFX sort it out.
     else
       @sfx_link = SFXHandler.new(
         title: @record.eds_title,
-        doc_number: clean_an,
+        source_title: @record.source_title,
+        year: @record.eds_publication_year,
+        volume: @record.eds_volume,
+        doc_number: clean_an
       ).url_generic
       'availability_check_online'
     end

--- a/app/views/record/_availability_check_online.html.erb
+++ b/app/views/record/_availability_check_online.html.erb
@@ -1,2 +1,4 @@
 <%# Make sure to set an @sfx_link value if using this partial! %>
-<a class="button button-secondary" href="<%= @sfx_link %>">Check for online copy</a>
+<% unless @sfx_link.include?('This+title+is+unavailable+for+guests') %>
+  <a class="button button-secondary" href="<%= @sfx_link %>">Check for online copy</a>
+<% end %>

--- a/test/concerns/sfx_handler_test.rb
+++ b/test/concerns/sfx_handler_test.rb
@@ -19,7 +19,7 @@ class SFXHandlerConcernTest < MiniTest::Test
       volume: volume
     ).url_for_scan
 
-    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO&amp;call_number=PS3552.U827.P37+2000&amp;barcode=39080014585712&amp;title=Parable+of+the+sower&amp;location=Hayden+Library&amp;rft.date=2010&amp;rft.volume=10&amp;genre=journal'
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO&amp;call_number=PS3552.U827.P37+2000&amp;barcode=39080014585712&amp;title=Parable+of+the+sower&amp;location=Hayden+Library&amp;rft.date=2010&amp;rft.volume=10&amp;rft.stitle=&amp;genre=journal'
 
     assert_equal(expected_url, sfx_link)
   end
@@ -32,7 +32,7 @@ class SFXHandlerConcernTest < MiniTest::Test
       doc_number: clean_an
     ).url_generic
 
-    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO_FALLBACK&amp;call_number=&amp;barcode=&amp;title=This+is+a+title&amp;location=&amp;rft.date=&amp;rft.volume=&amp;pid=DocNumber=35819515,Ip=library.mit.edu,Port=9909'
+    expected_url = 'https://sfx.mit.edu/sfx_test?sid=ALEPH:BENTO_FALLBACK&amp;call_number=&amp;barcode=&amp;title=This+is+a+title&amp;location=&amp;rft.date=&amp;rft.volume=&amp;rft.stitle=&amp;pid=DocNumber=35819515,Ip=library.mit.edu,Port=9909'
 
     assert_equal(expected_url, sfx_link)
   end

--- a/test/models/button_scan_test.rb
+++ b/test/models/button_scan_test.rb
@@ -72,7 +72,7 @@ class ButtonScanTest < ActiveSupport::TestCase
         '&amp;barcode=39080023421933',
         '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
         '&amp;location=Hayden+Library',
-        '&amp;rft.date=2001&amp;rft.volume=v.16&amp;genre=journal'
+        '&amp;rft.date=2001&amp;rft.volume=v.16&amp;rft.stitle=&amp;genre=journal'
       ].join('')
       assert_equal(url, @button.url)
     end
@@ -88,7 +88,7 @@ class ButtonScanTest < ActiveSupport::TestCase
           '&amp;barcode=39080023421933',
           '&amp;title=The+collected+works+of+Langston+Hughes+%2F+edited+with+an+introduction+by+Arnold+Rampersad.',
           '&amp;location=Hayden+Library',
-          '&amp;rft.date=2001&amp;rft.volume=v.16&amp;genre=journal'
+          '&amp;rft.date=2001&amp;rft.volume=v.16&amp;rft.stitle=&amp;genre=journal'
         ].join('')
         assert_equal(url, @button.url)
       end


### PR DESCRIPTION
#### What does this PR do?

- uses relevant links from EDS custom links section if they exist and fulltext links is not present. This is the second to last option so it is only used when we'd previously construct an SFX link
- adds rft.stitle to our constructed sfx link fallback if present

#### Helpful background context (if appropriate)

The logic behind the links is awful and unfortunately we essentially duplicate it because our initial search does direct API calls and our single record view uses an EDS maintained wrapper gem. At one point a project was proposed to normalize that to always using the wrapper gem but that work was denied. It has been long enough and the effects of that decision are painful enough that it may be appropriate to do that work as routine maintenance.

#### How can a reviewer manually see the effects of these changes?

`/record/edsoro/oro.9780195156003.013.0057`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-801

#### Todo:
- [ ] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
