### PR TITLE
Change language for Aeon button link text

### DIFF
--- a/app/models/button_aeon.rb
+++ b/app/models/button_aeon.rb
@@ -21,7 +21,7 @@ class ButtonAeon
     if @aeon_type == 'onsite'
       'Request for on-site use'
     else
-      'Order a copy'
+      'Order/get a copy'
     end
   end
 

--- a/test/models/button_aeon_test.rb
+++ b/test/models/button_aeon_test.rb
@@ -13,7 +13,7 @@ class ButtonAeonTest < ActiveSupport::TestCase
   test 'html_button_eligible' do
     button = ButtonAeon.new(@item, @oclc, @scan)
     button.instance_variable_set(:@library, 'Institute Archives')
-    assert(button.html_button.include?('Order a copy'))
+    assert(button.html_button.include?('Order/get a copy'))
 
     button.instance_variable_set(:@aeon_type, 'onsite')
     assert(button.html_button.include?('Request for on-site use'))


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Changes the link text for Aeon requests from 'Order a copy' to 'Order/get a copy'.

#### How can a reviewer manually see the effects of these changes?
Check a record with an Institute Archives/Distinctive Collections holding, e.g.: https://mit-bento-staging-pr-723.herokuapp.com/record/cat00916a/mit.000583269

The button to the right of 'Order for on-site use' should read 'Order/get a copy'.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-986

#### Todo:
- [x] Tests
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
