### PR TITLE
Add 'Get It' links for Primo results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ custom hint metadata.
 - `EDS_PROFILE_URI`: URI for the EDS UI (not API) profile
 - `EDS_URL`: the root EDS API URL
 - `EDS_USER_ID`: your EDS API user id
+- `EXL_INST_ID`: your Ex Libris institution ID.
 - `GOOGLE_API_KEY`: your Google Custom Search API key
 - `GOOGLE_CUSTOM_SEARCH_ID`: your Google Custom Search engine ID
 - `MAX_AUTHORS`: the maximum number of authors displayed in any record.

--- a/app/models/normalize_primo_articles.rb
+++ b/app/models/normalize_primo_articles.rb
@@ -8,6 +8,7 @@ class NormalizePrimoArticles
   def article_metadata(result)
     result.citation = numbering || chapter_numbering
     result.in = journal_title || book_title
+    result.openurl = openurl
     result
   end
 
@@ -34,5 +35,10 @@ class NormalizePrimoArticles
     return unless @record['pnx']['addata']['btitle']
     return unless @record['pnx']['addata']['date'] && @record['pnx']['addata']['pages']
     "#{@record['pnx']['addata']['date'].join('')}, pp. #{@record['pnx']['addata']['pages'].join('')}"
+  end
+
+  def openurl
+    return unless @record['delivery']['almaOpenurl']
+    @record['delivery']['almaOpenurl']
   end
 end

--- a/app/models/normalize_primo_books.rb
+++ b/app/models/normalize_primo_books.rb
@@ -10,6 +10,7 @@ class NormalizePrimoBooks
     result.publisher = publisher
     result.location = location
     result.subjects = subjects
+    result.openurl = openurl
     result
   end
 
@@ -45,6 +46,16 @@ class NormalizePrimoBooks
     @record['delivery']['holding'].map do |holding|
       return unless holding['mainLocation'] && holding['subLocation'] && holding['callNumber']
       ["#{holding['mainLocation']} #{holding['subLocation']}", holding['callNumber']]
+    end
+  end
+
+  def openurl
+    return unless @record['pnx']['display']['mms']
+    return unless @record['delivery']['deliveryCategory']
+    mms_id = @record['pnx']['display']['mms'].first
+    if @record['delivery']['deliveryCategory'].include?('Alma-E')
+      [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=', ENV['EXL_INST_ID'],
+      '&vid=', ENV['PRIMO_VID'], '&rft.mms_id=', mms_id].join('')
     end
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -23,7 +23,13 @@ class Result
       best_link(marc_856, 'marc_856')
     elsif fulltext_links && relevant_fulltext_links?
       best_link(fulltext_links_picker(true), 'eds fulltext')
+    elsif Flipflop.enabled? :primo_search
+      alma_link_resolver_url
     end
+  end
+
+  def alma_link_resolver_url
+    self.openurl
   end
 
   # URL to use for check_sfx button in the UI

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,6 +29,7 @@ Rails.application.configure do
   ENV['ALEPH_HINT_SOURCE'] = 'https://fake.example.com/s/fake/getserial_mini.xml?dl=1'
   ENV['FULL_RECORD_TOGGLE_BUTTON'] = 'true'
 
+  ENV['EXL_INST_ID'] = '01MIT_INST'
   ENV['PRIMO_SEARCH'] = 'true'
   ENV['PRIMO_SEARCH_API_URL'] = 'https://another_fake_server.example.com'
   ENV['PRIMO_SEARCH_API_KEY'] = 'FAKE_PRIMO_SEARCH_API_KEY'

--- a/test/models/normalize_primo_articles_test.rb
+++ b/test/models/normalize_primo_articles_test.rb
@@ -23,8 +23,8 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
 
   def missing_fields_articles
     # Note that this cassette has been manually edited to remove the 
-    # following fields from the first result: jtitle, volume, issue.
-    # And the following field from the second result: issue.
+    # following fields from the first result: jtitle, volume, issue, 
+    # almaOpenurl; and the following field from the second result: issue.
     VCR.use_cassette('missing fields primo articles', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
@@ -87,5 +87,16 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
     result = missing_fields_articles['results'].second
     assert_nothing_raised { result.citation }
     assert_equal 'volume 2012', result.citation
+  end
+
+  test 'constructs full-text links as expected' do
+    result = popcorn_articles['results'].first
+    assert_equal 'https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit',
+                  result.openurl
+  end
+
+  test 'handles results without full-text links' do
+    result = missing_fields_articles['results'].first
+    assert_nothing_raised { result.openurl }
   end
 end

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -93,4 +93,16 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     assert_nothing_raised { result.location }
     assert_nil result.location
   end
+
+  test 'constructs full-text links as expected' do
+    result = popcorn_books['results'].first
+    assert_equal "https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&rft.mms_id=990022823660206761",
+                 result.openurl
+  end
+
+  test 'handles results without full-text links' do
+    result = physical_book['results'].first
+    assert_nothing_raised { result.url }
+    assert_nil result.openurl
+  end
 end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -244,4 +244,15 @@ class ResultTest < ActiveSupport::TestCase
     assert_nil(r.getit_url)
     assert_equal('http://sfx.mit.edu/example', r.check_sfx_url)
   end
+
+  test 'Primo full-text URLs map correctly to getit_url' do
+    r = Result.new('title', 'http://example.com')
+    r.openurl = 'https://mit.primo.exlibrisgroup.com/discovery/openurl?example'
+    assert_equal r.getit_url, r.openurl
+  end
+
+  test 'Primo records without full-text URLs do not a have getit_url' do
+    r = Result.new('title', 'http://example.com')
+    assert_nil r.getit_url
+  end
 end

--- a/test/vcr_cassettes/missing_fields_primo_articles.yml
+++ b/test/vcr_cassettes/missing_fields_primo_articles.yml
@@ -144,8 +144,7 @@ http_interactions:
               "physicalItemTextCodes" : "",
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit"
+              "holding" : [ ]
             },
             "context" : "PC",
             "adaptor" : "Primo Central",


### PR DESCRIPTION
#### Why these changes are being introduced:

If a resource is available online, a user should be able to access
the full text from the Bento record.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2008

#### How this addresses that need:

This renders full-text/Get It links when available for Alma and CDI
results. For Alma results, we construct an Alma link resolver URL if the
resource is tagged as 'Alma-E'. CDI results already have these URLs in
the API response, so we can pull them directly from the JSON.

#### Side effects of this change:

Because some Alma records are not yet linked to their eresources, certain
'Get It' links will not be proxied. This is a known issue and is being
actively investigated.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
