### PR TITLE
DA-164 Add Matomo tracking code to Bento

### DIFF
--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -1,3 +1,24 @@
+<script>
+// Matomo
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+  var u = '<%= ENV['MATOMO_URL'] %>';
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '<%= ENV['MATOMO_SITE_ID'] %>']);
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.type = 'text/javascript';
+  g.async = true;
+  g.defer = true;
+  g.src = u + 'matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();
+// End Matomo Code
+</script>
 <div class="wrap-outer-breadcrumb layout-band">
   <div class="wrap-breadcrumb" role="navigation" aria-label="breadcrumbs">
     <div class="breadcrumbs">


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

#### What does this PR do?
Adds to the asset pipeline the JavaScript required to track site usage with Matomo. There are a two details that we will need to address before merging:

1. The tracking code currently sends data to a staging app. We will need to update once we confirm and data is coming in as expected and our production environment is ready.
2. The website tracked is this PR build, so we will need to update the Matomo config to track Bento in production.

#### How can a reviewer manually see the effects of these changes?
There should be no visible changes. We will need to check the dashboard in our Matomo staging app to confirm that it is collecting data. (EDIT: this was confirmed on 6/23/20; see screenshot below.)

#### Screenshots
![Screen Shot 2020-06-23 at 4 55 57 PM](https://user-images.githubusercontent.com/16103405/85461565-7f02a380-b572-11ea-9bed-5e7502d2cf5b.png)

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DA-164
- https://mitlibraries.atlassian.net/browse/DA-177

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
