### PR TITLE
Add Primo Search model

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ custom hint metadata.
 - `GOOGLE_CUSTOM_SEARCH_ID`: your Google Custom Search engine ID
 - `MAX_AUTHORS`: the maximum number of authors displayed in any record.
   If exceeded, 'et al' will be appended after this number.
+- `PRIMO_SEARCH_API_KEY`: the Primo Search API key.
+- `PRIMO_SEARCH_API_URL`: the root URL for the Primo Search API.
+- `PRIMO_VID_INST`: this is actually two separate Primo Search API params, 
+`vid` and `inst`. We use the same variable for both because they are 
+currently the same value, so VCR will break when it filters out the real 
+values. If the values diverge in the future, they will need to become 
+separate variables.
 - `RECAPTCHA_SITE_KEY`
 - `RECAPTCHA_SECRET_KEY`
 - `TIMDEX_URL`: The GraphQL endpoint for Timdex/ArchiveSpace

--- a/app/models/search_primo.rb
+++ b/app/models/search_primo.rb
@@ -1,0 +1,44 @@
+# Searches Primosearch API and formats results into {Result} object
+#
+# == Required Environment Variables:
+# - PRIMO_SEARCH_API_URL
+# - PRIMO_SEARCH_API_KEY
+# - PRIMO_VID_INST
+#
+
+class SearchPrimo
+  attr_reader :results
+
+  PRIMO_SEARCH_API_URL = ENV['PRIMO_SEARCH_API_URL'].freeze
+  PRIMO_SEARCH_API_KEY = ENV['PRIMO_SEARCH_API_KEY']
+  PRIMO_VID_INST = ENV['PRIMO_VID_INST']
+
+  def initialize
+    @primo_http = HTTP.persistent(PRIMO_SEARCH_API_URL)
+    @results = {}
+  end
+
+  def search(term)
+    result = @primo_http.headers(accept: 'application/json')
+                        .get(search_url(term))
+
+    raise "Primo Error Detected: #{result.status}" unless result.status == 200
+
+    JSON.parse(result)
+  end
+
+  private
+
+  # Initial search term sanitization.
+  def clean_term(term)
+    URI.encode(term.strip.tr(' ', '+').delete(',').tr(':', '+'))
+  end
+
+  # This is subject to change. Right now we are just using the required 
+  # params and assuming that no operators are used.
+  def search_url(term)
+    [PRIMO_SEARCH_API_URL, '/primo/v1/search?vid=', PRIMO_VID_INST,
+     '&tab=Everything&scope=default_scope&q=any,contains,', clean_term(term),
+     '&inst=', PRIMO_VID_INST, '&apikey=', PRIMO_SEARCH_API_KEY].join('')
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,10 @@ Rails.application.configure do
   ENV['ALEPH_HINT_SOURCE'] = 'https://fake.example.com/s/fake/getserial_mini.xml?dl=1'
   ENV['FULL_RECORD_TOGGLE_BUTTON'] = 'true'
 
+  ENV['PRIMO_SEARCH_API_URL'] = 'https://another_fake_server.example.com'
+  ENV['PRIMO_SEARCH_API_KEY'] = 'FAKE_PRIMO_SEARCH_API_KEY'
+  ENV['PRIMO_VID_INST'] = 'FAKE_PRIMO_VID_INST'
+
   ENV['SCAN_EXCLUSIONS']='Materials -- Standards -- United States -- Periodicals;Materials -- Standards -- United States -- Periodicals;Standards, Engineering;Standards, Engineering -- Periodicals'
 
   ENV['TIMDEX_URL']='https://timdex.mit.edu/graphql'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180821195231) do
+ActiveRecord::Schema.define(version: 2018_08_21_195231) do
 
   create_table "hints", force: :cascade do |t|
     t.string "title", null: false

--- a/test/models/search_primo_test.rb
+++ b/test/models/search_primo_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class SearchPrimoTest < ActiveSupport::TestCase
+  test 'can call Primo API' do
+    VCR.use_cassette('popcorn primo', allow_playback_repeats: true) do
+      query = SearchPrimo.new.search('popcorn')
+      assert_equal Hash, query.class
+    end
+  end
+
+  test 'searching returns a list of results' do
+    VCR.use_cassette('popcorn primo', allow_playback_repeats: true) do
+      query = SearchPrimo.new.search('popcorn')
+      assert_operator query['info']['total'], :>, 0
+      assert_operator query['docs'].length, :>, 0
+    end
+  end
+
+  test 'handles error states as expected' do
+    VCR.use_cassette('bad primo response', allow_playback_repeats: true) do
+      assert_raises "Primo Error Detected: 500 Internal Server Error" do 
+        SearchPrimo.new.search('popcorn')
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,6 +76,16 @@ VCR.configure do |config|
   config.filter_sensitive_data('FAKE_GOOGLE_CUSTOM_SEARCH_ID') do
     (ENV['GOOGLE_CUSTOM_SEARCH_ID']).to_s
   end
