### PR TITLE
Allow UI links to test aleph and update hold button wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ custom hint metadata.
 ## Required Environment Variables
 
 - `ALEPH_API_URI`: endpoint URI for Aleph Realtime Availability checks
+- `ALEPH_UI_HOST`: hostname for Aleph UI. Defaults to production
 - `ALEPH_KEY`: we use a custom API adapter to aleph that restricts via key
   instead of IP address
 - `EDS_ARTICLE_FACETS`: facets to apply to create an articles search

--- a/app/models/button_hold_recall.rb
+++ b/app/models/button_hold_recall.rb
@@ -14,7 +14,7 @@ class ButtonHoldRecall
         "href='#{url}'>Recall (7+ days)</a>"
     elsif eligible_hold?
       "<a class='btn button-secondary button-small' " \
-          "href='#{url}'>Place hold (1-2 days)</a>"
+          "href='#{url}'>Place hold</a>"
     end
   end
 
@@ -38,12 +38,13 @@ class ButtonHoldRecall
   end
 
   def url
+    aleph_host = ENV.fetch('ALEPH_UI_HOST', 'library.mit.edu')
     queryarray = { func: 'item-hold-request',
                    doc_library: 'MIT50',
                    adm_doc_number: @doc_number,
                    item_sequence: @item_sequence }
 
-    url = URI::HTTP.build(host: 'library.mit.edu',
+    url = URI::HTTP.build(host: aleph_host,
                           path: '/F',
                           query: queryarray.to_query)
     url.to_s

--- a/test/integration/aleph_test.rb
+++ b/test/integration/aleph_test.rb
@@ -93,7 +93,7 @@ class AlephTest < ActionDispatch::IntegrationTest
   test 'place hold link displayed' do
     VCR.use_cassette('realtime aleph') do
       get full_item_status_path, params: { id: 'MIT01001739356' }
-      assert_select 'a', text: 'Place hold (1-2 days)' do |value|
+      assert_select 'a', text: 'Place hold' do |value|
         parsed_url = URI.parse(value.first[:href])
         assert_equal parsed_url.host, 'library.mit.edu'
         assert_equal parsed_url.path, '/F'

--- a/test/models/button_hold_recall_test.rb
+++ b/test/models/button_hold_recall_test.rb
@@ -13,13 +13,13 @@ class ButtonHoldRecallTest < ActiveSupport::TestCase
   test 'html_button_recall' do
     @button.stub :eligible_recall?, true do
       assert(@button.html_button.include?('Recall (7+ days)'))
-      refute(@button.html_button.include?('Place hold (1-2 days)'))
+      refute(@button.html_button.include?('Place hold'))
     end
   end
 
   test 'html_button_hold' do
     @button.stub :eligible_hold?, true do
-      assert(@button.html_button.include?('Place hold (1-2 days)'))
+      assert(@button.html_button.include?('Place hold'))
       refute(@button.html_button.include?('Recall (7+ days)'))
     end
   end


### PR DESCRIPTION
Adds configurable Aleph UI host name so we can test links to non-production system.

Updates wording to not reflect the time to place a Hold.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-874

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
