### PR TITLE
Update hold button wording to match Aleph

### DIFF
--- a/app/models/button_hold_recall.rb
+++ b/app/models/button_hold_recall.rb
@@ -14,7 +14,7 @@ class ButtonHoldRecall
         "href='#{url}'>Recall (7+ days)</a>"
     elsif eligible_hold?
       "<a class='btn button-secondary button-small' " \
-          "href='#{url}'>Place hold</a>"
+          "href='#{url}'>Request item</a>"
     end
   end
 

--- a/test/integration/aleph_test.rb
+++ b/test/integration/aleph_test.rb
@@ -93,7 +93,7 @@ class AlephTest < ActionDispatch::IntegrationTest
   test 'place hold link displayed' do
     VCR.use_cassette('realtime aleph') do
       get full_item_status_path, params: { id: 'MIT01001739356' }
-      assert_select 'a', text: 'Place hold' do |value|
+      assert_select 'a', text: 'Request item' do |value|
         parsed_url = URI.parse(value.first[:href])
         assert_equal parsed_url.host, 'library.mit.edu'
         assert_equal parsed_url.path, '/F'

--- a/test/models/button_hold_recall_test.rb
+++ b/test/models/button_hold_recall_test.rb
@@ -13,13 +13,13 @@ class ButtonHoldRecallTest < ActiveSupport::TestCase
   test 'html_button_recall' do
     @button.stub :eligible_recall?, true do
       assert(@button.html_button.include?('Recall (7+ days)'))
-      refute(@button.html_button.include?('Place hold'))
+      refute(@button.html_button.include?('Request item'))
     end
   end
 
   test 'html_button_hold' do
     @button.stub :eligible_hold?, true do
-      assert(@button.html_button.include?('Place hold'))
+      assert(@button.html_button.include?('Request item'))
       refute(@button.html_button.include?('Recall (7+ days)'))
     end
   end


### PR DESCRIPTION
Stakeholders requested a small wording change to match the button that provides the same functionality in Aleph.

Partial work towards

https://mitlibraries.atlassian.net/browse/DI-874

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-874

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
