### PR TITLE
revert travis bundler install as it seems fine now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ sudo: false
 env:
   - SPEC_REPORTER=true
 script: bin/rails test
-before_install:
-  - gem update --system
-  - gem install bundler


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Removes a workaround for the bundler version that seems to have been resolved (finally) in the Travis base image.

#### Helpful background context (if appropriate)

https://github.com/MITLibraries/bento/commit/ebc8a06097c9593d16445d949931fc839577957d

#### How can a reviewer manually see the effects of these changes?

The travis build works

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