+
+  config.filter_sensitive_data('https://another_fake_server.example.com') do
+    (ENV['PRIMO_SEARCH_API_URL']).to_s
+  end
+  config.filter_sensitive_data('FAKE_PRIMO_SEARCH_API_KEY') do
+    (ENV['PRIMO_SEARCH_API_KEY']).to_s
+  end
+  config.filter_sensitive_data('FAKE_PRIMO_VID_INST') do
+    (ENV['PRIMO_VID_INST']).to_s
+  end
 end
 
 module ActiveSupport

--- a/test/vcr_cassettes/bad_primo_response.yml
+++ b/test/vcr_cassettes/bad_primo_response.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&inst=FAKE_PRIMO_VID_INST&q=any,contains,popcorn&scope=default_scope&tab=Everything&vid=FAKE_PRIMO_VID_INST
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - api-na.hosted.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      X-Exl-Api-Remaining:
+      - '549998'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,POST,DELETE,PUT,OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 13 Apr 2021 15:21:56 GMT
+      Connection:
+      - close
+      Server:
+      - CA-API-Gateway/9.0
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 13 Apr 2021 15:21:56 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo.yml
+++ b/test/vcr_cassettes/popcorn_primo.yml
@@ -1,0 +1,967 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&inst=FAKE_PRIMO_VID_INST&q=any,contains,popcorn&scope=default_scope&tab=Everything&vid=FAKE_PRIMO_VID_INST
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - api-na.hosted.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Vary:
+      - accept-encoding
+      X-Exl-Api-Remaining:
+      - '549996'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,POST,DELETE,PUT,OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 13 Apr 2021 15:45:20 GMT
+      Server:
+      - CA-API-Gateway/9.0
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "info" : {
+            "totalResultsLocal" : 132,
+            "totalResultsPC" : -1,
+            "total" : 132,
+            "first" : 1,
+            "last" : 10
+          },
+          "highlights" : {
+            "termsUnion" : [ ]
+          },
+          "docs" : [ {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933026557106761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "BKSE" ],
+                "language" : [ "eng" ],
+                "title" : [ "Atmospheric Measurements during POPCORN — Characterisation of the Photochemistry over a Rural Area" ],
+                "subject" : [ "Atmospheric sciences", "Climate change" ],
+                "format" : [ "1 online resource (VI, 246 p.) " ],
+                "identifier" : [ "$$CISBN$$V94-017-0813-4;$$CISBN$$V0-7923-5531-8;$$CISBN$$V90-481-5158-9" ],
+                "creationdate" : [ "1998" ],
+                "publisher" : [ "Dordrecht : Springer Netherlands : Imprint: Springer" ],
+                "description" : [ "Present policy issues concern the reduction of ozone levels by controlling its precursors, NOx and volatile organic compounds (VOC). VOC are emitted from anthropogenic and biogenic sources. Whereas our understanding of VOC emissions from anthropogenic sources has advanced significantly in recent years, there is still a lack of knowledge concerning the contribution of biogenic VOC to the budget of organic trace gases and their impact on the formation of ozone in the troposphere. Improving ozone reduction strategies in the future requires a detailed understanding of the chemical processes in the troposphere. This book comprises the results of atmospheric measurements obtained during the field campaign POPCORN (Photo-Oxidant Formation by Plant Emitted Compounds and OH Radicals in North-Eastern Germany) which was carried out to investigate the role and impact of biogenic trace gases on tropospheric chemistry. This volume describes meteorological situations and origins of air masses during the campaign, and presents measurements of a variety of trace gases, solar radiation and photolysis frequencies. Special attention is given to OH radical measurements and the in-situ comparison of the two OH measurement techniques." ],
+                "mms" : [ "9933026557106761" ],
+                "dedupmemberids" : [ "990022823660206761" ],
+                "contributor" : [ "Rudolph, J. editor.$$QRudolph, J.", "Koppmann, R. editor.$$QKoppmann, R." ],
+                "edition" : [ "1st ed. 1998." ],
+                "contents" : [ "POPCORN: A Field Study of Photochemistry in North-Eastern Germany -- Meteorological Aspects, Ozone, and Solar Radiation Measurements During POPCORN 1994 -- Measurements of Carbon Monoxide and Nonmethane Hydrocarbons During POPCORN -- Measurements of Volatile Organic Compounds (VOC) During POPCORN 1994: Applying a New On-Line GC—MS-Technique -- Measurements of Atmospheric Formaldehyde (HCHO) and Acetaldehyde (CH3CHO) During POPCORN 1994 Using 2.4DNPH Coated Silica Cartridges -- Mixing Ratios and Photostationary State of NO and NO2 Observed During the POPCORN Field Campaign at a Rural Site in Germany -- Peroxyacetyl Nitrate (PAN) Measurements During the POPCORN Campaign -- Field Measurements of Atmospheric Photolysis Frequencies for O3, NO2, HCHO, CH3CHO, H2O2 and HONO by UV Spectroradiometry -- In-situ Measurements of Tropospheric Hydroxyl Radicals by Folded Long-Path Laser Absorption During the Field Campaign POPCORN -- Highly Time Resolved Measurements of OH During POPCORN Using Laser-Induced Fluorescence Spectroscopy -- Intercomparison of Tropospheric OH Measurements by Different Laser Techniques During the POPCORN Campaign 1994." ],
+                "place" : [ "Dordrecht :" ],
+                "version" : [ "1" ],
+                "lds01" : [ "Atmospheric sciences.", "Climate change." ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933026557106761" ],
+                "recordid" : [ "alma9933026557106761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "992660000000030035" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "6.515894E-4" ]
+              },
+              "addata" : {
+                "aulast" : [ "Rudolph", "Koppmann" ],
+                "aufirst" : [ "J.", "R." ],
+                "auinit" : [ "J", "R" ],
+                "addau" : [ "Rudolph, J.", "Koppmann, R." ],
+                "date" : [ "1998" ],
+                "isbn" : [ "94-017-0813-4", "0-7923-5531-8", "90-481-5158-9" ],
+                "notes" : [ "Includes bibliographical references at the end of each chapters." ],
+                "abstract" : [ "Present policy issues concern the reduction of ozone levels by controlling its precursors, NOx and volatile organic compounds (VOC). VOC are emitted from anthropogenic and biogenic sources. Whereas our understanding of VOC emissions from anthropogenic sources has advanced significantly in recent years, there is still a lack of knowledge concerning the contribution of biogenic VOC to the budget of organic trace gases and their impact on the formation of ozone in the troposphere. Improving ozone reduction strategies in the future requires a detailed understanding of the chemical processes in the troposphere. This book comprises the results of atmospheric measurements obtained during the field campaign POPCORN (Photo-Oxidant Formation by Plant Emitted Compounds and OH Radicals in North-Eastern Germany) which was carried out to investigate the role and impact of biogenic trace gases on tropospheric chemistry. This volume describes meteorological situations and origins of air masses during the campaign, and presents measurements of a variety of trace gases, solar radiation and photolysis frequencies. Special attention is given to OH radical measurements and the in-situ comparison of the two OH measurement techniques." ],
+                "cop" : [ "Dordrecht" ],
+                "pub" : [ "Springer Netherlands" ],
+                "oclcid" : [ "(ckb)2660000000030035", "(ssid)ssj962211", "(pqkbmanifestationid)11975177", "(pqkbtitlecode)tc962211", "(pqkbworkid)10975491", "(pqkb)10586780", "(de-he213)978-94-017-0813-5", "(miaapq)ebc4712446" ],
+                "doi" : [ "10.1007/978-94-017-0813-5" ],
+                "edition" : [ "1st ed. 1998." ],
+                "btitle" : [ "Atmospheric Measurements during POPCORN — Characterisation of the Photochemistry over a Rural Area" ]
+              },
+              "sort" : {
+                "title" : [ "Atmospheric Measurements during POPCORN — Characterisation of the Photochemistry over a Rural Area [electronic resource] / edited by J. Rudolph, R. Koppmann." ],
+                "author" : [ "Rudolph, J. editor." ],
+                "creationdate" : [ "1998" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9064564515824186148" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "FAKE_PRIMO_VID_INST",
+                "libraryCode" : "NET",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "UNASSIGNED location",
+                "subLocationCode" : "UNASSIGNED",
+                "mainLocation" : "Internet Resource",
+                "callNumber" : "**See URL(s)",
+                "callNumberType" : "8",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990022823660206761",
+                "holdId" : "2267438950006761",
+                "holKey" : "HoldingResultKey [mid=2267438950006761, libraryId=161683420006761, locationCode=UNASSIGNED, callNumber=**See URL(s)]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "FAKE_PRIMO_VID_INST",
+                "libraryCode" : "NET",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "UNASSIGNED location",
+                "subLocationCode" : "UNASSIGNED",
+                "mainLocation" : "Internet Resource",
+                "callNumber" : "**See URL(s)",
+                "callNumberType" : "8",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990022823660206761",
+                "holdId" : "2267438950006761",
+                "holKey" : "HoldingResultKey [mid=2267438950006761, libraryId=161683420006761, locationCode=UNASSIGNED, callNumber=**See URL(s)]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "check_holdings", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990022823660206761",
+                  "link" : "OVP",
+                  "inst4opac" : "FAKE_PRIMO_VID_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:9401708134,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "**See URL(s)",
+                "callNumberBrowseField" : "8"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "qc\"851-999",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721306761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019721306761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019721306761" ],
+                "recordid" : [ "alma9933019721306761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573078" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573078" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Thailand" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9003628398970808267" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723406761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019723406761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019723406761" ],
+                "recordid" : [ "alma9933019723406761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573061" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573061" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Greece" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9037562016405007885" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722106761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019722106761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019722106761" ],
+                "recordid" : [ "alma9933019722106761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573073" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573073" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: South Korea" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9004595849084473098" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019724206761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019724206761" ],
+                "recordid" : [ "alma9933019724206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573053" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573053" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Chile" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9007649350935717203" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723106761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Ireland" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019723106761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019723106761" ],
+                "recordid" : [ "alma9933019723106761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573064" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573064" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Ireland" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Ireland" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9064624205021560521" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019721206761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019721206761" ],
+                "recordid" : [ "alma9933019721206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573079" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573079" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: the Netherlands" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9013384081808631136" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724706761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019724706761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019724706761" ],
+                "recordid" : [ "alma9933019724706761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573048" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573048" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Asia-Pacific" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9070104524867762023" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722806761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Mexico" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019722806761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019722806761" ],
+                "recordid" : [ "alma9933019722806761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573067" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573067" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Mexico" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Mexico" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9050063563168056425" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723906761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "journal" ],
+                "language" : [ "fre" ],
+                "title" : [ "Popcorn Industry Profile: Europe" ],
+                "publisher" : [ "Datamonitor Plc" ],
+                "mms" : [ "9933019723906761" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "9933019723906761" ],
+                "recordid" : [ "alma9933019723906761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "991000000000573056" ],
+                "sourcesystem" : [ "SFX" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.999237E-4" ]
+              },
+              "addata" : {
+                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
+                "pub" : [ "Datamonitor Plc" ],
+                "oclcid" : [ "(ckb)1000000000573056" ],
+                "format" : [ "journal" ],
+                "genre" : [ "journal" ],
+                "ristype" : [ "JOUR" ],
+                "jtitle" : [ "Popcorn Industry Profile: Europe" ]
+              },
+              "sort" : {
+                "title" : [ "Popcorn Industry Profile: Europe" ],
+                "creationdate" : [ "0000" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9061988140408692301" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "FAKE_PRIMO_VID_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              }
+            }
+          } ],
+          "timelog" : {
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "249",
+            "CALL_SOLR_GET_IDS_LIST" : "2340",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "606",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "71",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "73",
+            "RETRIVE_FROM_DB_RECORDS" : "78",
+            "RETRIVE_FROM_DB_RELATIONS" : "20",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "304",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "302",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "320",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "3743",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
+            "BUILD_COMBINED_RESULTS_MAP" : 3767,
+            "COMBINED_SEARCH_TIME" : 3771,
+            "PROCESS_COMBINED_RESULTS" : 0,
+            "FEATURED_SEARCH_TIME" : 1
+          },
+          "facets" : [ ]
+        }
+  recorded_at: Tue, 13 Apr 2021 15:45:20 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### Why these changes are being introduced:

With the Primo launch forthcoming, we need to update Bento to query the
Primo Search API.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-1871

#### How this addresses that need:

This introduces a Primo Search model, which includes some rudimentary
logic to call the Primo Search API, and updates the readme accordingly.

#### Side effects of this change:

* The db schema timestamp updated in a weird way, as a result of my
having to run migrations locally.
* There are two new VCR cassettes: one for a normal Primo search, and
one for a bad Primo API response.
* Various API params have been added to ENV. Notably, PRIMO_VID_INST
is actually two params (see the changes to the readme for more info).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES (I believe the new timestamp will require them)

#### Includes new or updated dependencies?

NO
