### PR TITLE
Allow disabling of ILL buttons for local items

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ custom hint metadata.
 - `SENTRY_DSN`: logs exceptions to Sentry
 - `DISABLE_SCANS`: if set will disable scans for local aleph items
 - `DISABLE_HOLDS`: if set will disable holds for local aleph items
+- `DISABLE_ILLS`: if set will disable ILLs for local aleph items
 - `DISABLE_RECALLS`: if set will disable recalls for local aleph items
 
 ## Developing locally with Docker

--- a/app/models/button_ill.rb
+++ b/app/models/button_ill.rb
@@ -23,6 +23,7 @@ class ButtonIll
   # or ILLiad. We prefer that patrons use BorrowDirect; WorldCat will send them
   # there preferentially if it is an option.
   def eligible?
+    return false if Flipflop.enabled?(:disable_ills) 
     # If it has a disqualifying status, you can't ILL it. If it doesn't, you're
     # good to go.
     [

--- a/config/features.rb
+++ b/config/features.rb
@@ -27,6 +27,10 @@ Flipflop.configure do
     default: ENV['DISABLE_HOLDS'],
     description: 'Determines if holds for local items are currently enabled'
 
+  feature :disable_ills,
+    default: ENV['DISABLE_ILLS'],
+    description: 'Determines if ILLs for local items are currently enabled'
+
   feature :disable_recalls,
     default: ENV['DISABLE_RECALLS'],
     description: 'Determines if recalls for local items are currently enabled'


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This adds the ability to disable ILL buttons controlled by optional ENV. Not setting the ENV defaults to the features being on, so we don't need to include these settings in app.json.

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-827

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
