### PR TITLE
Hold button tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ custom hint metadata.
 ## Optional Environment Variables
 
 - `ALEPH_HINT_SOURCE`: HTTP GET accessible marcxml source for Hints
+- `ALEPH_HOLD_TYPE`: Switches between links to Aleph `item-hold-request` and
+  `item-global`. Defaults to `item-global`.
 - `EDS_TIMEOUT`: value to override the 6 second default for EDS timeout
 - `EDS_GEM_HOSTS_LIST`: override list of hosts to use for our full record views
   defaults to the (theoretically) load balanced EDS API endpoint. The protocol

--- a/app/models/button_hold_recall.rb
+++ b/app/models/button_hold_recall.rb
@@ -52,6 +52,7 @@ class ButtonHoldRecall
 
   # Items with these process & item statuses may be put on hold/recalled.
   def hold_recallable?
+    return false if @library == 'Unavailable due to renovation'
     return false if @on_reserve || @library == 'Physics Dept. Reading Room'
     [
       # Items with these status codes may be requested from any library,

--- a/app/models/button_hold_recall.rb
+++ b/app/models/button_hold_recall.rb
@@ -39,10 +39,18 @@ class ButtonHoldRecall
 
   def url
     aleph_host = ENV.fetch('ALEPH_UI_HOST', 'library.mit.edu')
-    queryarray = { func: 'item-hold-request',
-                   doc_library: 'MIT50',
-                   adm_doc_number: @doc_number,
-                   item_sequence: @item_sequence }
+    aleph_hold_type = ENV.fetch('ALEPH_HOLD_TYPE', 'item-hold-request')
+
+    queryarray = if aleph_hold_type == 'item-hold-request'
+                   { func: 'item-hold-request',
+                     doc_library: 'MIT50',
+                     adm_doc_number: @doc_number,
+                     item_sequence: @item_sequence }
+                 else
+                   { func: 'item-global',
+                     doc_library: 'MIT01',
+                     doc_number: @doc_number }
+                 end
 
     url = URI::HTTP.build(host: aleph_host,
                           path: '/F',

--- a/app/models/button_maker.rb
+++ b/app/models/button_maker.rb
@@ -42,6 +42,7 @@ module ButtonMaker
   # We won't generally ILL or Recall items that fit these criteria as we want
   # them to be placed on hold if possible.
   def available_here_now?
+    return true if Flipflop.enabled?(:disable_recalls)
     # You can request things that are in the library and have reasonable
     # loan policies.
     [


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Adjust logic for Hold buttons based on stakeholder feedback.

- Ensures Hold buttons are not displayed for renovation affected items even if WorldCatinator feature is disabled
- Allows Holds on any item status if Recalls are disabled


#### How can a reviewer manually see the effects of these changes?

There are example records in the linked ticket, but mostly we need to check with stakeholders for edge case detection to know for sure if this is 🌈 


#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DI-917


#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
