### PR TITLE
Allow disabling of hold, recall and scan buttons for local items

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ custom hint metadata.
 - `LOG_LEVEL`: set log level for development, default is `:debug`
 - `RESULTS_PER_BOX`: defaults to 3
 - `SENTRY_DSN`: logs exceptions to Sentry
+- `DISABLE_SCANS`: if set will disable scans for local aleph items
+- `DISABLE_HOLDS`: if set will disable holds for local aleph items
+- `DISABLE_RECALLS`: if set will disable recalls for local aleph items
 
 ## Developing locally with Docker
 

--- a/app/models/button_hold_recall.rb
+++ b/app/models/button_hold_recall.rb
@@ -25,10 +25,12 @@ class ButtonHoldRecall
 
   def eligible_hold?
     return false if @on_reserve || @library == 'Physics Dept. Reading Room'
+    return false if Flipflop.enabled?(:disable_holds)
     available_here_now? && hold_recallable?
   end
 
   def eligible_recall?
+    return false if Flipflop.enabled?(:disable_recalls)
     return unless recallable_status?
     return false if @on_reserve || @library == 'Physics Dept. Reading Room'
     !eligible_hold? && hold_recallable?

--- a/app/models/button_scan.rb
+++ b/app/models/button_scan.rb
@@ -14,6 +14,7 @@ class ButtonScan
   # issue, like "item is not in the library right now" or "item is an audio
   # tape".
   def eligible?
+    return false if Flipflop.enabled?(:disable_scans) 
     [
       call_number_valid?,
       z30status_valid?,

--- a/config/features.rb
+++ b/config/features.rb
@@ -22,4 +22,16 @@ Flipflop.configure do
   feature :pride,
     default: ENV['PRIDE'],
     description: 'Enables rainbows for records with LGBT subjects/keywords'
+
+  feature :disable_holds,
+    default: ENV['DISABLE_HOLDS'],
+    description: 'Determines if holds for local items are currently enabled'
+
+  feature :disable_recalls,
+    default: ENV['DISABLE_RECALLS'],
+    description: 'Determines if recalls for local items are currently enabled'
+
+  feature :disable_scans,
+    default: ENV['DISABLE_SCANS'],
+    description: 'Determines if scans for local items are currently enabled'
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This adds 3 features controlled by optional ENV to determine if we will display holds, recalls and scans. Not setting the ENV defaults to the features being on, so we don't need to include these settings in app.json.

#### How can a reviewer manually see the effects of these changes?

View the examples in the linked ticket in prod and the pr build and note the missing buttons in the PR build.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-827

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
