### PR TITLE
Don't throw exceptions on no record found

### DIFF
--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -6,6 +6,12 @@ class RecordController < ApplicationController
   class DbLimitReached < StandardError; end
   class UnknownEdsError < StandardError; end
 
+  rescue_from NoSuchRecordError, with: :no_such_record
+
+  def no_such_record
+    render 'not_found', status: 404
+  end
+
   # We are using ActionCaching due to EDS not providing an readily cacheable
   # object to use with low level caching like we do with our bento results.
   # They provide a cache option but it is hardcoded to use a file system cache.
@@ -102,9 +108,9 @@ class RecordController < ApplicationController
     if e.message.include?('Simultaneous User Limit Reached')
       raise RecordController::DbLimitReached, e
     elsif e.message.include?('DbId Not In Profile')
-      raise RecordController::NoSuchRecordError, "Record not found: #{e}"
+      raise RecordController::NoSuchRecordError
     elsif e.message.include?('Record not found')
-      raise RecordController::NoSuchRecordError, "Record not found: #{e}"
+      raise RecordController::NoSuchRecordError
     else
       raise RecordController::UnknownEdsError, e
     end

--- a/app/views/record/not_found.erb
+++ b/app/views/record/not_found.erb
@@ -1,0 +1,3 @@
+<h2 class="title title-page">The requested record was not found.</h2>
+
+<p><%= link_to('Starting over', root_path) %> may help. If it does not, please <%= link_to('let us know', 'https://libraries.mit.edu/ask/') %>!</p>

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -16,9 +16,8 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
   test 'should handle invalid parameters' do
     VCR.use_cassette('record: no such database',
                      allow_playback_repeats: true) do
-      assert_raises RecordController::NoSuchRecordError do
-        get record_url('dog00916a', 'mit.001492509')
-      end
+      get record_url('dog00916a', 'mit.001492509')
+      assert_includes(@response.body, 'The requested record was not found.')
     end
   end
 
@@ -54,18 +53,16 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
   test 'direct_link with invalid record' do
     VCR.use_cassette('record: direct invalid', allow_playback_repeats: true) do
       ActionDispatch::Request.any_instance.stubs(:remote_ip).returns('18.0.0.0')
-      assert_raises RecordController::NoSuchRecordError do
-        get record_direct_link_url('dog00916a', 'mit.001492509')
-      end
+      get record_direct_link_url('dog00916a', 'mit.001492509')
+      assert_includes(@response.body, 'The requested record was not found.')
     end
   end
 
   test 'record not found' do
     VCR.use_cassette('record: not found', allow_playback_repeats: true) do
       ActionDispatch::Request.any_instance.stubs(:remote_ip).returns('18.0.0.0')
-      assert_raises RecordController::NoSuchRecordError do
-        get record_direct_link_url('cat00916a', 'mit.003696445')
-      end
+      get record_direct_link_url('cat00916a', 'mit.003696445')
+      assert_includes(@response.body, 'The requested record was not found.')
     end
   end
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

For some reason we were sending exceptions on every invalid record request. We also sent 404 status but throwing an exception was not appropriate here so this removes that.

#### How can a reviewer manually see the effects of these changes?

Locally, check out the master branch and request an invalid record such as:

localhost:3000/record/cat00916a/mit.fake

Note the exceptions in the logs.

Check out this branch and request the same record. You should see no exceptions logged.

#### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/ENGX-44
#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
