### PR TITLE
removes therubyracer per heroku instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'sentry-raven'
 gem 'skylight'
 gem 'staccato'
 gem 'stringex'
-gem 'therubyracer', platforms: :ruby
 gem 'uglifier'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,6 @@ GEM
       kaminari-core (= 1.2.0)
     kaminari-core (1.2.0)
     latex-decode (0.3.1)
-    libv8 (3.16.14.19)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -279,7 +278,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    ref (2.0.0)
     regexp_parser (1.6.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -342,9 +340,6 @@ GEM
     stringex (2.8.5)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -414,7 +409,6 @@ DEPENDENCIES
   sqlite3 (= 1.3.13)
   staccato
   stringex
-  therubyracer
   uglifier
   vcr
   web-console


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
This removes the apparently-unneeded gem `therubyracer`

#### Helpful background context (if appropriate)
https://devcenter.heroku.com/articles/rails-asset-pipeline#therubyracer

#### How can a reviewer manually see the effects of these changes?
The usual way

#### Todo:
- [ ] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES - therubyracer is removed, but I think this happens automatically
