### PR TITLE
IMP-1776 Render Primo search results in Bento view

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -63,7 +63,7 @@ class SearchController < ApplicationController
     elsif params[:target] == 'articles' || params[:target] == 'books'
       search_eds(page, per_page)
     else
-      search_primo
+      search_primo(per_page)
     end
   end
 
@@ -84,8 +84,8 @@ class SearchController < ApplicationController
   end
 
   # Searches Primo
-  def search_primo
-    raw_results = SearchPrimo.new.search(strip_truncate_q, primo_scope)
+  def search_primo(per_page)
+    raw_results = SearchPrimo.new.search(strip_truncate_q, primo_scope, per_page)
     NormalizePrimo.new.to_result(raw_results, params[:target], strip_truncate_q)
   end
 

--- a/app/models/search_primo.rb
+++ b/app/models/search_primo.rb
@@ -18,9 +18,9 @@ class SearchPrimo
     @results = {}
   end
 
-  def search(term, scope)
+  def search(term, scope, per_page)
     result = @primo_http.headers(accept: 'application/json')
-                        .get(search_url(term, scope))
+                        .get(search_url(term, scope, per_page))
 
     raise "Primo Error Detected: #{result.status}" unless result.status == 200
 
@@ -36,9 +36,9 @@ class SearchPrimo
 
   # This is subject to change. Right now we are just using the required 
   # params and assuming that no operators are used.
-  def search_url(term, scope)
+  def search_url(term, scope, per_page)
     [PRIMO_SEARCH_API_URL, '/primo/v1/search?q=any,contains,', 
       clean_term(term), '&vid=', PRIMO_VID, '&tab=bento&scope=', scope,
-      '&apikey=', PRIMO_SEARCH_API_KEY].join('')
+      '&limit=', per_page, '&apikey=', PRIMO_SEARCH_API_KEY].join('')
   end
 end

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -7,9 +7,15 @@
     <span class="search-summary">Showing results for "<%= params[:q] %>" sorted by relevance</span>
     <span class="title">Found: </span>
 
-    <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="books">Books and media <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+    <% if Flipflop.enabled? :primo_search %>
+      <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="alma">Books+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
 
-    <a href="#box-articles_content" data-type="Jump to articles"><span class="results-summary-item" data-region="articles">Articles and journals <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+      <a href="#box-articles_content" data-type="Jump to articles"><span class="results-summary-item" data-region="cdi">Articles+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+    <% else %>
+      <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="books">Books and media <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+
+      <a href="#box-articles_content" data-type="Jump to articles"><span class="results-summary-item" data-region="articles">Articles and journals <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>      
+    <% end %>
 
     <a href="#box-aspace_content" data-type="Jump to distinctive collections"><span class="results-summary-item" data-region="timdex">Archives and manuscripts <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
 
@@ -24,9 +30,15 @@
 <div id="hint"></div>
 
 <div class="gridband layout-2c">
-  <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand search to libraries around the world</a>", advsearch: "<a href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand your search to libraries around the world</a> or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
+  <% if Flipflop.enabled? :primo_search %>
+    <%= render partial: "placeholders", locals: { heading: 'Books+', id: 'books_content', description: "MIT-owned books, ebooks, journals, databases, media, music and more. <a class='wc-link' href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand search to libraries around the world</a>", advsearch: "<a href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand your search to libraries around the world</a> or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
 
-  <%= render partial: "placeholders", locals: { heading: 'Articles and journals', id: 'articles_content', description: 'Articles from a variety of periodicals, including scholarly journals and magazines at MIT. <a href="https://libraries.mit.edu/search/">More search options</a>', advsearch: "...or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
+    <%= render partial: "placeholders", locals: { heading: 'Articles+', id: 'articles_content', description: 'Search a combined index of 100s of databases. <a href="https://libraries.mit.edu/search/">More options</a>', advsearch: "...or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
+  <% else %>
+    <%= render partial: "placeholders", locals: { heading: 'Books and media', id: 'books_content', description: "Books, ebooks, audio books, music, and videos at MIT. <a class='wc-link' href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand search to libraries around the world</a>", advsearch: "<a href='https://mit.on.worldcat.org/search?queryString=#{params[:q]}'>Expand your search to libraries around the world</a> or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
+
+    <%= render partial: "placeholders", locals: { heading: 'Articles and journals', id: 'articles_content', description: 'Articles from a variety of periodicals, including scholarly journals and magazines at MIT. <a href="https://libraries.mit.edu/search/">More search options</a>', advsearch: "...or try <a href='https://libraries.mit.edu/bartonplus-advanced'>advanced search</a>" } %>
+  <% end %>
 </div>
 
 <div class="gridband layout-2c">
@@ -40,9 +52,15 @@
 <%= render partial: "help" %>
 
 <script>
-  <%= render partial: "trigger_search", locals: { target: 'articles', id: 'articles_content'} %>
+  <% if Flipflop.enabled? :primo_search %>
+    <%= render partial: "trigger_search", locals: { target: 'cdi', id: 'articles_content'} %>
 
-  <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
+    <%= render partial: "trigger_search", locals: { target: 'alma', id: 'books_content'} %>
+  <% else %>
+    <%= render partial: "trigger_search", locals: { target: 'articles', id: 'articles_content'} %>
+
+    <%= render partial: "trigger_search", locals: { target: 'books', id: 'books_content'} %>
+  <% end %>
 
   <%= render partial: "trigger_search", locals: { target: 'google', id: 'website_content'} %>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -48,6 +48,6 @@ Flipflop.configure do
     description: 'Determines if links for renovation items should be enabled'
 
   feature :primo_search,
-    default: ENV['PRIMO_SEARCH'],
+    default: ActiveModel::Type::Boolean.new.cast(ENV.fetch('PRIMO_SEARCH')),
     description: 'Returns results from Primo Search API instead of EDS'
 end

--- a/test/models/normalize_primo_articles_test.rb
+++ b/test/models/normalize_primo_articles_test.rb
@@ -5,7 +5,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn primo articles',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
-                                         ENV['PRIMO_ARTICLE_SCOPE'])
+                                         ENV['PRIMO_ARTICLE_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_ARTICLE_SCOPE'], 
                                    'popcorn')
     end
@@ -15,7 +15,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
     VCR.use_cassette('primo chapter',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('"spider monkey optimization algorithm"',
-                                         ENV['PRIMO_ARTICLE_SCOPE'])
+                                         ENV['PRIMO_ARTICLE_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_ARTICLE_SCOPE'], 
                                    '"spider monkey optimization algorithm"')
     end
@@ -28,7 +28,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
     VCR.use_cassette('missing fields primo articles', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
-                                         ENV['PRIMO_ARTICLE_SCOPE'])
+                                         ENV['PRIMO_ARTICLE_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_ARTICLE_SCOPE'], 
                                    'popcorn')
     end
@@ -36,11 +36,11 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
 
   def missing_fields_chapter
     # Note that this cassette has been manually eduited to remove the 
-    # following fields from the first result: btitle, pages, date.
+    # following fields from the first result: btitle, pages.
     VCR.use_cassette('missing fields primo chapter',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('"spider monkey optimization algorithm"',
-                                         ENV['PRIMO_ARTICLE_SCOPE'])
+                                         ENV['PRIMO_ARTICLE_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_ARTICLE_SCOPE'], 
                                    '"spider monkey optimization algorithm"')
     end
@@ -91,7 +91,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
 
   test 'constructs full-text links as expected' do
     result = popcorn_articles['results'].first
-    assert_equal 'https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit',
+    assert_equal 'https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit',
                   result.openurl
   end
 

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -5,7 +5,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn primo books',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'], 
                                    'popcorn')
     end
@@ -18,7 +18,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('missing fields primo books', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'], 
                                    'popcorn')
     end
@@ -28,7 +28,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('physical book primo', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('Chʻomsŭkʻi, kkŭt ŏmnŭn tojŏn', 
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'], 
                                    'Chʻomsŭkʻi, kkŭt ŏmnŭn tojŏn')
     end
@@ -38,7 +38,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     VCR.use_cassette('local journal primo',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('Journal of heat transfer',
-                                          ENV['PRIMO_BOOK_SCOPE'])
+                                          ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'],
                                    'Journal of heat transfer')
     end

--- a/test/models/normalize_primo_test.rb
+++ b/test/models/normalize_primo_test.rb
@@ -5,7 +5,7 @@ class NormalizePrimoTest < ActiveSupport::TestCase
     VCR.use_cassette('popcorn primo',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcorn', 
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'], 
                                    'popcorn')
     end
@@ -13,12 +13,12 @@ class NormalizePrimoTest < ActiveSupport::TestCase
 
   def missing_fields
     # Note that this cassette has been manually edited to remove the 
-    # following fields from the result: creationdate, title, author, 
-    # contributor
+    # following fields from the result: creationdate, title, creator, 
+    # contributor, type, recordid
     VCR.use_cassette('missing fields primo', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('Chʻomsŭkʻi, kkŭt ŏmnŭn tojŏn', 
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'], 
                                    'Chʻomsŭkʻi, kkŭt ŏmnŭn tojŏn')
     end
@@ -28,7 +28,7 @@ class NormalizePrimoTest < ActiveSupport::TestCase
     VCR.use_cassette('no results primo',
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('popcornandorangejuice',
-                                         ENV['PRIMO_BOOK_SCOPE'])
+                                         ENV['PRIMO_BOOK_SCOPE'], 5)
       query = NormalizePrimo.new.to_result(raw_query, ENV['PRIMO_BOOK_SCOPE'],
                                            'popcornandorangejuice')
       assert_equal(0, query['total'])

--- a/test/vcr_cassettes/local_journal_primo.yml
+++ b/test/vcr_cassettes/local_journal_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,Journal%20of%20heat%20transfer&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Journal%20of%20heat%20transfer&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549997'
+      - '549993'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Tue, 11 May 2021 16:04:53 GMT
+      - Mon, 17 May 2021 15:06:23 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -49,15 +49,15 @@ http_interactions:
             "totalResultsPC" : -1,
             "total" : 89,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "creator" : [ "Heat", "Transfer" ],
             "contributor" : [ "Heat", "Transfer" ],
             "subject" : [ "Heat" ],
-            "title" : [ "Heat", "transfer", "Journal", "of heat", "heat", "journal" ],
-            "addtitle" : [ "journal", "of heat", "heat", "transfer", "Heat" ],
-            "termsUnion" : [ "Heat", "Transfer", "transfer", "Journal", "of heat", "heat", "journal" ]
+            "title" : [ "Journal", "of heat", "heat", "transfer", "journal" ],
+            "addtitle" : [ "Heat", "transfer" ],
+            "termsUnion" : [ "Heat", "Transfer", "Journal", "of heat", "heat", "transfer", "journal" ]
           },
           "docs" : [ {
             "context" : "L",
@@ -91,7 +91,7 @@ http_interactions:
                 "originalsourceid" : [ "000293592-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.32079008" ]
+                "score" : [ "0.31791705" ]
               },
               "addata" : {
                 "stitle" : [ "J. heat transfer" ],
@@ -303,7 +303,7 @@ http_interactions:
                 "originalsourceid" : [ "000281976-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0049785483" ]
+                "score" : [ "0.00488179" ]
               },
               "addata" : {
                 "stitle" : [ "Int. j. heat mass transfer" ],
@@ -515,7 +515,7 @@ http_interactions:
                 "originalsourceid" : [ "000368998-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.011723392" ]
+                "score" : [ "0.011505032" ]
               },
               "addata" : {
                 "stitle" : [ "J. thermophys. heat transf." ],
@@ -692,7 +692,7 @@ http_interactions:
                 "originalsourceid" : [ "001438833-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0031921514" ]
+                "score" : [ "0.0030544077" ]
               },
               "addata" : {
                 "date" : [ "1974 - 1982", "1974-1982" ],
@@ -931,7 +931,7 @@ http_interactions:
                 "originalsourceid" : [ "000300548-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0030415426" ]
+                "score" : [ "0.0029876889" ]
               },
               "addata" : {
                 "addtitle" : [ "Transactions of American Society of Mechanical Engineers", "Transactions of the ASME", "Transactions of the American Society of Mechanical Engineers" ],
@@ -1064,881 +1064,26 @@ http_interactions:
                 "callNumberBrowseField" : "LOCAL_CL_09X"
               }
             }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990002908100206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "eng" ],
-                "title" : [ "Progress in heat and mass transfer." ],
-                "subject" : [ "Heat -- Transmission", "Mass transfer" ],
-                "format" : [ "v. ill. 26 cm." ],
-                "identifier" : [ "$$CLC$$V   73091700;$$CISSN$$V0079-631X;$$COCLC$$V(OCoLC)01608191;$$COCLC$$V(OCoLC)00304740" ],
-                "creationdate" : [ "1969 - 197?" ],
-                "publisher" : [ "Oxford, New York, Pergamon Press.", "Ceased with vol. 8?" ],
-                "mms" : [ "990002908100206761" ],
-                "addtitle" : [ "International journal of heat and mass transfer.", "Heat transfer reviews." ],
-                "relation" : [ "$$Cother_relationship$$VInternational journal of heat and mass transfer$$QInternational journal of heat and mass transfer$$Z990002819760206761" ],
-                "place" : [ "Oxford, New York," ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "990002908100206761" ],
-                "recordid" : [ "alma990002908100206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "000290810-MIT01" ],
-                "sourcesystem" : [ "ILS" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0017861724" ]
-              },
-              "addata" : {
-                "stitle" : [ "Prog. heat mass transfer" ],
-                "date" : [ "1969 - 197?" ],
-                "issn" : [ "0079-631X" ],
-                "coden" : [ "PGHMB9" ],
-                "cop" : [ "Oxford" ],
-                "pub" : [ "Pergamon Press." ],
-                "oclcid" : [ "(mcm)290810", "(mcm)290810mit01", "mitb10290810", "(ocolc)1608191", "glis290810", "(ocolc)304740", "fax18854" ],
-                "lccn" : [ "73091700" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Progress in heat and mass transfer." ]
-              },
-              "sort" : {
-                "title" : [ "Progress in heat and mass transfer." ],
-                "creationdate" : [ "1969" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9003008525285283420" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.P964",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990002908100206761",
-                "holdId" : "2227934470006761",
-                "holKey" : "HoldingResultKey [mid=2227934470006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.P964]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              },
-              "holding" : [ {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.P964",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990002908100206761",
-                "holdId" : "2227934470006761",
-                "holKey" : "HoldingResultKey [mid=2227934470006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.P964]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              } ],
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P" ],
-              "serviceMode" : [ "ovp" ],
-              "availability" : [ "available_in_library" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "sharedDigitalCandidates" : null,
-              "GetIt1" : [ {
-                "category" : "Alma-P",
-                "links" : [ {
-                  "isLinktoOnline" : false,
-                  "getItTabText" : "service_getit",
-                  "adaptorid" : "ALMA_01",
-                  "ilsApiId" : "990002908100206761",
-                  "link" : "OVP",
-                  "inst4opac" : "01MIT_INST",
-                  "displayText" : null,
-                  "@id" : "_:0"
-                } ]
-              } ],
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:73091700&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "TJ260.P964",
-                "callNumberBrowseField" : "0"
-              },
-              "bibVirtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "tj000000000260.p000000000964",
-                "callNumberBrowseField" : "LOCAL_CL_09X"
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990003689520206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "eng" ],
-                "title" : [ "JSME international journal. Series II, Fluids engineering, heat transfer, power, combustion, thermophysical properties." ],
-                "subject" : [ "Mechanical engineering" ],
-                "format" : [ "5 v. : ill. ; 30 cm." ],
-                "identifier" : [ "$$CLC$$V   92642662 //r94;$$CISSN$$V0914-8817;$$COCLC$$V(OCoLC)17852357" ],
-                "creationdate" : [ "c1988-c1992" ],
-                "publisher" : [ "Tokyo, Japan : Japan Society of Mechanical Engineers", "Vol. 31, no. 1 (Feb. 1988)-v. 35, no. 4 (Nov. 1992)." ],
-                "mms" : [ "990003689520206761" ],
-                "dedupmemberids" : [ "9933109186606761" ],
-                "contributor" : [ "Nihon Kikai Gakkai.$$QNihon Kikai Gakkai." ],
-                "addtitle" : [ "Fluids engineering, heat transfer, power, combustion, thermophysical properties" ],
-                "frequency" : [ "Quarterly" ],
-                "genre" : [ "Periodicals." ],
-                "relation" : [ "$$Cearlier_title$$VJSME international journal$$QJSME international journal$$Z990003685960206761", "$$Clater_title$$VJSME international journal.  Series B, Fluids and thermal engineering$$QJSME international journal.  Series B, Fluids and thermal engineering$$Z990006499070206761" ],
-                "place" : [ "Tokyo, Japan :" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "990003689520206761" ],
-                "recordid" : [ "alma990003689520206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "000368952-MIT01" ],
-                "sourcesystem" : [ "ILS" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0014547773" ]
-              },
-              "addata" : {
-                "stitle" : [ "JSME int. j., Ser. 2 Fluids eng. heat transf. power combust. thermophys. prop." ],
-                "addtitle" : [ "Fluids engineering, heat transfer, power, combustion, thermophysical properties" ],
-                "date" : [ "1988 - 1992", "c1988-c1992" ],
-                "issn" : [ "0914-8817" ],
-                "coden" : [ "JSFPET" ],
-                "cop" : [ "Tokyo, Japan" ],
-                "pub" : [ "Japan Society of Mechanical Engineers" ],
-                "oclcid" : [ "(mcm)368952", "(mcm)368952mit01", "mitb10368952", "(sfx)954928596043", "(ocolc)17852357", "glis368952" ],
-                "lccn" : [ "92642662 //r94", "sn 88013883" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "JSME international journal. Series II, Fluids engineering, heat transfer, power, combustion, thermophysical properties." ]
-              },
-              "sort" : {
-                "title" : [ "JSME international journal. Series II, Fluids engineering, heat transfer, power, combustion, thermophysical properties." ],
-                "author" : [ "Nihon Kikai Gakkai." ],
-                "creationdate" : [ "1988" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9085386931780974532" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Journal Collection (LSA4)",
-                "subLocationCode" : "LSA4",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ.J892",
-                "callNumberType" : "7",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990003689520206761",
-                "holdId" : "2262878950006761",
-                "holKey" : "HoldingResultKey [mid=2262878950006761, libraryId=161682860006761, locationCode=LSA4, callNumber=TJ.J892]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              },
-              "holding" : [ {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Journal Collection (LSA4)",
-                "subLocationCode" : "LSA4",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ.J892",
-                "callNumberType" : "7",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990003689520206761",
-                "holdId" : "2262878950006761",
-                "holKey" : "HoldingResultKey [mid=2262878950006761, libraryId=161682860006761, locationCode=LSA4, callNumber=TJ.J892]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              } ],
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
-              "serviceMode" : [ "ovp", "Viewit" ],
-              "availability" : [ "available_in_library", "not_restricted" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "sharedDigitalCandidates" : null,
-              "GetIt1" : [ {
-                "category" : "Alma-P",
-                "links" : [ {
-                  "isLinktoOnline" : false,
-                  "getItTabText" : "service_getit",
-                  "adaptorid" : "ALMA_01",
-                  "ilsApiId" : "990003689520206761",
-                  "link" : "OVP",
-                  "inst4opac" : "01MIT_INST",
-                  "displayText" : null,
-                  "@id" : "_:0"
-                } ]
-              } ],
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:92642662&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              }, {
-                "@id" : ":_1",
-                "linkType" : "linktorsrc",
-                "linkURL" : "http://catalog.hathitrust.org/api/volumes/oclc/17852357.html",
-                "displayLabel" : "Hathi Trust"
-              }, {
-                "@id" : ":_2",
-                "linkType" : "linktorsrc",
-                "linkURL" : "https://sfx.mit.edu/sfx%5Flocal?rft.object%5Fid=954928596043&url%5Fver=Z39.88-2004&ctx%5Fver=Z39.88-2004&ctx%5Fenc=info:ofi/enc:UTF-8&rfr%5Fid=info:sid/sfxit.com:opac%5F856&url%5Fctx%5Ffmt=info:ofi/fmt:kev:mtx:ctx&sfx.ignore%5Fdate%5Fthreshold=1&svc%5Fval%5Ffmt=info:ofi/fmt:kev:mtx:sch%5Fsvc&",
-                "displayLabel" : "$$Elinktorsrc"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "TJ.J892",
-                "callNumberBrowseField" : "7"
-              },
-              "bibVirtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "tj 1ǂ j752",
-                "callNumberBrowseField" : "LOC_CL"
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990005199140206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "book" ],
-                "language" : [ "eng" ],
-                "title" : [ "Heat transfer reviews, 1976-1986 " ],
-                "subject" : [ "Heat -- Transmission" ],
-                "format" : [ "vii, 681 p. ; 26 cm." ],
-                "identifier" : [ "$$CLC$$V   89021469;$$CISBN$$V0471524581;$$COCLC$$V(OCoLC)20853758" ],
-                "creationdate" : [ "c1990" ],
-                "publisher" : [ "New York : Wiley" ],
-                "mms" : [ "990005199140206761" ],
-                "contributor" : [ "Eckert, E. R. G. (Ernst Rudolf Georg), 1904-2004.$$QEckert, E. R. G." ],
-                "addtitle" : [ "International journal of heat and mass transfer." ],
-                "place" : [ "New York :" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "990005199140206761" ],
-                "recordid" : [ "alma990005199140206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "000519914-MIT01" ],
-                "sourcesystem" : [ "ILS" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0014270761" ]
-              },
-              "addata" : {
-                "aulast" : [ "Eckert" ],
-                "aufirst" : [ "E. R. G." ],
-                "auinit" : [ "E" ],
-                "addau" : [ "Eckert, E. R. G. (Ernst Rudolf Georg)" ],
-                "date" : [ "1990", "c1990" ],
-                "isbn" : [ "0471524581" ],
-                "notes" : [ "Includes bibliographical references." ],
-                "cop" : [ "New York" ],
-                "pub" : [ "Wiley" ],
-                "oclcid" : [ "(mcm)519914", "(mcm)519914mit01", "mitb10519914", "(ocolc)20853758", "glis519914" ],
-                "lccn" : [ "89021469" ],
-                "format" : [ "book" ],
-                "genre" : [ "book" ],
-                "ristype" : [ "BOOK" ],
-                "btitle" : [ "Heat transfer reviews, 1976-1986" ]
-              },
-              "sort" : {
-                "title" : [ "Heat transfer reviews, 1976-1986 / edited by E.R.G. Eckert ... [et al.]." ],
-                "author" : [ "Eckert, E. R. G. (Ernst Rudolf Georg), 1904-2004." ],
-                "creationdate" : [ "1990" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9021358273130691239" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.H3965 1990",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990005199140206761",
-                "holdId" : "2238640780006761",
-                "holKey" : "HoldingResultKey [mid=2238640780006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.H3965 1990]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              },
-              "holding" : [ {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.H3965 1990",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990005199140206761",
-                "holdId" : "2238640780006761",
-                "holKey" : "HoldingResultKey [mid=2238640780006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.H3965 1990]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              } ],
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
-              "serviceMode" : [ "ovp", "Viewit" ],
-              "availability" : [ "available_in_library", "not_restricted" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "sharedDigitalCandidates" : null,
-              "GetIt1" : [ {
-                "category" : "Alma-P",
-                "links" : [ {
-                  "isLinktoOnline" : false,
-                  "getItTabText" : "service_getit",
-                  "adaptorid" : "ALMA_01",
-                  "ilsApiId" : "990005199140206761",
-                  "link" : "OVP",
-                  "inst4opac" : "01MIT_INST",
-                  "displayText" : null,
-                  "@id" : "_:0"
-                } ]
-              } ],
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0471524581,OCLC:,LCCN:89021469&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              }, {
-                "@id" : ":_1",
-                "linkType" : "linktorsrc",
-                "linkURL" : "http://catalog.hathitrust.org/api/volumes/oclc/20853758.html",
-                "displayLabel" : "Hathi Trust"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "TJ260.H3965 1990",
-                "callNumberBrowseField" : "0"
-              },
-              "bibVirtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "tj\"260ǂ h3965 1990",
-                "callNumberBrowseField" : "LOC_CL"
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990000532160206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "book" ],
-                "language" : [ "eng" ],
-                "title" : [ "Developments in heat and mass transfer : Allan Ede memorial issue " ],
-                "subject" : [ "Heat -- Transmission", "Mass transfer" ],
-                "format" : [ "p. 1077-1216 : ill. ; 28 cm." ],
-                "identifier" : [ "$$CLC$$V   76025723;$$CISBN$$V0080212859;$$COCLC$$V(OCoLC)03320095" ],
-                "creationdate" : [ "1976" ],
-                "publisher" : [ "Oxford ; New York : Pergamon" ],
-                "mms" : [ "990000532160206761" ],
-                "contributor" : [ "Spalding, D. B. (Dudley Brian), 1923-$$QSpalding, D. B.", "Ede, A. J.$$QEde, A. J." ],
-                "addtitle" : [ "International journal of heat and mass transfer." ],
-                "place" : [ "Oxford ; New York :" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "990000532160206761" ],
-                "recordid" : [ "alma990000532160206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "000053216-MIT01" ],
-                "sourcesystem" : [ "ILS" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0013086726" ]
-              },
-              "addata" : {
-                "aulast" : [ "Spalding", "Ede" ],
-                "aufirst" : [ "D. B.", "A. J." ],
-                "auinit" : [ "D", "A" ],
-                "addau" : [ "Spalding, D. B. (Dudley Brian)", "Ede, A. J." ],
-                "date" : [ "1976" ],
-                "isbn" : [ "0080212859" ],
-                "notes" : [ "Includes bibliographies." ],
-                "cop" : [ "Oxford ;" ],
-                "pub" : [ "Pergamon" ],
-                "oclcid" : [ "(mcm)53216", "(mcm)53216mit01", "mitb10053216", "(ocolc)3320095", "glis53216" ],
-                "lccn" : [ "76025723" ],
-                "format" : [ "book" ],
-                "genre" : [ "book" ],
-                "ristype" : [ "BOOK" ],
-                "btitle" : [ "Developments in heat and mass transfer : Allan Ede memorial issue" ]
-              },
-              "sort" : {
-                "title" : [ "Developments in heat and mass transfer : Allan Ede memorial issue / coordinating editor, D. B. Spaulding." ],
-                "author" : [ "Spalding, D. B. (Dudley Brian), 1923-" ],
-                "creationdate" : [ "1976" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9034217328821763243" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.D4",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990000532160206761",
-                "holdId" : "2248827980006761",
-                "holKey" : "HoldingResultKey [mid=2248827980006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.D4]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              },
-              "holding" : [ {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Off Campus Collection",
-                "subLocationCode" : "OCC",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "TJ260.D4",
-                "callNumberType" : "0",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990000532160206761",
-                "holdId" : "2248827980006761",
-                "holKey" : "HoldingResultKey [mid=2248827980006761, libraryId=161682860006761, locationCode=OCC, callNumber=TJ260.D4]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              } ],
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P" ],
-              "serviceMode" : [ "ovp" ],
-              "availability" : [ "available_in_library" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "sharedDigitalCandidates" : null,
-              "GetIt1" : [ {
-                "category" : "Alma-P",
-                "links" : [ {
-                  "isLinktoOnline" : false,
-                  "getItTabText" : "service_getit",
-                  "adaptorid" : "ALMA_01",
-                  "ilsApiId" : "990000532160206761",
-                  "link" : "OVP",
-                  "inst4opac" : "01MIT_INST",
-                  "displayText" : null,
-                  "@id" : "_:0"
-                } ]
-              } ],
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0080212859,OCLC:,LCCN:76025723&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "TJ260.D4",
-                "callNumberBrowseField" : "0"
-              },
-              "bibVirtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "tj000000000260.d000000000004",
-                "callNumberBrowseField" : "LOCAL_CL_09X"
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990006341460206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "eng" ],
-                "title" : [ "Heat transfer research." ],
-                "subject" : [ "Heat -- Transmission" ],
-                "format" : [ "v. : ill. ; 26 cm." ],
-                "identifier" : [ "$$CLC$$V   92645910;$$CISSN$$V1064-2285;$$COCLC$$V(OCoLC)26275498" ],
-                "creationdate" : [ "c1992-" ],
-                "publisher" : [ "New York, N.Y. : Scripta Technica", "Vol. 24, no. 1 (1992)-" ],
-                "mms" : [ "990006341460206761" ],
-                "dedupmemberids" : [ "9933068134206761" ],
-                "contributor" : [ "Scripta Technica, inc.$$QScripta Technica, inc.", "American Society of Mechanical Engineers. Heat Transfer Division.$$QAmerican Society of Mechanical Engineers. Heat Transfer Division." ],
-                "edition" : [ "English ed." ],
-                "frequency" : [ "Eight no. a year" ],
-                "genre" : [ "Periodicals." ],
-                "relation" : [ "$$Clater_title$$VInternational journal of fluid mechanics research.$$Z990008918200206761", "$$Cform$$VHeat transfer research (Online)$$QHeat transfer research (Online)", "$$Cearlier_title$$VHeat transfer: Soviet research$$QHeat transfer: Soviet research$$Z990002906590206761" ],
-                "place" : [ "New York, N.Y. :" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "990006341460206761" ],
-                "recordid" : [ "alma990006341460206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "000634146-MIT01" ],
-                "sourcesystem" : [ "ILS" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "6.300541E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "Heat transf. res." ],
-                "date" : [ "1992", "c1992-" ],
-                "issn" : [ "1064-2285" ],
-                "coden" : [ "HTREE7" ],
-                "cop" : [ "New York, N.Y" ],
-                "pub" : [ "Scripta Technica" ],
-                "oclcid" : [ "(mcm)634146mit01", "(vera)530156", "(ocolc)26275498" ],
-                "lccn" : [ "92645910", "sn 92005130" ],
-                "edition" : [ "English ed." ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Heat transfer research." ]
-              },
-              "sort" : {
-                "title" : [ "Heat transfer research." ],
-                "author" : [ "Scripta Technica, inc." ],
-                "creationdate" : [ "1992" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9040881535041399509" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Journal Collection (LSA4)",
-                "subLocationCode" : "LSA4",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "QC.H442",
-                "callNumberType" : "7",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990006341460206761",
-                "holdId" : "2270107120006761",
-                "holKey" : "HoldingResultKey [mid=2270107120006761, libraryId=161682860006761, locationCode=LSA4, callNumber=QC.H442]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              },
-              "holding" : [ {
-                "isValidUser" : true,
-                "organization" : "01MIT_INST",
-                "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
-                "subLocation" : "Journal Collection (LSA4)",
-                "subLocationCode" : "LSA4",
-                "mainLocation" : "Library Storage Annex",
-                "callNumber" : "QC.H442",
-                "callNumberType" : "7",
-                "holdingURL" : "OVP",
-                "adaptorid" : "ALMA_01",
-                "ilsApiId" : "990006341460206761",
-                "holdId" : "2270107120006761",
-                "holKey" : "HoldingResultKey [mid=2270107120006761, libraryId=161682860006761, locationCode=LSA4, callNumber=QC.H442]",
-                "matchForHoldings" : [ {
-                  "matchOn" : "MainLocation",
-                  "holdingRecord" : "852##b"
-                } ],
-                "stackMapUrl" : "",
-                "relatedTitle" : null,
-                "yearFilter" : null,
-                "volumeFilter" : null,
-                "singleUnavailableItemProcessType" : null,
-                "boundWith" : false,
-                "@id" : "_:0"
-              } ],
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
-              "serviceMode" : [ "ovp", "Viewit" ],
-              "availability" : [ "available_in_library", "not_restricted" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "sharedDigitalCandidates" : null,
-              "GetIt1" : [ {
-                "category" : "Alma-P",
-                "links" : [ {
-                  "isLinktoOnline" : false,
-                  "getItTabText" : "service_getit",
-                  "adaptorid" : "ALMA_01",
-                  "ilsApiId" : "990006341460206761",
-                  "link" : "OVP",
-                  "inst4opac" : "01MIT_INST",
-                  "displayText" : null,
-                  "@id" : "_:0"
-                } ]
-              } ],
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:92645910&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              }, {
-                "@id" : ":_1",
-                "linkType" : "linktorsrc",
-                "linkURL" : "http://catalog.hathitrust.org/api/volumes/oclc/26275498.html",
-                "displayLabel" : "Hathi Trust"
-              }, {
-                "@id" : ":_2",
-                "linkType" : "linktorsrc",
-                "linkURL" : "http://dl.begellhouse.com/journals/46784ef93dddff27.html",
-                "displayLabel" : "$$Elinktorsrc"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "QC.H442",
-                "callNumberBrowseField" : "7"
-              },
-              "bibVirtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : true,
-                "callNumber" : "qc\"320ǂ h38",
-                "callNumberBrowseField" : "LOC_CL"
-              }
-            }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "1874",
-            "CALL_SOLR_GET_IDS_LIST" : "1076",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "7649",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "236",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "473",
+            "CALL_SOLR_GET_IDS_LIST" : "1727",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "3913",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "143",
             "RETRIVE_FROM_DB_COURSE_INFO" : "3",
-            "RETRIVE_FROM_DB_RECORDS" : "786",
-            "RETRIVE_FROM_DB_RELATIONS" : "124",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "5464",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "2185",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "3047",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "13670",
+            "RETRIVE_FROM_DB_RECORDS" : "52",
+            "RETRIVE_FROM_DB_RELATIONS" : "72",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "3216",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "697",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "333",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "6465",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 13771,
-            "COMBINED_SEARCH_TIME" : 13781,
+            "BUILD_COMBINED_RESULTS_MAP" : 6568,
+            "COMBINED_SEARCH_TIME" : 6573,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Tue, 11 May 2021 16:04:53 GMT
+  recorded_at: Mon, 17 May 2021 15:06:24 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo.yml
+++ b/test/vcr_cassettes/missing_fields_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549960'
+      - '549998'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -35,9 +35,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '7908'
+      - '7959'
       Date:
-      - Thu, 29 Apr 2021 19:24:17 GMT
+      - Mon, 17 May 2021 15:06:01 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -84,7 +84,7 @@ http_interactions:
                 "originalsourceid" : [ "001349272-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.020787643" ]
+                "score" : [ "0.020869972" ]
               },
               "addata" : {
                 "aulast" : [ "Barsky" ],
@@ -189,6 +189,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -225,24 +226,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "28",
-            "CALL_SOLR_GET_IDS_LIST" : "436",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "375",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "8",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "3",
-            "RETRIVE_FROM_DB_RECORDS" : "14",
-            "RETRIVE_FROM_DB_RELATIONS" : "1",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "324",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "51",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "41",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "892",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "280",
+            "CALL_SOLR_GET_IDS_LIST" : "2693",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "396",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "147",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "39",
+            "RETRIVE_FROM_DB_RECORDS" : "74",
+            "RETRIVE_FROM_DB_RELATIONS" : "17",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "197",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "199",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "125",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "3511",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 958,
-            "COMBINED_SEARCH_TIME" : 963,
+            "BUILD_COMBINED_RESULTS_MAP" : 5226,
+            "COMBINED_SEARCH_TIME" : 5229,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Thu, 29 Apr 2021 19:24:17 GMT
+  recorded_at: Mon, 17 May 2021 15:06:01 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_articles.yml
+++ b/test/vcr_cassettes/missing_fields_primo_articles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549991'
+      - '549997'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Fri, 30 Apr 2021 20:41:34 GMT
+      - Mon, 17 May 2021 15:06:13 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,10 +46,10 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 132106,
-            "total" : 132106,
+            "totalResultsPC" : 132266,
+            "total" : 132266,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "snippet" : [ "popcorn" ],
@@ -59,73 +59,73 @@ http_interactions:
           "docs" : [ {
             "pnx" : {
               "sort" : {
-                "title" : [ "Popcorn" ],
-                "creationdate" : [ "201611" ]
+                "creationdate" : [ "201611" ],
+                "title" : [ "Popcorn" ]
               },
               "control" : {
                 "recordid" : [ "cdi_crossref_primary_10_1088_2058_7058_29_11_46" ],
                 "sourcerecordid" : [ "10_1088_2058_7058_29_11_46" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c790-4ffb71fa678ae1427e5c8fc4dc8faddf186b598d2c7bf03781c03b21824f685e3" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9j8tKBDEQRQtRtB39Af8hdlWelaUMvmBAF7MP6XQKFLWHZOXfO43i5ly4i8u5ADeEt4TMo0bHKhwx6jgSjdafwPBfnsKA0RnFjt0FXPb-jkjeshvg_HU5lKV9XcGZ5I9er_9yA_uH-_32Se1eHp-3dztVQkRlRaZAkn3gXMnqUF1hKXY-Ms-zEPvJRZ51CZOgCUwFzaSJtRXPrpoN6N_Z0pbeW5V0aG-fuX0nwrQ-Sat0WqWTjokoWW9-AAIdOhI" ],
+                "addsrcrecordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "crossref" ],
-                "score" : [ "0.021826506" ]
+                "score" : [ "0.021811698" ]
+              },
+              "addata" : {
+                "issn" : [ "0953-8585" ],
+                "genre" : [ "article" ],
+                "atitle" : [ "Popcorn" ],
+                "date" : [ "2016-11" ],
+                "risdate" : [ "2016" ],
+                "spage" : [ "42" ],
+                "epage" : [ "42" ],
+                "pages" : [ "42-42" ],
+                "eissn" : [ "2058-7058" ],
+                "ristype" : [ "JOUR" ],
+                "doi" : [ "10.1088/2058-7058/29/11/46" ],
+                "format" : [ "journal" ]
               },
               "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "title" : [ "Popcorn", "Physics world" ],
                 "creationdate" : [ "2016" ],
-                "recordid" : [ "eNo9j8tKBDEQRQtRtB39Af8hdlWelaUMvmBAF7MP6XQKFLWHZOXfO43i5ly4i8u5ADeEt4TMo0bHKhwx6jgSjdafwPBfnsKA0RnFjt0FXPb-jkjeshvg_HU5lKV9XcGZ5I9er_9yA_uH-_32Se1eHp-3dztVQkRlRaZAkn3gXMnqUF1hKXY-Ms-zEPvJRZ51CZOgCUwFzaSJtRXPrpoN6N_Z0pbeW5V0aG-fuX0nwrQ-Sat0WqWTjokoWW9-AAIdOhI" ],
+                "title" : [ "Popcorn", "Physics world" ],
+                "recordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
                 "recordtype" : [ "article" ],
-                "rsrctype" : [ "article" ],
+                "scope" : [ "AAYXX", "CITATION" ],
                 "issn" : [ "0953-8585", "2058-7058" ],
                 "fulltext" : [ "true" ],
+                "rsrctype" : [ "article" ],
                 "startdate" : [ "201611" ],
-                "enddate" : [ "201611" ],
-                "scope" : [ "CITATION", "AAYXX" ]
+                "enddate" : [ "201611" ]
               },
               "display" : {
                 "title" : [ "Popcorn" ],
-                "language" : [ "eng" ],
-                "source" : [ "Alma/SFX Local Collection" ],
                 "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
-                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
                 "type" : [ "article" ],
+                "source" : [ "Alma/SFX Local Collection" ],
+                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
+                "language" : [ "eng" ],
                 "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
-              "addata" : {
-                "format" : [ "journal" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0953-8585" ],
-                "pages" : [ "42-42" ],
-                "eissn" : [ "2058-7058" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1088/2058-7058/29/11/46" ],
-                "atitle" : [ "Popcorn" ],
-                "date" : [ "2016-11" ],
-                "risdate" : [ "2016" ],
-                "spage" : [ "42" ],
-                "epage" : [ "42" ]
-              },
               "facets" : {
                 "creationdate" : [ "2016" ],
+                "rsrctype" : [ "articles" ],
                 "language" : [ "eng" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c790-4ffb71fa678ae1427e5c8fc4dc8faddf186b598d2c7bf03781c03b21824f685e3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Physics world" ]
               }
@@ -159,79 +159,29 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Baryonic popcorn" ],
                 "creationdate" : [ "201211" ],
+                "title" : [ "Baryonic popcorn" ],
                 "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ]
               },
               "control" : {
                 "recordid" : [ "cdi_crossref_primary_10_1007_JHEP11_2012_047" ],
                 "sourcerecordid" : [ "2398248625" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpNjz1PwzAQhi0EEqUgsbEiscAQeuePOB6hKhRUCQaYrTg5o1YQB5sO_Pu6pAKme6V77uNh7AzhGgH05HE-e0a85ID8CqTeYyMEbopKarP_Lx-yo5RWAKjQwIid3tbxO3TL5rwPfRNid8wOfP2e6GRXx-z1bvYynReLp_uH6c2iQKEqXZi29kpgKR2RB1VRq8gZjs7ItjayBu2JK1U6jlxIqZByg6rSee6MQRJjdjHs7WP4XFP6squwjl0-abkwFZdVyVWmJgPVxJBSJG_7uPzIL1sEu9W2g7bdatus_TeRMtm9Ufyd-EFQoIBdRKtAo9gAAc1WHw" ],
+                "addsrcrecordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2398248625" ],
-                "score" : [ "0.020147637" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
-                "creationdate" : [ "2012" ],
-                "recordid" : [ "eNpNjz1PwzAQhi0EEqUgsbEiscAQeuePOB6hKhRUCQaYrTg5o1YQB5sO_Pu6pAKme6V77uNh7AzhGgH05HE-e0a85ID8CqTeYyMEbopKarP_Lx-yo5RWAKjQwIid3tbxO3TL5rwPfRNid8wOfP2e6GRXx-z1bvYynReLp_uH6c2iQKEqXZi29kpgKR2RB1VRq8gZjs7ItjayBu2JK1U6jlxIqZByg6rSee6MQRJjdjHs7WP4XFP6squwjl0-abkwFZdVyVWmJgPVxJBSJG_7uPzIL1sEu9W2g7bdatus_TeRMtm9Ufyd-EFQoIBdRKtAo9gAAc1WHw" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
-                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "issn" : [ "1029-8479", "1029-8479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "J. High Energ. Phys" ],
-                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
-                "startdate" : [ "201211" ],
-                "enddate" : [ "201211" ],
-                "scope" : [ "CITATION", "AAYXX", "AZQEC", "PQEST", "ARAPS", "P62", "BENPR", "DWQXO", "P5Z", "PIMPY", "HCIFZ", "8FE", "ABUWG", "BGLVJ", "8FG", "PQQKQ", "PQUKI" ]
-              },
-              "display" : {
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "title" : [ "Baryonic popcorn" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
-                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
-                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
-                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
-                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.020141866" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
+                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "issn" : [ "1029-8479" ],
+                "oa" : [ "free_for_read" ],
                 "jtitle" : [ "The journal of high energy physics" ],
                 "genre" : [ "article" ],
-                "issn" : [ "1029-8479" ],
-                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "pages" : [ "1-85" ],
-                "eissn" : [ "1029-8479" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Berlin/Heidelberg" ],
-                "pub" : [ "Springer-Verlag" ],
-                "doi" : [ "10.1007/JHEP11(2012)047" ],
                 "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
                 "atitle" : [ "Baryonic popcorn" ],
                 "stitle" : [ "J. High Energ. Phys" ],
@@ -240,18 +190,68 @@ http_interactions:
                 "volume" : [ "2012" ],
                 "spage" : [ "1" ],
                 "epage" : [ "85" ],
-                "oa" : [ "free_for_read" ]
+                "pages" : [ "1-85" ],
+                "eissn" : [ "1029-8479" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Berlin/Heidelberg" ],
+                "pub" : [ "Springer-Verlag" ],
+                "doi" : [ "10.1007/JHEP11(2012)047" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2012" ],
+                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
+                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
+                "recordtype" : [ "article" ],
+                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
+                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ],
+                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "issn" : [ "1029-8479", "1029-8479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "J. High Energ. Phys" ],
+                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "201211" ],
+                "enddate" : [ "201211" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
+              },
+              "display" : {
+                "title" : [ "Baryonic popcorn" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
+                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
+                "type" : [ "article" ],
+                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
+                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
+                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "language" : [ "eng" ],
+                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
+                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ],
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2012" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "Solitons Monopoles and Instantons", "AdS-CFT Correspondence", "Quantum Physics", "Quantum Field Theories, String Theory", "Classical and Quantum Gravitation, Relativity Theory", "Physics", "Phase Diagram of QCD", "Elementary Particles, Quantum Field Theory", "Flavor (particle physics)", "Lattices", "Chains", "Phase transitions", "Density", "Instantons", "Baryons", "Multilayers", "Gauge theory", "Ferromagnetism", "Configurations", "Nuclear matter", "Crystal structure", "Branes", "Solid phases" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "CrossRef", "ProQuest Central Essentials", "ProQuest One Academic Eastern Edition", "Advanced Technologies & Aerospace Collection", "ProQuest Advanced Technologies & Aerospace Collection", "ProQuest Central", "ProQuest Central Korea", "Advanced Technologies & Aerospace Database", "Publicly Available Content Database", "SciTech Premium Collection", "ProQuest SciTech Collection", "ProQuest Central (Alumni Edition)", "Technology Collection", "ProQuest Technology Collection", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
+                "collection" : [ "CrossRef", "ProQuest SciTech Collection", "ProQuest Technology Collection", "ProQuest Central (Alumni Edition)", "Advanced Technologies & Aerospace Collection", "ProQuest Central Essentials", "ProQuest Central", "Technology Collection", "ProQuest Central Korea", "SciTech Premium Collection", "Advanced Technologies & Aerospace Database", "ProQuest Advanced Technologies & Aerospace Collection", "Publicly Available Content Database", "ProQuest One Academic Eastern Edition", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "The journal of high energy physics" ]
               }
@@ -271,14 +271,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
-                "citedby" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ]
+                "citing" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
+                "citedby" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ]
               },
               "timesCited" : { }
             },
@@ -286,81 +286,30 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "creationdate" : [ "20200717" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ]
               },
               "control" : {
                 "recordid" : [ "cdi_proquest_miscellaneous_2407314819" ],
                 "sourcerecordid" : [ "2424628284" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqF0UFv0zAUB3ALgdgYXDkiS1yGRIv97MTJcUSUVprUHXaPHOeZZkrtYjtMvfER-Iz7JHNpGRIX5IOtp5__etKfkLeczTlj8MnsNmYODBhjnJfPyDmXop6pUvLnp7cEUZyRVzHeZVMxxV-SMwGyqIoCzsn92tG0QbrwYavT4B319vfgxu-MD44uRv3DB-0ShY_i4eevz1PSDvsskV42S9Gs81mKD3Rw9Mpg0mOPm32PmTbeJT24wX2jK5cwxITjqANdGYyvyQurx4hvTvcFuV18uW2Ws-v111VzdT0zgpV81hWoe8sBFbO1qUwpwNpeQdVpo5QBMJ3WFdpSsRoKJnvZIyuE7aSSnRHiglweY3fBf58wpnY7RHNYw6GfYguSKcFlxetM3_9D7_wUXF4uK5AlVFDJrOZHZYKPMaBtd2HY6rBvOWsPjbSHRtqnRvKHd6fYqdti_8T_VJBBfQT3w4j7_8S1zc2y-Rv-CBm1mHs" ],
+                "addsrcrecordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2424628284" ],
-                "score" : [ "0.01912676" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
-                "creationdate" : [ "2020" ],
-                "recordid" : [ "eNqF0UFv0zAUB3ALgdgYXDkiS1yGRIv97MTJcUSUVprUHXaPHOeZZkrtYjtMvfER-Iz7JHNpGRIX5IOtp5__etKfkLeczTlj8MnsNmYODBhjnJfPyDmXop6pUvLnp7cEUZyRVzHeZVMxxV-SMwGyqIoCzsn92tG0QbrwYavT4B319vfgxu-MD44uRv3DB-0ShY_i4eevz1PSDvsskV42S9Gs81mKD3Rw9Mpg0mOPm32PmTbeJT24wX2jK5cwxITjqANdGYyvyQurx4hvTvcFuV18uW2Ws-v111VzdT0zgpV81hWoe8sBFbO1qUwpwNpeQdVpo5QBMJ3WFdpSsRoKJnvZIyuE7aSSnRHiglweY3fBf58wpnY7RHNYw6GfYguSKcFlxetM3_9D7_wUXF4uK5AlVFDJrOZHZYKPMaBtd2HY6rBvOWsPjbSHRtqnRvKHd6fYqdti_8T_VJBBfQT3w4j7_8S1zc2y-Rv-CBm1mHs" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
-                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "issn" : [ "1439-4235", "1439-7641" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Chemphyschem" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "startdate" : [ "20200717" ],
-                "enddate" : [ "20200717" ],
-                "scope" : [ "CVF", "NPM", "EIF", "CUY", "ECM", "CGR", "CITATION", "AAYXX", "K9.", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
-                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
-                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
-                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.019118225" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Chemphyschem" ],
-                "genre" : [ "article" ],
+                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
                 "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
                 "issn" : [ "1439-4235" ],
                 "addtitle" : [ "Chemphyschem" ],
-                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "pages" : [ "1531-1540" ],
-                "eissn" : [ "1439-7641" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Germany" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/cphc.202000116" ],
-                "tpages" : [ "10" ],
+                "jtitle" : [ "Chemphyschem" ],
+                "genre" : [ "article" ],
                 "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
                 "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "date" : [ "2020-07-17" ],
@@ -368,18 +317,69 @@ http_interactions:
                 "volume" : [ "21" ],
                 "issue" : [ "14" ],
                 "spage" : [ "1531" ],
-                "epage" : [ "1540" ]
+                "epage" : [ "1540" ],
+                "pages" : [ "1531-1540" ],
+                "eissn" : [ "1439-7641" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Germany" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/cphc.202000116" ],
+                "tpages" : [ "10" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2020" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
+                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ],
+                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
+                "issn" : [ "1439-4235", "1439-7641" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Chemphyschem" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20200717" ],
+                "enddate" : [ "20200717" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
+              },
+              "display" : {
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
+                "type" : [ "article" ],
+                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
+                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
+                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2020" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "non-equilibrium processes", "interstellar synthesis", "IR spectroscopy", "mass spectroscopy", "complex organic molecules", "Acetaldehyde - chemistry", "Cold Temperature", "Flavoring Agents - chemical synthesis", "Ultraviolet Rays", "Models, Chemical", "Free Radicals - chemistry", "Deuterium - chemistry", "Diacetyl - chemical synthesis", "Acetaldehyde - radiation effects", "Extraterrestrial Environment - chemistry", "Deep space", "Molecular structure", "Molecular clouds", "Galactic cosmic rays", "Substitution reactions", "Amino acids", "Ice", "Aldehydes", "Cosmic rays", "Acetaldehyde", "Complexity", "Organic chemistry", "Ionizing radiation", "Meteorites", "Star formation", "Photoionization", "Interstellar chemistry", "Astrochemistry", "Chemical synthesis", "Interstellar matter", "Index Medicus" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "MEDLINE (Ovid)", "PubMed", "MEDLINE", "MEDLINE", "MEDLINE", "Medline", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
+                "collection" : [ "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Chemphyschem" ]
               }
@@ -399,13 +399,13 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "citing" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "citedby" : [ ]
               },
               "timesCited" : { }
@@ -414,78 +414,29 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "creationdate" : [ "20180105" ],
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ]
               },
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A521493458" ],
                 "sourcerecordid" : [ "A521493458" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqFkM9OwzAMxisEEtPYlXNeoCNJ03_cxrTBpA2mAecqTZ0R1CZV0grtxoE34A15EjINbUfsgy3b3yf5FwTXBI8JxvSGg27GFJMUE0LwWTAgCWFhkjF8fuwjehmMnHvHPlhOcBQNgq-1aYWxGi20a5WFCq2NNb1DKy6sEVDXfc0tmnJbGn2LNrxV_qSXUuktmvPSKsE7ZTSS1jRoowQgriu06ByatG39t3VIabRU3Zvqm5_P7-e-lr1Fd7zrwCpwV8GF5LWD0V8dBq_z2cv0IVw-3S-mk2VIGM1wyGSZR4IlUEJegohyhllVlSlQKZNY-i9plcURSyFPBZC4lAwAQ55QGjMgNBoG44PvltdQKC1NZ7nwWUGjhNEglZ9PYkpYHrE4Owk8C-csyKK1quF2VxBc7LkXe-7FkbsX5AfBh3fa_XNdTGaPq5P2FwvRiaY" ],
+                "addsrcrecordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A521493458" ],
-                "score" : [ "0.018666698" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
-                "creationdate" : [ "2018" ],
-                "recordid" : [ "eNqFkM9OwzAMxisEEtPYlXNeoCNJ03_cxrTBpA2mAecqTZ0R1CZV0grtxoE34A15EjINbUfsgy3b3yf5FwTXBI8JxvSGg27GFJMUE0LwWTAgCWFhkjF8fuwjehmMnHvHPlhOcBQNgq-1aYWxGi20a5WFCq2NNb1DKy6sEVDXfc0tmnJbGn2LNrxV_qSXUuktmvPSKsE7ZTSS1jRoowQgriu06ByatG39t3VIabRU3Zvqm5_P7-e-lr1Fd7zrwCpwV8GF5LWD0V8dBq_z2cv0IVw-3S-mk2VIGM1wyGSZR4IlUEJegohyhllVlSlQKZNY-i9plcURSyFPBZC4lAwAQ55QGjMgNBoG44PvltdQKC1NZ7nwWUGjhNEglZ9PYkpYHrE4Owk8C-csyKK1quF2VxBc7LkXe-7FkbsX5AfBh3fa_XNdTGaPq5P2FwvRiaY" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
-                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "issn" : [ "1614-6832", "1614-6840" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "startdate" : [ "20180105" ],
-                "enddate" : [ "20180105" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "publisher" : [ "Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
-                "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
-                "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
-                "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.018662874" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Advanced energy materials" ],
-                "genre" : [ "article" ],
+                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
                 "issn" : [ "1614-6832" ],
-                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "pages" : [ "1701110-n/a" ],
-                "eissn" : [ "1614-6840" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/aenm.201701110" ],
-                "tpages" : [ "8" ],
+                "jtitle" : [ "Advanced energy materials" ],
+                "genre" : [ "article" ],
                 "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
                 "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "date" : [ "2018-01-05" ],
@@ -493,18 +444,67 @@ http_interactions:
                 "volume" : [ "8" ],
                 "issue" : [ "1" ],
                 "spage" : [ "1701110" ],
-                "epage" : [ "n/a" ]
+                "epage" : [ "n/a" ],
+                "pages" : [ "1701110-n/a" ],
+                "eissn" : [ "1614-6840" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/aenm.201701110" ],
+                "tpages" : [ "8" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2018" ],
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
+                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "recordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
+                "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "issn" : [ "1614-6832", "1614-6840" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20180105" ],
+                "enddate" : [ "20180105" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+              },
+              "display" : {
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "publisher" : [ "Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
+                "type" : [ "article" ],
+                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
+                "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
+                "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2018" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "biomass‐derived porous carbons", "lithium–sulfur batteries", "cathodes", "nanostructures", "metal–carbon composites", "Sulfur compounds", "Electrical conductivity", "Electrochemistry", "Porosity", "Batteries", "Sulfur", "Electric properties" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Advanced energy materials" ]
               }
@@ -524,14 +524,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
-                "citedby" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ]
+                "citing" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
+                "citedby" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ]
               },
               "timesCited" : { }
             },
@@ -539,95 +539,95 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "creationdate" : [ "20140815" ],
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "author" : [ "Moreta, Cristina ; Tena, María Teresa" ]
               },
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A375736650" ],
                 "sourcerecordid" : [ "A375736650" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3503-5cd834cab94a649b1fc87b95fb5aa6d48e70dc72d08a7130176da5eab6da26f63" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9UbuO1TAQTQESy4U_oHBDtwl2Hk5ug7RantJKNFBbE3uc67uOnbUTRLr9B76Phi_B2ay2RC5mdHzOmVeWvWG0YJTxd-dCnoIfoSgpqwvKC8q6Z9kFpSXLj7ytXmQvYzxTylralhfZnw84YxiNg9l4R7wmEwZtFx82CBUBe7taAtKoSIwj0gd3SSY_bQkBp57yHoZIetQ-4AMOOhknvr81biD9SrSXS0yOi50DRL8kTvTWqL_3v625W4wi-Cv9yK2RS_II7cPMfggwndYH47sFVFgmbzGfzYhbz9qa4TSTEWIkcUI5JxHOYX2VPddgI75-jIfsx6eP36-_5DffPn-9vrrJZdXQKm-k6qpaQn-sgdfHnmnZtf2x0X0DwFXdYUuVbEtFO2hZlXbHFTQIfQol17w6ZMXuO4BFYZz22yDpKRyN9A61SfhV1TZtxXkqecjqXSCDjzGgFlMwI4RVMCq2O4qz2EcX2x0F5SLdMcne7rIJogSrAzhp4pO27HgiU5Z473cepqF_GgwiSoNOojIhbUcob_5f6B_A58Bk" ],
+                "addsrcrecordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A375736650" ],
-                "score" : [ "0.018276263" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=28601401$$DView record in Pascal Francis" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
-                "creationdate" : [ "2014" ],
-                "recordid" : [ "eNp9UbuO1TAQTQESy4U_oHBDtwl2Hk5ug7RantJKNFBbE3uc67uOnbUTRLr9B76Phi_B2ay2RC5mdHzOmVeWvWG0YJTxd-dCnoIfoSgpqwvKC8q6Z9kFpSXLj7ytXmQvYzxTylralhfZnw84YxiNg9l4R7wmEwZtFx82CBUBe7taAtKoSIwj0gd3SSY_bQkBp57yHoZIetQ-4AMOOhknvr81biD9SrSXS0yOi50DRL8kTvTWqL_3v625W4wi-Cv9yK2RS_II7cPMfggwndYH47sFVFgmbzGfzYhbz9qa4TSTEWIkcUI5JxHOYX2VPddgI75-jIfsx6eP36-_5DffPn-9vrrJZdXQKm-k6qpaQn-sgdfHnmnZtf2x0X0DwFXdYUuVbEtFO2hZlXbHFTQIfQol17w6ZMXuO4BFYZz22yDpKRyN9A61SfhV1TZtxXkqecjqXSCDjzGgFlMwI4RVMCq2O4qz2EcX2x0F5SLdMcne7rIJogSrAzhp4pO27HgiU5Z473cepqF_GgwiSoNOojIhbUcob_5f6B_A58Bk" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "issn" : [ "0021-9673" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V", "Elsevier" ],
-                "startdate" : [ "20140815" ],
-                "enddate" : [ "20140815" ],
-                "scope" : [ "IQODW", "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "publisher" : [ "Amsterdam: Elsevier B.V" ],
-                "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
-                "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
-                "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
-                "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.018273484" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
+                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
+                "issn" : [ "0021-9673" ],
                 "jtitle" : [ "Journal of Chromatography A" ],
                 "genre" : [ "article" ],
-                "issn" : [ "0021-9673" ],
-                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "pages" : [ "211-218" ],
-                "coden" : [ "JOCRAM" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Amsterdam" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
                 "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
                 "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "date" : [ "2014-08-15" ],
                 "risdate" : [ "2014" ],
                 "volume" : [ "1355" ],
                 "spage" : [ "211" ],
-                "epage" : [ "218" ]
+                "epage" : [ "218" ],
+                "pages" : [ "211-218" ],
+                "coden" : [ "JOCRAM" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Amsterdam" ],
+                "pub" : [ "Elsevier B.V" ],
+                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=28601401$$DView record in Pascal Francis" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2014" ],
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
+                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "recordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ],
+                "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "issn" : [ "0021-9673" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Elsevier B.V", "Elsevier" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20140815" ],
+                "enddate" : [ "20140815" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+              },
+              "display" : {
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "publisher" : [ "Amsterdam: Elsevier B.V" ],
+                "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
+                "type" : [ "article" ],
+                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
+                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
+                "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
+                "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2014" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "Packaging", "Quadrupole-time of flight mass spectrometry", "Liquid chromatography", "Perfluorinated alkyl acids", "Focused ultrasound solid–liquid extraction", "Popcorn", "Fundamental and applied biological sciences. Psychology", "Food industries", "Biological and medical sciences", "Cereal and baking product industries", "Corn", "Ammonium perfluorooctanoate", "Mass spectrometry", "Analysis" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "Pascal-Francis", "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3503-5cd834cab94a649b1fc87b95fb5aa6d48e70dc72d08a7130176da5eab6da26f63" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Journal of Chromatography A" ]
               }
@@ -647,7 +647,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -659,628 +659,14 @@ http_interactions:
               "timesCited" : { }
             },
             "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A375736650"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "creationdate" : [ "202102" ],
-                "author" : [ "Rafee, Shameer ; Killeen, Ronan P ; Tubridy, Niall" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_2454123461" ],
-                "sourcerecordid" : [ "2454123461" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kM1Kw0AQxxdRbK2-gUiOXhL3K5usB6EGv6CgBz0vm80ENzTZutsI3voY-np9ElNSr56GYX7_GeaH0DnBCcFEXDWJbpsWqoRiihMsE0z4AZqSNE3jjAh6iKYYYxpLxtkEnYTQDC2WqThGE8awJEyyKSLbzfeLWxnnu-3mJ7JdtH6H6NZr211H86jQfYCodj4qXFf3wbruFB3VehngbF9n6O3-7rV4jBfPD0_FfBEbImkWlyCBZ6SiZY2loFVV6koYxolOgekcZyI3gkgwLGc5MK6znJUlAGE1zpmu2AxdjntX3n30ENaqtcHAcqk7cH1QlKecUMYFGVA-osa7EDzUauVtq_2XIljtZKlGjbLUTpbCUg2yhtjF_kJf7mZ_oT87A3AzAjD8-WnBq2AsdAYq68GsVeXs_xd-Ab2QfDw" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "2454123461" ],
-                "score" : [ "0.018145857" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion", "The American journal of medicine" ],
-                "creationdate" : [ "2021" ],
-                "recordid" : [ "eNp9kM1Kw0AQxxdRbK2-gUiOXhL3K5usB6EGv6CgBz0vm80ENzTZutsI3voY-np9ElNSr56GYX7_GeaH0DnBCcFEXDWJbpsWqoRiihMsE0z4AZqSNE3jjAh6iKYYYxpLxtkEnYTQDC2WqThGE8awJEyyKSLbzfeLWxnnu-3mJ7JdtH6H6NZr211H86jQfYCodj4qXFf3wbruFB3VehngbF9n6O3-7rV4jBfPD0_FfBEbImkWlyCBZ6SiZY2loFVV6koYxolOgekcZyI3gkgwLGc5MK6znJUlAGE1zpmu2AxdjntX3n30ENaqtcHAcqk7cH1QlKecUMYFGVA-osa7EDzUauVtq_2XIljtZKlGjbLUTpbCUg2yhtjF_kJf7mZ_oT87A3AzAjD8-WnBq2AsdAYq68GsVeXs_xd-Ab2QfDw" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-9231-8133", "https://orcid.org/0000-0002-0756-3135" ],
-                "creator" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "subject" : [ "Hemangioma, Cavernous, Central Nervous System - surgery ; Young Adult ; Hemangioma, Cavernous, Central Nervous System - diagnosis ; Confusion - etiology ; Hemangioma, Cavernous, Central Nervous System - pathology ; Humans ; Index Medicus ; Abridged Index Medicus" ],
-                "issn" : [ "0002-9343", "1555-7162" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Am J Med" ],
-                "general" : [ "Elsevier Inc" ],
-                "startdate" : [ "202102" ],
-                "enddate" : [ "202102" ],
-                "scope" : [ "CVF", "NPM", "EIF", "CUY", "ECM", "CGR", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Rafee, Shameer ; Killeen, Ronan P ; Tubridy, Niall" ],
-                "subject" : [ "Hemangioma, Cavernous, Central Nervous System - surgery ; Young Adult ; Hemangioma, Cavernous, Central Nervous System - diagnosis ; Confusion - etiology ; Hemangioma, Cavernous, Central Nervous System - pathology ; Humans ; Index Medicus ; Abridged Index Medicus" ],
-                "source" : [ "Alma/SFX Local Collection", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: Elsevier Inc" ],
-                "ispartof" : [ "The American journal of medicine, 2021-02, Vol.134 (2), p.216-217" ],
-                "identifier" : [ "ISSN: 0002-9343", "EISSN: 1555-7162", "DOI: 10.1016/j.amjmed.2020.09.014", "PMID: 33091393" ],
-                "rights" : [ "2020 Elsevier Inc." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "The American journal of medicine" ],
-                "genre" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-9231-8133", "https://orcid.org/0000-0002-0756-3135" ],
-                "issn" : [ "0002-9343" ],
-                "addtitle" : [ "Am J Med" ],
-                "pages" : [ "216-217" ],
-                "eissn" : [ "1555-7162" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "Elsevier Inc" ],
-                "doi" : [ "10.1016/j.amjmed.2020.09.014" ],
-                "au" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "atitle" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "date" : [ "2021-02" ],
-                "risdate" : [ "2021" ],
-                "volume" : [ "134" ],
-                "issue" : [ "2" ],
-                "spage" : [ "216" ],
-                "epage" : [ "217" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2021" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "topic" : [ "Hemangioma, Cavernous, Central Nervous System - surgery", "Young Adult", "Hemangioma, Cavernous, Central Nervous System - diagnosis", "Confusion - etiology", "Hemangioma, Cavernous, Central Nervous System - pathology", "Humans", "Index Medicus", "Abridged Index Medicus" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "MEDLINE (Ovid)", "PubMed", "MEDLINE", "MEDLINE", "MEDLINE", "Medline", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "The American journal of medicine" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=%E2%80%98Popcorn%E2%80%99+in+the+Brain%3A+A+Cause+for+Confusion&rft.jtitle=The+American+journal+of+medicine&rft.au=Rafee%2C+Shameer&rft.date=2021-02&rft.volume=134&rft.issue=2&rft.spage=216&rft.epage=217&rft.pages=216-217&rft.issn=0002-9343&rft.eissn=1555-7162&rft_id=info:doi/10.1016%2Fj.amjmed.2020.09.014&rft.pub=Elsevier+Inc&rft.place=United+States&rft_dat=<proquest_cross>2454123461</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_2454123461"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "creationdate" : [ "201708" ],
-                "author" : [ "Canfora, Fabrizio ; Tallarita, Gianni" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_doaj_primary_oai_doaj_org_article_ca6c27608a414e0484c23159f93cb0b7" ],
-                "sourcerecordid" : [ "S0550321317301967" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12051-2c631b1ebca7d2be2e5dde20bf2e0fb2cc5ce6abe5093b09d5d69df6f3ee04e73" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9kFtOwzAQRS0EEqWwBrIAEsZ27DSfpeJRqYiPwrflxwQc0iSyU6SuhAWxMRJAzM9I92qORoeQSwoZBSqv66zd26Z_O0STMaBFBjIDoEdkRhcFT6mQ7JjMQAhIOaP8lJzFWMM4ki9m5OZx3ww-3b4fws53bUy6Nlm6Lfv63LKrJOhhDHWT7HQfE926pO9624U2GYJuo5_aeE5OKt1EvPjbc_Jyd_u8ekg3T_fr1XKTUgaCpsxKTg1FY3XhmEGGwjlkYCqGUBlmrbAotUEBJTdQOuFk6SpZcUTIseBzsv7luk7Xqg9-p8NBddqrn6ALr0qHwdsGldXSskLCQuc0H68XuWWcirIquTVgJtbyl4Xjwx8eg4rWY2vR-YB2GIleUVCTYFWrf8FqEqxAqlEw_waviXPt" ],
-                "sourcetype" : [ "Open Website" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_doaj_" ],
-                "score" : [ "0.01814528" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions", "Nuclear physics. B" ],
-                "creationdate" : [ "2017" ],
-                "recordid" : [ "eNo9kFtOwzAQRS0EEqWwBrIAEsZ27DSfpeJRqYiPwrflxwQc0iSyU6SuhAWxMRJAzM9I92qORoeQSwoZBSqv66zd26Z_O0STMaBFBjIDoEdkRhcFT6mQ7JjMQAhIOaP8lJzFWMM4ki9m5OZx3ww-3b4fws53bUy6Nlm6Lfv63LKrJOhhDHWT7HQfE926pO9624U2GYJuo5_aeE5OKt1EvPjbc_Jyd_u8ekg3T_fr1XKTUgaCpsxKTg1FY3XhmEGGwjlkYCqGUBlmrbAotUEBJTdQOuFk6SpZcUTIseBzsv7luk7Xqg9-p8NBddqrn6ALr0qHwdsGldXSskLCQuc0H68XuWWcirIquTVgJtbyl4Xjwx8eg4rWY2vR-YB2GIleUVCTYFWrf8FqEqxAqlEw_waviXPt" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH", "DOA" ],
-                "creatorcontrib" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "issn" : [ "0550-3213", "1873-1562" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V", "Elsevier" ],
-                "startdate" : [ "201708" ],
-                "enddate" : [ "201708" ],
-                "scope" : [ "AAFTH", "6I.", "DOA" ]
-              },
-              "display" : {
-                "description" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Canfora, Fabrizio ; Tallarita, Gianni" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Directory of Open Access Journals", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "Elsevier PhysicsDirect Journals", "Elsevier:ScienceDirect:Open Access", "Backfile Package - Mathematics 1995-2004 [BFJMAT9504]", "ScienceDirect Government Edition", "Elsevier:ScienceDirect:Mathematics Subject Collection:2018" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Nuclear physics. B, 2017-08, Vol.921 (C), p.394-410" ],
-                "identifier" : [ "ISSN: 0550-3213", "EISSN: 1873-1562", "DOI: 10.1016/j.nuclphysb.2017.06.001" ],
-                "rights" : [ "2017 The Author(s)" ],
-                "snippet" : [ "... with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Nuclear physics. B" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0550-3213" ],
-                "abstract" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "pages" : [ "394-410" ],
-                "eissn" : [ "1873-1562" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.nuclphysb.2017.06.001" ],
-                "au" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "atitle" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "date" : [ "2017-08" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "921" ],
-                "issue" : [ "C" ],
-                "spage" : [ "394" ],
-                "epage" : [ "410" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2017" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "Directory of Open Access Journals" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12051-2c631b1ebca7d2be2e5dde20bf2e0fb2cc5ce6abe5093b09d5d69df6f3ee04e73" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Nuclear physics. B" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_doaj_&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Multi-Skyrmions+on+AdS2%C3%97S2%2C+rational+maps+and+popcorn+transitions&rft.jtitle=Nuclear+physics.+B&rft.au=Canfora%2C+Fabrizio&rft.date=2017-08&rft.volume=921&rft.issue=C&rft.spage=394&rft.epage=410&rft.pages=394-410&rft.issn=0550-3213&rft.eissn=1873-1562&rft_id=info:doi/10.1016%2Fj.nuclphysb.2017.06.001&rft.pub=Elsevier+B.V&rft_dat=<elsevier_doaj_>S0550321317301967</elsevier_doaj_>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_doaj_primary_oai_doaj_org_article_ca6c27608a414e0484c23159f93cb0b7"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "creationdate" : [ "20120228" ],
-                "author" : [ "Edgar, Jonathan A ; McDonagh, Andrew M ; Cortie, Michael B" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_924964320" ],
-                "sourcerecordid" : [ "924964320" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNptkL9OwzAQhy0EoqUw8ALIC0IMAduJnXiEihak8kcCJLbIdmyRKrGLnQzd-iDwcn0SjAqdkIez7r77SfcBcIzRBUYEX1pLUEoLNt8BQ8xTlqCCve1u_xQPwEEIc4RoXuRsHwwISVEc5kNwPXG-FV3tLHQGTl1TwQdhnXdVgHIJBXzunHoXoasVXK8-n9xCOW_Xqy94r2Pf1qE9BHtGNEEf_dYReJ3cvIxvk9nj9G58NUtwijhLChwf1ySTRsjMZDkhWCIsOUWUmopxyU3FuaRScVJwkglCK8qwNkWVSi3SETjb5C68--h16Mq2Dko3jbDa9aGMK5xlaVQxAucbUnkXgtemXPi6FX5ZYlT-GCu3xiJ78pvay1ZXW_JPUQRON4BQoZy73tt45D9B3xBUcrY" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "924964320" ],
-                "score" : [ "0.01807377" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism", "ACS nano" ],
-                "creationdate" : [ "2012" ],
-                "recordid" : [ "eNptkL9OwzAQhy0EoqUw8ALIC0IMAduJnXiEihak8kcCJLbIdmyRKrGLnQzd-iDwcn0SjAqdkIez7r77SfcBcIzRBUYEX1pLUEoLNt8BQ8xTlqCCve1u_xQPwEEIc4RoXuRsHwwISVEc5kNwPXG-FV3tLHQGTl1TwQdhnXdVgHIJBXzunHoXoasVXK8-n9xCOW_Xqy94r2Pf1qE9BHtGNEEf_dYReJ3cvIxvk9nj9G58NUtwijhLChwf1ySTRsjMZDkhWCIsOUWUmopxyU3FuaRScVJwkglCK8qwNkWVSi3SETjb5C68--h16Mq2Dko3jbDa9aGMK5xlaVQxAucbUnkXgtemXPi6FX5ZYlT-GCu3xiJ78pvay1ZXW_JPUQRON4BQoZy73tt45D9B3xBUcrY" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "issn" : [ "1936-0851", "1936-086X" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "ACS Nano" ],
-                "general" : [ "American Chemical Society" ],
-                "startdate" : [ "20120228" ],
-                "enddate" : [ "20120228" ],
-                "scope" : [ "NPM", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Edgar, Jonathan A ; McDonagh, Andrew M ; Cortie, Michael B" ],
-                "source" : [ "American Chemical Society Single Title Subscriptions", "ACS Publications", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: American Chemical Society" ],
-                "ispartof" : [ "ACS nano, 2012-02-28, Vol.6 (2), p.1116-1125" ],
-                "identifier" : [ "ISSN: 1936-0851", "EISSN: 1936-086X", "DOI: 10.1021/nn203586j", "PMID: 22301937" ],
-                "rights" : [ "Copyright © 2012 American Chemical Society" ],
-                "snippet" : [ ".... Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn...", ".... Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, \"popcorn\"-like mechanism of growth, in which individual..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "ACS nano" ],
-                "genre" : [ "article" ],
-                "issn" : [ "1936-0851" ],
-                "addtitle" : [ "ACS Nano" ],
-                "abstract" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "pages" : [ "1116-1125" ],
-                "eissn" : [ "1936-086X" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "American Chemical Society" ],
-                "doi" : [ "10.1021/nn203586j" ],
-                "au" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "atitle" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "date" : [ "2012-02-28" ],
-                "risdate" : [ "2012" ],
-                "volume" : [ "6" ],
-                "issue" : [ "2" ],
-                "spage" : [ "1116" ],
-                "epage" : [ "1125" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2012" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "PubMed", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "ACS nano" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Formation+of+Gold+Nanorods+by+a+Stochastic+%E2%80%9CPopcorn%E2%80%9D+Mechanism&rft.jtitle=ACS+nano&rft.au=Edgar%2C+Jonathan+A&rft.date=2012-02-28&rft.volume=6&rft.issue=2&rft.spage=1116&rft.epage=1125&rft.pages=1116-1125&rft.issn=1936-0851&rft.eissn=1936-086X&rft_id=info:doi/10.1021%2Fnn203586j&rft.pub=American+Chemical+Society&rft.place=United+States&rft_dat=<proquest_cross>924964320</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_924964320"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "creationdate" : [ "20190220" ],
-                "author" : [ "Lim, Suh-Ciuan ; Chan, Cheng-Ying ; Chen, Kuan-Ting ; Tuan, Hsing-Yu" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A569709825" ],
-                "sourcerecordid" : [ "A569709825" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3443-c0079cdcabdfeae9cef90da4e646888c639ed0d31ed91e4352660fd284cd31913" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqFkcGKFDEQhoMoOK4-gznqoXuTTne6-zgsugoLK6jnUJtUpjNkkibJLPRr-MRmHPEqFahQ5P-pLz8h7zlrOePy9tiiR12gnrZjfGo5b_nQvSA7Po2iEdMwvyQ7xrhoejnJ1-RNzkfG2ChHtiO_vm-hLJhdptHSNa46ptDkBVY09ADeu_OpWT0UF84n-uEevhXxkQYIcYVUnPaYKWS6uMPiN4rWOu0wFArB0FzgySP9s16KGgr4LZdMbUx02UyKBwwUn6M_FxcDTVgZ6uUteWXBZ3z3t9-Qn58__bj70jw83n-92z80WvS9aHRFmLXR8GQsAs4a7cwM9Cgr5jRpKWY0zAiOZubYi6GTklnTTb2uw5mLG9JefSsmKhdsLAl0LYMnp2NA6-p8P8h5ZPPUDVUwXgU6xZwTWrUmd4K0Kc7UJQt1VP-yUJcsFOeqZlGV-6sSK8-zw6Ty5Zs0Gpfqe2Wi-6_Hb2NPm44" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_cross" ],
-                "galeid" : [ "A569709825" ],
-                "score" : [ "0.018060364" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction", "Electrochimica acta" ],
-                "creationdate" : [ "2019" ],
-                "recordid" : [ "eNqFkcGKFDEQhoMoOK4-gznqoXuTTne6-zgsugoLK6jnUJtUpjNkkibJLPRr-MRmHPEqFahQ5P-pLz8h7zlrOePy9tiiR12gnrZjfGo5b_nQvSA7Po2iEdMwvyQ7xrhoejnJ1-RNzkfG2ChHtiO_vm-hLJhdptHSNa46ptDkBVY09ADeu_OpWT0UF84n-uEevhXxkQYIcYVUnPaYKWS6uMPiN4rWOu0wFArB0FzgySP9s16KGgr4LZdMbUx02UyKBwwUn6M_FxcDTVgZ6uUteWXBZ3z3t9-Qn58__bj70jw83n-92z80WvS9aHRFmLXR8GQsAs4a7cwM9Cgr5jRpKWY0zAiOZubYi6GTklnTTb2uw5mLG9JefSsmKhdsLAl0LYMnp2NA6-p8P8h5ZPPUDVUwXgU6xZwTWrUmd4K0Kc7UJQt1VP-yUJcsFOeqZlGV-6sSK8-zw6Ty5Zs0Gpfqe2Wi-6_Hb2NPm44" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "subject" : [ "Nanoparticles ; Hydrogen evolution reaction ; Platinum alloy ; Fuel cell ; Popcorn-shaped ; Intermetallic compounds ; Catalysts ; Hydrogen ; Fuel cells ; Green technology ; Platinum alloys" ],
-                "issn" : [ "0013-4686", "1873-3859" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier Ltd", "Elsevier B.V" ],
-                "startdate" : [ "20190220" ],
-                "enddate" : [ "20190220" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Lim, Suh-Ciuan ; Chan, Cheng-Ying ; Chen, Kuan-Ting ; Tuan, Hsing-Yu" ],
-                "subject" : [ "Nanoparticles ; Hydrogen evolution reaction ; Platinum alloy ; Fuel cell ; Popcorn-shaped ; Intermetallic compounds ; Catalysts ; Hydrogen ; Fuel cells ; Green technology ; Platinum alloys" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "publisher" : [ "Elsevier Ltd" ],
-                "ispartof" : [ "Electrochimica acta, 2019-02-20, Vol.297, p.288-296" ],
-                "identifier" : [ "ISSN: 0013-4686", "EISSN: 1873-3859", "DOI: 10.1016/j.electacta.2018.11.152" ],
-                "rights" : [ "2018 Elsevier Ltd", "COPYRIGHT 2019 Elsevier B.V." ],
-                "snippet" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Electrochimica acta" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0013-4686" ],
-                "abstract" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "pages" : [ "288-296" ],
-                "eissn" : [ "1873-3859" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier Ltd" ],
-                "doi" : [ "10.1016/j.electacta.2018.11.152" ],
-                "au" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "atitle" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "date" : [ "2019-02-20" ],
-                "risdate" : [ "2019" ],
-                "volume" : [ "297" ],
-                "spage" : [ "288" ],
-                "epage" : [ "296" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "topic" : [ "Nanoparticles", "Hydrogen evolution reaction", "Platinum alloy", "Fuel cell", "Popcorn-shaped", "Intermetallic compounds", "Catalysts", "Hydrogen", "Fuel cells", "Green technology", "Platinum alloys" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3443-c0079cdcabdfeae9cef90da4e646888c639ed0d31ed91e4352660fd284cd31913" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Electrochimica acta" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Synthesis+of+popcorn-shaped+gallium-platinum+%28GaPt3%29+nanoparticles+as+highly+efficient+and+stable+electrocatalysts+for+hydrogen+evolution+reaction&rft.jtitle=Electrochimica+acta&rft.au=Lim%2C+Suh-Ciuan&rft.date=2019-02-20&rft.volume=297&rft.spage=288&rft.epage=296&rft.pages=288-296&rft.issn=0013-4686&rft.eissn=1873-3859&rft_id=info:doi/10.1016%2Fj.electacta.2018.11.152&rft.pub=Elsevier+Ltd&rft_dat=<gale_cross>A569709825</gale_cross>&svc_dat=viewit&rft_galeid=A569709825"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A569709825"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "creationdate" : [ "20160816" ],
-                "author" : [ "Liang, Ting ; Chen, Chunlin ; Li, Xing ; Zhang, Jian" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_1812224163" ],
-                "sourcerecordid" : [ "1812224163" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kE1Lw0AQhhdRbK3-A5E9eknd7yQ3JdYPKLSgnpfdZFNSmmycbYT-e7e09ehhGBied2b3QeiWkikljD6YMkw3plu1QwNTZQnNJT9DYyoZSWTG0nM0JqngSSoUH6GrENaEkJyL_BKNWCqkpBkfo8el70sPXfLsoPlxFV568EPAhQHrO1x7wLPOwWqHP7YezMph01W4WLBI9NsB3DW6qM0muJtjn6Cvl9ln8ZbMF6_vxdM8MUxylVS2TJ2shXWWiFhVKSlXaW7KlCtGBZG2VnFoGKtlVjkmVW4rFkHJmRWWT9D9YW8P_ntwYavbJpRuExW4-GBNM8oYE1TxiIoDWoIPAVyte2haAztNid6709GdPrnTR3cxdne8MNjWVX-hk6wIkAOwj6_9AF388P87fwGsXH17" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "1812224163" ],
-                "score" : [ "0.01801862" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture", "Langmuir" ],
-                "creationdate" : [ "2016" ],
-                "recordid" : [ "eNp9kE1Lw0AQhhdRbK3-A5E9eknd7yQ3JdYPKLSgnpfdZFNSmmycbYT-e7e09ehhGBied2b3QeiWkikljD6YMkw3plu1QwNTZQnNJT9DYyoZSWTG0nM0JqngSSoUH6GrENaEkJyL_BKNWCqkpBkfo8el70sPXfLsoPlxFV568EPAhQHrO1x7wLPOwWqHP7YezMph01W4WLBI9NsB3DW6qM0muJtjn6Cvl9ln8ZbMF6_vxdM8MUxylVS2TJ2shXWWiFhVKSlXaW7KlCtGBZG2VnFoGKtlVjkmVW4rFkHJmRWWT9D9YW8P_ntwYavbJpRuExW4-GBNM8oYE1TxiIoDWoIPAVyte2haAztNid6709GdPrnTR3cxdne8MNjWVX-hk6wIkAOwj6_9AF388P87fwGsXH17" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "subject" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage ; Index Medicus" ],
-                "issn" : [ "0743-7463", "1520-5827" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Langmuir" ],
-                "general" : [ "American Chemical Society" ],
-                "startdate" : [ "20160816" ],
-                "enddate" : [ "20160816" ],
-                "scope" : [ "NPM", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Liang, Ting ; Chen, Chunlin ; Li, Xing ; Zhang, Jian" ],
-                "subject" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage ; Index Medicus" ],
-                "source" : [ "Alma/SFX Local Collection", "ACS Publications", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: American Chemical Society" ],
-                "ispartof" : [ "Langmuir, 2016-08-16, Vol.32 (32), p.8042-8049" ],
-                "identifier" : [ "ISSN: 0743-7463", "EISSN: 1520-5827", "DOI: 10.1021/acs.langmuir.6b01953", "PMID: 27455183" ],
-                "rights" : [ "Copyright © 2016 American Chemical Society" ],
-                "snippet" : [ ".... Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Langmuir" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0743-7463" ],
-                "addtitle" : [ "Langmuir" ],
-                "abstract" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "pages" : [ "8042-8049" ],
-                "eissn" : [ "1520-5827" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "American Chemical Society" ],
-                "doi" : [ "10.1021/acs.langmuir.6b01953" ],
-                "au" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "atitle" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "date" : [ "2016-08-16" ],
-                "risdate" : [ "2016" ],
-                "volume" : [ "32" ],
-                "issue" : [ "32" ],
-                "spage" : [ "8042" ],
-                "epage" : [ "8049" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2016" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "topic" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage", "Index Medicus" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "PubMed", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Langmuir" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-30 16:41:34&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn-Derived+Porous+Carbon+for+Energy+Storage+and+CO2+Capture&rft.jtitle=Langmuir&rft.au=Liang%2C+Ting&rft.date=2016-08-16&rft.volume=32&rft.issue=32&rft.spage=8042&rft.epage=8049&rft.pages=8042-8049&rft.issn=0743-7463&rft.eissn=1520-5827&rft_id=info:doi/10.1021%2Facs.langmuir.6b01953&rft.pub=American+Chemical+Society&rft.place=United+States&rft_dat=<proquest_cross>1812224163</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_1812224163"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "189",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "63",
-            "PC_SEARCH_TIME_TOTAL" : "252",
-            "BUILD_BLEND_AND_CACHE_RESULTS" : 1,
-            "BUILD_COMBINED_RESULTS_MAP" : 253,
-            "COMBINED_SEARCH_TIME" : 266,
+            "PC_SEARCH_CALL_TIME" : "663",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "39",
+            "PC_SEARCH_TIME_TOTAL" : "702",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
+            "BUILD_COMBINED_RESULTS_MAP" : 703,
+            "COMBINED_SEARCH_TIME" : 710,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
@@ -1288,22 +674,22 @@ http_interactions:
             "name" : "jtitle",
             "values" : [ {
               "value" : "The Washington Post",
-              "count" : "7866"
+              "count" : "7878"
             }, {
               "value" : "Chicago Tribune",
-              "count" : "7576"
+              "count" : "7579"
             }, {
               "value" : "The Los Angeles Times",
-              "count" : "6320"
+              "count" : "6322"
             }, {
               "value" : "The New York Times",
-              "count" : "5988"
+              "count" : "5992"
             }, {
               "value" : "Toronto Star",
               "count" : "3743"
             }, {
               "value" : "Edmonton Journal",
-              "count" : "2831"
+              "count" : "2833"
             }, {
               "value" : "Variety",
               "count" : "2731"
@@ -1321,16 +707,16 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "131607"
+              "count" : "131767"
             }, {
               "value" : "por",
-              "count" : "248"
+              "count" : "249"
             }, {
               "value" : "spa",
-              "count" : "199"
+              "count" : "202"
             }, {
               "value" : "ger",
-              "count" : "139"
+              "count" : "141"
             }, {
               "value" : "chi",
               "count" : "88"
@@ -1353,10 +739,10 @@ http_interactions:
               "value" : "slo",
               "count" : "11"
             }, {
-              "value" : "tur",
-              "count" : "8"
-            }, {
               "value" : "ita",
+              "count" : "9"
+            }, {
+              "value" : "tur",
               "count" : "8"
             }, {
               "value" : "nor",
@@ -1384,184 +770,184 @@ http_interactions:
             "name" : "topic",
             "values" : [ {
               "value" : "Motion Pictures",
-              "count" : "6836"
+              "count" : "6843"
             }, {
               "value" : "Science & Technology",
-              "count" : "5791"
+              "count" : "5824"
             }, {
               "value" : "Life Sciences & Biomedicine",
-              "count" : "4256"
+              "count" : "4279"
             }, {
               "value" : "Marketing",
-              "count" : "4169"
+              "count" : "4190"
             }, {
               "value" : "Restaurants",
-              "count" : "4071"
+              "count" : "4076"
             }, {
               "value" : "Food",
-              "count" : "2719"
+              "count" : "2726"
             }, {
               "value" : "Humans",
-              "count" : "2408"
+              "count" : "2418"
             }, {
               "value" : "Management",
-              "count" : "2123"
+              "count" : "2124"
             }, {
               "value" : "Analysis",
-              "count" : "1792"
+              "count" : "1800"
             }, {
               "value" : "Nutrition",
-              "count" : "1708"
-            }, {
-              "value" : "Theaters & Cinemas",
-              "count" : "1706"
-            }, {
-              "value" : "Methods",
-              "count" : "1703"
+              "count" : "1711"
             }, {
               "value" : "Snack Foods",
-              "count" : "1703"
+              "count" : "1708"
+            }, {
+              "value" : "Methods",
+              "count" : "1707"
+            }, {
+              "value" : "Theaters & Cinemas",
+              "count" : "1707"
             }, {
               "value" : "Motion Picture Industry",
-              "count" : "1696"
+              "count" : "1698"
             }, {
               "value" : "Diet",
-              "count" : "1640"
+              "count" : "1643"
             }, {
               "value" : "Research",
-              "count" : "1638"
+              "count" : "1641"
             }, {
               "value" : "Social Sciences",
               "count" : "1581"
             }, {
               "value" : "Theater",
-              "count" : "1507"
+              "count" : "1508"
             }, {
               "value" : "Health Aspects",
-              "count" : "1500"
+              "count" : "1501"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "newspaper_articles",
-              "count" : "62945"
+              "count" : "62942"
             }, {
               "value" : "articles",
-              "count" : "58185"
+              "count" : "58336"
             }, {
               "value" : "reviews",
-              "count" : "3958"
+              "count" : "3968"
             }, {
               "value" : "journals",
-              "count" : "2900"
+              "count" : "2903"
             }, {
               "value" : "book_chapters",
-              "count" : "2266"
+              "count" : "2265"
             }, {
               "value" : "reference_entrys",
-              "count" : "631"
+              "count" : "632"
             }, {
               "value" : "web_resources",
-              "count" : "537"
+              "count" : "535"
             }, {
               "value" : "conference_proceedings",
               "count" : "328"
             }, {
               "value" : "reports",
-              "count" : "211"
+              "count" : "213"
             }, {
               "value" : "books",
               "count" : "135"
             }, {
               "value" : "text_resources",
-              "count" : "10"
+              "count" : "9"
             } ]
           }, {
             "name" : "domain",
             "values" : [ {
               "value" : "ProQuest Historical Newspapers",
-              "count" : "132106"
+              "count" : "132266"
             }, {
               "value" : "Global Newsstream",
-              "count" : "64413"
+              "count" : "64456"
             }, {
               "value" : "Factiva",
-              "count" : "60830"
+              "count" : "60921"
             }, {
               "value" : "Nexis Uni",
-              "count" : "54167"
+              "count" : "54236"
             }, {
               "value" : "PressReader",
-              "count" : "43371"
+              "count" : "43423"
             }, {
               "value" : "Single Journals",
-              "count" : "32964"
+              "count" : "32986"
             }, {
               "value" : "ABI/INFORM Collection",
-              "count" : "30722"
+              "count" : "30745"
             }, {
               "value" : "Academic Search Complete",
-              "count" : "19349"
+              "count" : "19383"
             }, {
               "value" : "Business Source Complete",
-              "count" : "17967"
+              "count" : "17986"
             }, {
               "value" : "Factiva (Selected Full Text)",
-              "count" : "7120"
+              "count" : "7127"
             }, {
               "value" : "Agricultural & Environmental Science Collection",
-              "count" : "6684"
+              "count" : "6734"
             }, {
               "value" : "Flipster",
-              "count" : "4753"
+              "count" : "4769"
             }, {
               "value" : "Ethnic NewsWatch",
-              "count" : "4260"
+              "count" : "4266"
             }, {
               "value" : "Advanced Technologies & Aerospace Collection",
-              "count" : "3234"
+              "count" : "3261"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "3207"
+              "count" : "3219"
             }, {
               "value" : "Environmental Science Collection",
-              "count" : "2857"
+              "count" : "2890"
             }, {
               "value" : "Freely Accessible General Interest Journals",
-              "count" : "2713"
+              "count" : "2717"
             }, {
               "value" : "Freely Accessible Journals",
-              "count" : "2656"
+              "count" : "2658"
             }, {
               "value" : "Wall Street Journal Online",
               "count" : "2603"
             }, {
-              "value" : "Directory of Open Access Journals",
-              "count" : "2568"
+              "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
+              "count" : "2574"
             } ]
           }, {
             "name" : "tlevel",
             "values" : [ {
               "value" : "open_access",
-              "count" : "3835"
+              "count" : "3866"
             }, {
               "value" : "peer_reviewed",
-              "count" : "10847"
+              "count" : "10892"
             }, {
               "value" : "online_resources",
-              "count" : "132106"
+              "count" : "132266"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
-              "value" : "90 days back",
-              "count" : "2608"
-            }, {
               "value" : "07 days back",
-              "count" : "97"
+              "count" : "24"
             }, {
               "value" : "30 days back",
-              "count" : "830"
+              "count" : "186"
+            }, {
+              "value" : "90 days back",
+              "count" : "2557"
             } ]
           }, {
             "name" : "creationdate",
@@ -1600,7 +986,7 @@ http_interactions:
               "count" : "89"
             }, {
               "value" : "1956",
-              "count" : "70"
+              "count" : "69"
             }, {
               "value" : "1957",
               "count" : "84"
@@ -1639,10 +1025,10 @@ http_interactions:
               "count" : "50"
             }, {
               "value" : "1969",
-              "count" : "114"
+              "count" : "115"
             }, {
               "value" : "1970",
-              "count" : "89"
+              "count" : "90"
             }, {
               "value" : "1971",
               "count" : "76"
@@ -1678,13 +1064,13 @@ http_interactions:
               "count" : "239"
             }, {
               "value" : "1982",
-              "count" : "275"
+              "count" : "276"
             }, {
               "value" : "1983",
               "count" : "229"
             }, {
               "value" : "1984",
-              "count" : "341"
+              "count" : "342"
             }, {
               "value" : "1985",
               "count" : "760"
@@ -1699,105 +1085,105 @@ http_interactions:
               "count" : "1235"
             }, {
               "value" : "1989",
-              "count" : "1589"
+              "count" : "1588"
             }, {
               "value" : "1990",
               "count" : "1589"
             }, {
               "value" : "1991",
-              "count" : "1842"
+              "count" : "1843"
             }, {
               "value" : "1992",
               "count" : "2047"
             }, {
               "value" : "1993",
-              "count" : "1935"
+              "count" : "1937"
             }, {
               "value" : "1994",
-              "count" : "2311"
+              "count" : "2312"
             }, {
               "value" : "1995",
-              "count" : "2257"
+              "count" : "2259"
             }, {
               "value" : "1996",
-              "count" : "2891"
+              "count" : "2894"
             }, {
               "value" : "1997",
-              "count" : "2842"
+              "count" : "2844"
             }, {
               "value" : "1998",
-              "count" : "3595"
+              "count" : "3596"
             }, {
               "value" : "1999",
               "count" : "3846"
             }, {
               "value" : "2000",
-              "count" : "4358"
+              "count" : "4357"
             }, {
               "value" : "2001",
               "count" : "4157"
             }, {
               "value" : "2002",
-              "count" : "4397"
+              "count" : "4402"
             }, {
               "value" : "2003",
-              "count" : "4581"
+              "count" : "4585"
             }, {
               "value" : "2004",
-              "count" : "4941"
+              "count" : "4942"
             }, {
               "value" : "2005",
-              "count" : "5327"
+              "count" : "5328"
             }, {
               "value" : "2006",
-              "count" : "5016"
+              "count" : "5017"
             }, {
               "value" : "2007",
-              "count" : "5234"
+              "count" : "5236"
             }, {
               "value" : "2008",
               "count" : "5026"
             }, {
               "value" : "2009",
-              "count" : "4863"
+              "count" : "4864"
             }, {
               "value" : "2010",
-              "count" : "4790"
+              "count" : "4793"
             }, {
               "value" : "2011",
-              "count" : "4590"
+              "count" : "4592"
             }, {
               "value" : "2012",
-              "count" : "5086"
+              "count" : "5089"
             }, {
               "value" : "2013",
-              "count" : "5223"
+              "count" : "5227"
             }, {
               "value" : "2014",
-              "count" : "5028"
+              "count" : "5031"
             }, {
               "value" : "2015",
-              "count" : "4661"
+              "count" : "4667"
             }, {
               "value" : "2016",
-              "count" : "4514"
+              "count" : "4523"
             }, {
               "value" : "2017",
-              "count" : "4088"
+              "count" : "4092"
             }, {
               "value" : "2018",
-              "count" : "3811"
+              "count" : "3810"
             }, {
               "value" : "2019",
-              "count" : "3798"
+              "count" : "3797"
             }, {
               "value" : "2020",
-              "count" : "2973"
+              "count" : "2978"
             }, {
               "value" : "2021",
-              "count" : "838"
+              "count" : "933"
             } ]
           } ]
         }
-  recorded_at: Fri, 30 Apr 2021 20:41:35 GMT
+  recorded_at: Mon, 17 May 2021 15:06:14 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_books.yml
+++ b/test/vcr_cassettes/missing_fields_primo_books.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549994'
+      - '549992'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Fri, 30 Apr 2021 20:05:33 GMT
+      - Mon, 17 May 2021 15:06:26 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -49,7 +49,7 @@ http_interactions:
             "totalResultsPC" : -1,
             "total" : 132,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "description" : [ "POPCORN" ],
@@ -84,7 +84,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "2.935073E-4" ]
+                "score" : [ "2.950539E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -110,25 +110,6 @@ http_interactions:
               }
             },
             "delivery" : {
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
-              "serviceMode" : [ "ovp", "Viewit" ],
-              "availability" : [ "check_holdings", "not_restricted" ],
-              "availabilityLinks" : [ "detailsgetit1" ],
-              "availabilityLinksUrl" : [ ],
-              "displayedAvailability" : null,
-              "displayLocation" : true,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : false,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -189,7 +170,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573078" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -231,6 +212,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -269,7 +251,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573061" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -311,6 +293,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -349,7 +332,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573073" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -391,6 +374,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -429,7 +413,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573053" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -471,406 +455,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723106761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723106761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723106761" ],
-                "recordid" : [ "alma9933019723106761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573064" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573064" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Ireland" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9064624205021560521" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721206761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019721206761" ],
-                "recordid" : [ "alma9933019721206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573079" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573079" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: the Netherlands" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9013384081808631136" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724706761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724706761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019724706761" ],
-                "recordid" : [ "alma9933019724706761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573048" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573048" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Asia-Pacific" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9070104524867762023" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722806761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722806761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019722806761" ],
-                "recordid" : [ "alma9933019722806761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573067" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573067" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Mexico" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9050063563168056425" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723906761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723906761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723906761" ],
-                "recordid" : [ "alma9933019723906761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573056" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553534E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573056" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Europe" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9061988140408692301" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -890,24 +475,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "91",
-            "CALL_SOLR_GET_IDS_LIST" : "763",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "537",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "14",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "41",
-            "RETRIVE_FROM_DB_RECORDS" : "32",
-            "RETRIVE_FROM_DB_RELATIONS" : "2",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "290",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "247",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "329",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "1734",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "513",
+            "CALL_SOLR_GET_IDS_LIST" : "1051",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "977",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "169",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "84",
+            "RETRIVE_FROM_DB_RECORDS" : "232",
+            "RETRIVE_FROM_DB_RELATIONS" : "24",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "499",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "478",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "334",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "2890",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 3214,
-            "COMBINED_SEARCH_TIME" : 3219,
+            "BUILD_COMBINED_RESULTS_MAP" : 0,
+            "COMBINED_SEARCH_TIME" : 4,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Fri, 30 Apr 2021 20:05:34 GMT
+  recorded_at: Mon, 17 May 2021 15:06:27 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_chapter.yml
+++ b/test/vcr_cassettes/missing_fields_primo_chapter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549984'
+      - '549987'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 10 May 2021 15:48:04 GMT
+      - Mon, 17 May 2021 15:18:50 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,14 +46,14 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 78,
-            "total" : 78,
+            "totalResultsPC" : 82,
+            "total" : 82,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "snippet" : [ "Spider Monkey Optimization algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm" ],
-            "title" : [ "Spider Monkey Optimization Algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm", "Spider Monkey Optimization algorithm" ],
+            "title" : [ "Spider Monkey Optimization Algorithm", "Spider monkey optimization algorithm" ],
             "termsUnion" : [ "Spider Monkey Optimization algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm", "Spider Monkey Optimization Algorithm" ]
           },
           "docs" : [ {
@@ -66,9 +66,9 @@ http_interactions:
               "control" : {
                 "recordid" : [ "cdi_springer_books_10_1007_978_3_319_91341_4_4" ],
                 "sourcerecordid" : [ "springer_books_10_1007_978_3_319_91341_4_4" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-s1027-f9f77010fc0aa79e296c03e91dcec7a8c16ed16a8d8415c09b83f7d0d8e09ce43" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "recordtype" : [ "book_chapter" ],
-                "addsrcrecordid" : [ "eNo9kMtOwzAURM1LopR-AZss2BrujRPbd1lVFJCKugAkdpZjO8Vqm0RxNvD1hPJYjWZGGmkOY1cINwigbklpLrhA4oSiQF6Y4ohdiDE4eHXMJqglcCpBnPwXgsrTv6Kgt3M2SylWMA5KnUsxYdfPXfShz57aZhs-snU3xH38tENsm2y-27R9HN73l-ystrsUZr86Za_Lu5fFA1-t7x8X8xVPCLniNdVKAULtwFpFISfpQARC74JTVjuUwaO02usCSwdUaVErD14HIBcKMWX4s5u6Pjab0JuqbbfJIJhvBmZkYIQZn5nDZzMyEF--DEpX" ],
+                "addsrcrecordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
                 "sourcetype" : [ "Publisher" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
@@ -83,6 +83,7 @@ http_interactions:
                 "au" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
                 "atitle" : [ "Spider Monkey Optimization Algorithm" ],
                 "seriestitle" : [ "Studies in Computational Intelligence" ],
+                "date" : [ "2018-06-07" ],
                 "risdate" : [ "2018" ],
                 "spage" : [ "43" ],
                 "epage" : [ "59" ],
@@ -103,7 +104,7 @@ http_interactions:
                 "creationdate" : [ "2018" ],
                 "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
                 "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNo9kMtOwzAURM1LopR-AZss2BrujRPbd1lVFJCKugAkdpZjO8Vqm0RxNvD1hPJYjWZGGmkOY1cINwigbklpLrhA4oSiQF6Y4ohdiDE4eHXMJqglcCpBnPwXgsrTv6Kgt3M2SylWMA5KnUsxYdfPXfShz57aZhs-snU3xH38tENsm2y-27R9HN73l-ystrsUZr86Za_Lu5fFA1-t7x8X8xVPCLniNdVKAULtwFpFISfpQARC74JTVjuUwaO02usCSwdUaVErD14HIBcKMWX4s5u6Pjab0JuqbbfJIJhvBmZkYIQZn5nDZzMyEF--DEpX" ],
+                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
                 "recordtype" : [ "book_chapter" ],
                 "sourceid" : [ "" ],
                 "scope" : [ "" ],
@@ -128,6 +129,7 @@ http_interactions:
                 "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
                 "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
                 "language" : [ "eng" ],
+                "relation" : [ "Studies in Computational Intelligence" ],
                 "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
                 "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
                 "lds50" : [ "peer_reviewed" ],
@@ -145,7 +147,7 @@ http_interactions:
                 "topic" : [ "Spider monkey optimization", "Swarm intelligence", "Numerical optimization", "Fission-fusion social structure" ],
                 "prefilter" : [ "book_chapters" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1027-f9f77010fc0aa79e296c03e91dcec7a8c16ed16a8d8415c09b83f7d0d8e09ce43" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ]
               }
@@ -165,7 +167,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -182,21 +184,21 @@ http_interactions:
               "sort" : {
                 "creationdate" : [ "201712" ],
                 "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "author" : [ "Gupta, Kavita ; Gupta, Kavita ; Deep, Kusum ; Deep, Kusum ; Bansal, Jagdish Chand ; Bansal, Jagdish Chand" ]
+                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
               },
               "control" : {
                 "recordid" : [ "cdi_proquest_journals_1954549491" ],
                 "sourcerecordid" : [ "A511146853" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kEtLxDAYRYso-PwB7goupWO-PCbNchCfCC7UdcjkMUanTU06i_HXm05FUUGySAjn5H65RXEMaAII8bOEEEOoQjCtMAVRoa1iDyghFadcbG_OuOJTSnaL_ZReEMLAGdkrbh86b2wsm9C-2nUZut43_l31PrSlWi5C9P1zU7oQSx3a1EflW2t-Yl0M86Vt0mGx49Qy2aPP_aB4urx4PL-u7u6vbs5nd5XGtWBVzWCKCDaaGq45RiAop6yeE0J4regcCBbaWUGdwQaoI4JrBUbNlQFilSMHxcn4bg5-W9nUy5ewim2OlCAYZVRQAZmajNRCLa30rQt5eJ2XsY3Pf7HO5_sZAwA6rRnJAoyCjiGlaJ3som9UXEtAcuhYjh3L3LEcOpYoO6ejkzLbLmz8cvBADTQGicmG_074Q2_AwZjF3us81-b9zrj_E_jvhA-yYJtk" ],
+                "addsrcrecordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_proqu" ],
                 "pqid" : [ "1954549491" ],
                 "galeid" : [ "A511146853" ],
-                "score" : [ "0.09795808" ]
+                "score" : [ "0.09796392" ]
               },
               "addata" : {
                 "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
@@ -204,7 +206,7 @@ http_interactions:
                 "issn" : [ "1432-7643" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
                 "stitle" : [ "Soft Comput" ],
                 "date" : [ "2017-12" ],
@@ -229,11 +231,11 @@ http_interactions:
               "search" : {
                 "creationdate" : [ "2017" ],
                 "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
-                "creator" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNp9kEtLxDAYRYso-PwB7goupWO-PCbNchCfCC7UdcjkMUanTU06i_HXm05FUUGySAjn5H65RXEMaAII8bOEEEOoQjCtMAVRoa1iDyghFadcbG_OuOJTSnaL_ZReEMLAGdkrbh86b2wsm9C-2nUZut43_l31PrSlWi5C9P1zU7oQSx3a1EflW2t-Yl0M86Vt0mGx49Qy2aPP_aB4urx4PL-u7u6vbs5nd5XGtWBVzWCKCDaaGq45RiAop6yeE0J4regcCBbaWUGdwQaoI4JrBUbNlQFilSMHxcn4bg5-W9nUy5ewim2OlCAYZVRQAZmajNRCLa30rQt5eJ2XsY3Pf7HO5_sZAwA6rRnJAoyCjiGlaJ3som9UXEtAcuhYjh3L3LEcOpYoO6ejkzLbLmz8cvBADTQGicmG_074Q2_AwZjF3us81-b9zrj_E_jvhA-yYJtk" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
                 "issn" : [ "1432-7643", "1433-7479" ],
                 "fulltext" : [ "true" ],
@@ -250,8 +252,8 @@ http_interactions:
                 "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
                 "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
                 "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "creator" : [ "Gupta, Kavita ; Gupta, Kavita ; Deep, Kusum ; Deep, Kusum ; Bansal, Jagdish Chand ; Bansal, Jagdish Chand" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
                 "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
                 "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
                 "language" : [ "eng" ],
@@ -266,14 +268,14 @@ http_interactions:
               },
               "facets" : {
                 "creationdate" : [ "2017" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "rsrctype" : [ "articles" ],
                 "language" : [ "eng" ],
                 "topic" : [ "Engineering", "Deb’s technique", "CEC2006", "Computational Intelligence", "Control, Robotics, Mechatronics", "Artificial Intelligence (incl. Robotics)", "Spider monkey optimization", "CEC2010", "Mathematical Logic and Foundations", "Constrained optimization", "Monkeys", "Algorithms", "Mathematical optimization", "Analysis", "Bees", "Optimization algorithms", "Benchmarks", "Global optimization", "Swarm intelligence" ],
                 "prefilter" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)", "Soft Computing" ]
               }
@@ -293,14 +295,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
-                "citedby" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ]
+                "citing" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
+                "citedby" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ]
               },
               "timesCited" : { }
             },
@@ -315,15 +317,15 @@ http_interactions:
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A648108178" ],
                 "sourcerecordid" : [ "A648108178" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNotkMtOQyEQhonRxHp5AVe8ABU4FM5Z1nprUu2imrg7QRha9BQqkBh9etGaWUwyme9P_g-hC0bHjFJ1mRnjShHKKaFK0YbIAzRiE8VJ24iXQzSiHe-I5Iwfo5Oc3yitWMdH6GMRtcVXetDB-LDGPuBVdOVTJyDX4HwAix-hfMb0nvFz_n1Z7byFhB9ieIcvvNwVv_XfuvgY8HRYx-TLZotdTLhsAM9DgRSg4Ojw06bi-QwdOT1kOP_fp-j59uZpdk8Wy7v5bLoghk0EJ8q8ug66idXCcq2dACmVlbq1XEpNHRil2KvTTeuMkOCEFcpRy7QBUTHZnKLxPnetB-h9cLEkbepY2HoTQy1X71MpWkZbptoK8D1gUsw5get3yW91-uoZ7X8t93vLfbXc_1nuZfMD1NRyeA" ],
+                "addsrcrecordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A648108178" ],
-                "score" : [ "0.066328235" ]
+                "score" : [ "0.06633203" ]
               },
               "addata" : {
                 "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
@@ -353,9 +355,9 @@ http_interactions:
                 "creationdate" : [ "2020" ],
                 "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
                 "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "recordid" : [ "eNotkMtOQyEQhonRxHp5AVe8ABU4FM5Z1nprUu2imrg7QRha9BQqkBh9etGaWUwyme9P_g-hC0bHjFJ1mRnjShHKKaFK0YbIAzRiE8VJ24iXQzSiHe-I5Iwfo5Oc3yitWMdH6GMRtcVXetDB-LDGPuBVdOVTJyDX4HwAix-hfMb0nvFz_n1Z7byFhB9ieIcvvNwVv_XfuvgY8HRYx-TLZotdTLhsAM9DgRSg4Ojw06bi-QwdOT1kOP_fp-j59uZpdk8Wy7v5bLoghk0EJ8q8ug66idXCcq2dACmVlbq1XEpNHRil2KvTTeuMkOCEFcpRy7QBUTHZnKLxPnetB-h9cLEkbepY2HoTQy1X71MpWkZbptoK8D1gUsw5get3yW91-uoZ7X8t93vLfbXc_1nuZfMD1NRyeA" ],
+                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
                 "issn" : [ "0929-6212", "1572-834X" ],
                 "fulltext" : [ "true" ],
@@ -394,7 +396,7 @@ http_interactions:
                 "prefilter" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Wireless personal communications" ]
               }
@@ -414,13 +416,13 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
+                "citing" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "citedby" : [ ]
               },
               "timesCited" : { }
@@ -436,14 +438,14 @@ http_interactions:
               "control" : {
                 "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2015_08_504" ],
                 "sourcerecordid" : [ "S1877050915026393" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kLFOwzAQhi0EEhX0CVj8Agnnxo6dgaFULSAVFQk6W459AZc2juwIqTw9acvAxC13w32_fn2E3DDIGbDydpN3MdiUT4CJHFQugJ-REVNSZiCgOv9zX5JxShsYplCqYnJE5gvft5gSvTcJHX0Jyfc-tHTdOdMj9S197bzDSJ9D-4l7uup6v_Pf5vg03b6H6PuP3TW5aMw24fh3X5H1Yv42e8yWq4en2XSZsaLgMqssR-tsCdyqCW9Eg6xxshSiUMYYmDSiLHnFuFSVgbqWrhailpViADVzThVXpDjl2hhSitjoLvqdiXvNQB9k6I0-ytAHGRqUHmQM1N2JwqHal8eok_XYWnQ-ou21C_5f_gfv2WkK" ],
+                "addsrcrecordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.066328235" ]
+                "score" : [ "0.06633203" ]
               },
               "addata" : {
                 "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
@@ -474,10 +476,10 @@ http_interactions:
                 "creationdate" : [ "2015" ],
                 "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
                 "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "recordid" : [ "eNp9kLFOwzAQhi0EEhX0CVj8Agnnxo6dgaFULSAVFQk6W459AZc2juwIqTw9acvAxC13w32_fn2E3DDIGbDydpN3MdiUT4CJHFQugJ-REVNSZiCgOv9zX5JxShsYplCqYnJE5gvft5gSvTcJHX0Jyfc-tHTdOdMj9S197bzDSJ9D-4l7uup6v_Pf5vg03b6H6PuP3TW5aMw24fh3X5H1Yv42e8yWq4en2XSZsaLgMqssR-tsCdyqCW9Eg6xxshSiUMYYmDSiLHnFuFSVgbqWrhailpViADVzThVXpDjl2hhSitjoLvqdiXvNQB9k6I0-ytAHGRqUHmQM1N2JwqHal8eok_XYWnQ-ou21C_5f_gfv2WkK" ],
+                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
                 "recordtype" : [ "article" ],
                 "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
+                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ],
                 "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
                 "issn" : [ "1877-0509", "1877-0509" ],
                 "fulltext" : [ "true" ],
@@ -515,9 +517,9 @@ http_interactions:
                 "language" : [ "eng" ],
                 "topic" : [ "Engineering optimization problems", "fission-fusion social structure", "Nature Inspired Algorithms", "Swarm intelligence", "Spider Monkey Optimization Algorithm" ],
                 "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
+                "collection" : [ "ScienceDirect Open Access Titles", "Elsevier:ScienceDirect:Open Access", "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Procedia computer science" ]
               }
@@ -537,14 +539,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
                 "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ]
+                "citedby" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ]
               },
               "timesCited" : { }
             },
@@ -559,15 +561,15 @@ http_interactions:
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A491502847" ],
                 "sourcerecordid" : [ "A491502847" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12628-49cdf08056271eddc7487514e58c6139354e0cde7e87bfa641a9c95245c812153" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpHgdO3aOUcWjUqFCpefIdZzWkNiREx7lB_ht3JYLu4dd7eyOZgehayATiHGjvXUToETCCRoBy0QiM0ZO0YhIyhKRp_wcXfT9KyEEUiZH6GfWdsF_WLfBw9bgudeqwUujgt7iYm0bO-ywr_Gys5UJ-NG7N7PDi26wrf1Wg_UOF83GBztsW7zq9zTP76oKEdK46CL1l22Pe7UPeOW0d_0QlHWm-kdzic5q1fTm6q-O0eru9mX6kMwX97NpMU-AZlQmLNdVTSThGRVgqkoLJgUHZrjUGaTxP2aIrowwUqxrlTFQuc45ZVxLoMDTMZoceTeqMaV1tY9qdMzKtDaKM7WN84LlwAmVTMQDOB58RmBXdiH-E3YlkHJveLk3vDwYXk4Xs6dDl_4CByB4Ow" ],
+                "addsrcrecordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_wiley" ],
                 "galeid" : [ "A491502847" ],
-                "score" : [ "0.06524447" ]
+                "score" : [ "0.06524757" ]
               },
               "addata" : {
                 "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
@@ -599,7 +601,7 @@ http_interactions:
                 "creationdate" : [ "2017" ],
                 "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
                 "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpHgdO3aOUcWjUqFCpefIdZzWkNiREx7lB_ht3JYLu4dd7eyOZgehayATiHGjvXUToETCCRoBy0QiM0ZO0YhIyhKRp_wcXfT9KyEEUiZH6GfWdsF_WLfBw9bgudeqwUujgt7iYm0bO-ywr_Gys5UJ-NG7N7PDi26wrf1Wg_UOF83GBztsW7zq9zTP76oKEdK46CL1l22Pe7UPeOW0d_0QlHWm-kdzic5q1fTm6q-O0eru9mX6kMwX97NpMU-AZlQmLNdVTSThGRVgqkoLJgUHZrjUGaTxP2aIrowwUqxrlTFQuc45ZVxLoMDTMZoceTeqMaV1tY9qdMzKtDaKM7WN84LlwAmVTMQDOB58RmBXdiH-E3YlkHJveLk3vDwYXk4Xs6dDl_4CByB4Ow" ],
+                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
                 "recordtype" : [ "article" ],
                 "scope" : [ "BSHEE" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
@@ -640,7 +642,7 @@ http_interactions:
                 "prefilter" : [ "articles" ],
                 "collection" : [ "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12628-49cdf08056271eddc7487514e58c6139354e0cde7e87bfa641a9c95245c812153" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Computational intelligence" ]
               }
@@ -660,7 +662,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -672,586 +674,16 @@ http_interactions:
               "timesCited" : { }
             },
             "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A491502847"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "20181110" ],
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "author" : [ "Kumar, Sandeep ; Sharma, Basudev ; Sharma, Vivek Kumar ; Poonia, Ramesh C" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1007_s12065_018_0186_9" ],
-                "sourcerecordid" : [ "10_1007_s12065_018_0186_9" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9kMtOwzAURC0EEqXwAez8A4brPPxYVhUvqRKb7oNr36SGJo5sZ1G-npQiFqOZxdyr0SHknsMDB5CPiRcgagZcnSSYviCL2StWay4v_zPoa3KT0ieAKEBWC_KxmnLoTUZHU_AHOkZ03mYfBjolP3R0ZzoWWtaiyVPERM3gqN2bkL2lafQOI-3D8IVHGsbse_9tfo_NoQvR531_S65ac0h49-dLsn1-2q5f2eb95W292jArBLB5_Q41OgG8BCm1MbYulNOysK6uSmi1U4XSysytVmoUmheItuKqdkraslwSfn5rY0gpYtuM0fcmHhsOzYlQcybUzHROEo0ufwArd1st" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.06390624" ]
-              },
-              "addata" : {
-                "orcidid" : [ "https://orcid.org/0000-0001-8054-2405" ],
-                "issn" : [ "1864-5909" ],
-                "jtitle" : [ "Evolutionary intelligence" ],
-                "genre" : [ "article" ],
-                "au" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "atitle" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "date" : [ "2018-11-10" ],
-                "risdate" : [ "2018" ],
-                "eissn" : [ "1864-5917" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1007/s12065-018-0186-9" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm", "Evolutionary intelligence" ],
-                "creator" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "recordid" : [ "eNo9kMtOwzAURC0EEqXwAez8A4brPPxYVhUvqRKb7oNr36SGJo5sZ1G-npQiFqOZxdyr0SHknsMDB5CPiRcgagZcnSSYviCL2StWay4v_zPoa3KT0ieAKEBWC_KxmnLoTUZHU_AHOkZ03mYfBjolP3R0ZzoWWtaiyVPERM3gqN2bkL2lafQOI-3D8IVHGsbse_9tfo_NoQvR531_S65ac0h49-dLsn1-2q5f2eb95W292jArBLB5_Q41OgG8BCm1MbYulNOysK6uSmi1U4XSysytVmoUmheItuKqdkraslwSfn5rY0gpYtuM0fcmHhsOzYlQcybUzHROEo0ufwArd1st" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "orcidid" : [ "https://orcid.org/0000-0001-8054-2405" ],
-                "issn" : [ "1864-5909", "1864-5917" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20181110" ],
-                "enddate" : [ "20181110" ]
-              },
-              "display" : {
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "ispartof" : [ "Evolutionary intelligence, 2018-11-10" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Kumar, Sandeep ; Sharma, Basudev ; Sharma, Vivek Kumar ; Poonia, Ramesh C" ],
-                "identifier" : [ "ISSN: 1864-5909", "EISSN: 1864-5917", "DOI: 10.1007/s12065-018-0186-9" ],
-                "language" : [ "eng" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2018" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Evolutionary intelligence" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Automated+soil+prediction+using+bag-of-features+and+chaotic+spider+monkey+optimization+algorithm&rft.jtitle=Evolutionary+intelligence&rft.au=Kumar%2C+Sandeep&rft.date=2018-11-10&rft.issn=1864-5909&rft.eissn=1864-5917&rft_id=info:doi/10.1007%2Fs12065-018-0186-9&rft_dat=<crossref>10_1007_s12065_018_0186_9</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1007_s12065_018_0186_9"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "201705" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1111_coin_12081" ],
-                "sourcerecordid" : [ "10_1111_coin_12081" ],
-                "originalsourceid" : [ "FETCH-crossref_primary_10_1111_coin_120813" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqVj81KxDAUhYMoWH82PsFdCx2TaZ2pyyKKA4rIOOsS03R6tc0NN1GsL-Br26obl57NWZzDB58QJ0rO1JgzQ-hmai4LtSMSlS-WabHI5a5IZDHP0-VFdr4vDkJ4llKqLC8S8bnqPdMbui3E1sItGd3B2mo2LZRP2GEcgBpYe6wtwx25FzvAvY_Y44eOSA7KbkuMse1hEybMw6uueZwMlH5Ev2P_82uIYeMMuRBZo7P1H8yR2Gt0F-zxbx-K0-urx8ub1DCFwLapPI8kHiolq0m1mlSrb9XsX-cvLItezw" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.063295685" ]
-              },
-              "addata" : {
-                "issn" : [ "0824-7935" ],
-                "jtitle" : [ "Computational intelligence" ],
-                "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "date" : [ "2017-05" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "33" ],
-                "issue" : [ "2" ],
-                "spage" : [ "210" ],
-                "epage" : [ "240" ],
-                "pages" : [ "210-240" ],
-                "eissn" : [ "1467-8640" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1111/coin.12081" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization: Improving the Local Search Ability of SMO Using QA", "Computational intelligence" ],
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNqVj81KxDAUhYMoWH82PsFdCx2TaZ2pyyKKA4rIOOsS03R6tc0NN1GsL-Br26obl57NWZzDB58QJ0rO1JgzQ-hmai4LtSMSlS-WabHI5a5IZDHP0-VFdr4vDkJ4llKqLC8S8bnqPdMbui3E1sItGd3B2mo2LZRP2GEcgBpYe6wtwx25FzvAvY_Y44eOSA7KbkuMse1hEybMw6uueZwMlH5Ev2P_82uIYeMMuRBZo7P1H8yR2Gt0F-zxbx-K0-urx8ub1DCFwLapPI8kHiolq0m1mlSrb9XsX-cvLItezw" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "issn" : [ "0824-7935", "1467-8640" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201705" ],
-                "enddate" : [ "201705" ]
-              },
-              "display" : {
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization: Improving the Local Search Ability of SMO Using QA" ],
-                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
-                "language" : [ "eng" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2017" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-crossref_primary_10_1111_coin_120813" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Computational intelligence" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft_dat=<crossref>10_1111_coin_12081</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-crossref_primary_10_1111_coin_120813" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1111_coin_12081"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "author" : [ "Rani, R. Ranjani ; Ramyachitra, D" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2018_10_358" ],
-                "sourcerecordid" : [ "S1877050918320544" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12543-474d325cb71cf555026d88971220a31edb4874af4b7851318ba89a8602647b53" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kMFOAjEQhhujiQR5Ai99gV3bbUvLwQPZCJpAOIBem27bxeKyu2kXDTy9hdXEk3OZyeT__8x8ANxjlGKExw-7tPWNDmmGsIiblDBxBQZYcJ4ghibXf-ZbMAphh2IRISaYD8DX0mnfKO_VEeaq1tbDua0tnFnVHbyFa1tZ3bmmhq_B1Vu4bp2JmmVTf9gjXLWd27uTugim1bbxrnvfQ1Wb37C8UiG40ulec-hD3pZ34KZUVbCjnz4Em9nTJn9OFqv5Sz5dJDhjlCSUU0MypguOdckYQ9nYxMs5zjKkCLamoIJTVdKCC4YJFoUSEyXGUUd5wcgQkD42PhmCt6Vsvdsrf5QYyTM9uZMXevJM77yM9KLrsXfZeNmns14G7Wz8xzgfaUjTuH_93z-BedI" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06325995" ]
-              },
-              "addata" : {
-                "abstract" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ],
-                "issn" : [ "1877-0509" ],
-                "oa" : [ "free_for_read" ],
-                "jtitle" : [ "Procedia computer science" ],
-                "genre" : [ "article" ],
-                "au" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "atitle" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "date" : [ "2018" ],
-                "risdate" : [ "2018" ],
-                "volume" : [ "143" ],
-                "spage" : [ "108" ],
-                "epage" : [ "116" ],
-                "pages" : [ "108-116" ],
-                "eissn" : [ "1877-0509" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.procs.2018.10.358" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM", "Procedia computer science" ],
-                "creator" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "recordid" : [ "eNp9kMFOAjEQhhujiQR5Ai99gV3bbUvLwQPZCJpAOIBem27bxeKyu2kXDTy9hdXEk3OZyeT__8x8ANxjlGKExw-7tPWNDmmGsIiblDBxBQZYcJ4ghibXf-ZbMAphh2IRISaYD8DX0mnfKO_VEeaq1tbDua0tnFnVHbyFa1tZ3bmmhq_B1Vu4bp2JmmVTf9gjXLWd27uTugim1bbxrnvfQ1Wb37C8UiG40ulec-hD3pZ34KZUVbCjnz4Em9nTJn9OFqv5Sz5dJDhjlCSUU0MypguOdckYQ9nYxMs5zjKkCLamoIJTVdKCC4YJFoUSEyXGUUd5wcgQkD42PhmCt6Vsvdsrf5QYyTM9uZMXevJM77yM9KLrsXfZeNmns14G7Wz8xzgfaUjTuH_93z-BedI" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "issn" : [ "1877-0509", "1877-0509" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2018" ],
-                "enddate" : [ "2018" ],
-                "subject" : [ "Feature Selection ; Spider Monkey Optimization ; Support Vector Machine ; Microarray Cancer Gene Expression ; Classification" ],
-                "description" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ]
-              },
-              "display" : {
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia computer science, 2018, Vol.143, p.108-116" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Rani, R. Ranjani ; Ramyachitra, D" ],
-                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2018.10.358" ],
-                "subject" : [ "Feature Selection ; Spider Monkey Optimization ; Support Vector Machine ; Microarray Cancer Gene Expression ; Classification" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2018" ],
-                "snippet" : [ ".... This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2018" ],
-                "creatorcontrib" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "topic" : [ "Feature Selection", "Spider Monkey Optimization", "Support Vector Machine", "Microarray Cancer Gene Expression", "Classification" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12543-474d325cb71cf555026d88971220a31edb4874af4b7851318ba89a8602647b53" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Procedia computer science" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Microarray+Cancer+Gene+Feature+Selection+Using+Spider+Monkey+Optimization+Algorithm+and+Cancer+Classification+using+SVM&rft.jtitle=Procedia+computer+science&rft.au=Rani%2C+R.+Ranjani&rft.date=2018&rft.volume=143&rft.spage=108&rft.epage=116&rft.pages=108-116&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2018.10.358&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050918320544</elsevier_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procs_2018_10_358"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "author" : [ "Wang, Zhengya ; Mumtaz, Jabir ; Zhang, Li ; Yue, Lei" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procir_2019_04_075" ],
-                "sourcerecordid" : [ "S2212827119306894" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-11931-c3017c05527bd0c3917682dfc02eaf53beddcf0fcc23b1b8ca88b9cc032c1d383" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kE1LxDAQhoMouKz7DzzkD7Tmo922F2Fd_IKVFdRzSCfJmrVpQlIW1l9vl3rw5FxmYOZ9GB6ErinJKaHLm30eogcbc0Zok5MiJ1V5hmaMUZbVrKLnf-ZLtEhpT8aqCsIpm6GwCqGzIAfre-wNlj22bgQetMJvwSod8Yvvv_QRb8Ngnf2eLmW389EOnw4bHzF4F3yv-wHLlOyud6dxhLSddtj2-HV9d9po13bHK3RhZJf04rfP0cfD_fv6KdtsH5_Xq01GacNpBpzQCkhZsqpVBHhDq2XNlAHCtDQlb7VSYIgBYLylbQ2yrtsGgHAGVPGaz1ExcSH6lKI2IkTrZDwKSsRJnNiLSZw4iROkEKO4MXY7xfT428HqKBJY3YNWNmoYhPL2f8APZyB7eQ" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06181559" ]
-              },
-              "addata" : {
-                "abstract" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ],
-                "issn" : [ "2212-8271" ],
-                "oa" : [ "free_for_read" ],
-                "jtitle" : [ "Procedia CIRP" ],
-                "genre" : [ "article" ],
-                "au" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "atitle" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "date" : [ "2019" ],
-                "risdate" : [ "2019" ],
-                "volume" : [ "83" ],
-                "spage" : [ "266" ],
-                "epage" : [ "271" ],
-                "pages" : [ "266-271" ],
-                "eissn" : [ "2212-8271" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.procir.2019.04.075" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly", "Procedia CIRP" ],
-                "creator" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "recordid" : [ "eNp9kE1LxDAQhoMouKz7DzzkD7Tmo922F2Fd_IKVFdRzSCfJmrVpQlIW1l9vl3rw5FxmYOZ9GB6ErinJKaHLm30eogcbc0Zok5MiJ1V5hmaMUZbVrKLnf-ZLtEhpT8aqCsIpm6GwCqGzIAfre-wNlj22bgQetMJvwSod8Yvvv_QRb8Ngnf2eLmW389EOnw4bHzF4F3yv-wHLlOyud6dxhLSddtj2-HV9d9po13bHK3RhZJf04rfP0cfD_fv6KdtsH5_Xq01GacNpBpzQCkhZsqpVBHhDq2XNlAHCtDQlb7VSYIgBYLylbQ2yrtsGgHAGVPGaz1ExcSH6lKI2IkTrZDwKSsRJnNiLSZw4iROkEKO4MXY7xfT428HqKBJY3YNWNmoYhPL2f8APZyB7eQ" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "issn" : [ "2212-8271", "2212-8271" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2019" ],
-                "enddate" : [ "2019" ],
-                "subject" : [ "Printed circuit board assembly ; component assignment ; Spider Monkey Optimizaton algorithm ; Product Services" ],
-                "description" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ]
-              },
-              "display" : {
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia CIRP, 2019, Vol.83, p.266-271" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Wang, Zhengya ; Mumtaz, Jabir ; Zhang, Li ; Yue, Lei" ],
-                "identifier" : [ "ISSN: 2212-8271", "EISSN: 2212-8271", "DOI: 10.1016/j.procir.2019.04.075" ],
-                "subject" : [ "Printed circuit board assembly ; component assignment ; Spider Monkey Optimizaton algorithm ; Product Services" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2019" ],
-                "snippet" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm,..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "creatorcontrib" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "topic" : [ "Printed circuit board assembly", "component assignment", "Spider Monkey Optimizaton algorithm", "Product Services" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-11931-c3017c05527bd0c3917682dfc02eaf53beddcf0fcc23b1b8ca88b9cc032c1d383" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Procedia CIRP" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Application+of+an+improved+Spider+Monkey+Optimization+algorithm+for+component+assignment+problem+in+PCB+assembly&rft.jtitle=Procedia+CIRP&rft.au=Wang%2C+Zhengya&rft.date=2019&rft.volume=83&rft.spage=266&rft.epage=271&rft.pages=266-271&rft.issn=2212-8271&rft.eissn=2212-8271&rft_id=info:doi/10.1016%2Fj.procir.2019.04.075&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S2212827119306894</elsevier_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procir_2019_04_075"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "20190517" ],
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "author" : [ "Singh, Prabhat Ranjan ; Moussa, Diallo ; Shengwu, Xiong ; Singh, Bikram Prasad" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_17993_3ctecno_2019_specialissue2_142_165" ],
-                "sourcerecordid" : [ "10_17993_3ctecno_2019_specialissue2_142_165" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-11175-cb627af98509b03c0bafd2258f677e62e309ace951edb8e3cc2237a2e128afe03" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpV0EtLAzEUBeAgCpba_5C9zJibzCvLUnwUWio-1iGTudHozGRIRqH-esfaha7uWVwOh4-QS2AplFKKK2FGNL1POQOZxgGN062L8QN5ChlPoMhPyIzzPEsyyMTpn3xOFjG-McaAgxQcZuRh3Q3Bf2JDHwfXYKBb37_jnu6G0XXuS4_O93TZvvjgxteOjp6OQbuebjf31PpAGz1qalodo7POHN4vyJnVbcTF8c7J88310-ou2exu16vlJgGAMk9MXfBSW1nlTNZMGFZr20xLK1uUJRYcBZPaoMwBm7pCYQznotQcgVfaIhNzsvrtNcHHGNCqIbhOh70Cpg5S6iilfqTUPyk1SalJSnwDyHhlLA" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.051464017" ]
-              },
-              "addata" : {
-                "issn" : [ "2254-4143" ],
-                "jtitle" : [ "3C tecnología" ],
-                "genre" : [ "article" ],
-                "au" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "atitle" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "date" : [ "2019-05-17" ],
-                "risdate" : [ "2019" ],
-                "spage" : [ "142" ],
-                "epage" : [ "165" ],
-                "pages" : [ "142-165" ],
-                "eissn" : [ "2254-4143" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.17993/3ctecno.2019.specialissue2.142-165" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification", "3C tecnología" ],
-                "creator" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "recordid" : [ "eNpV0EtLAzEUBeAgCpba_5C9zJibzCvLUnwUWio-1iGTudHozGRIRqH-esfaha7uWVwOh4-QS2AplFKKK2FGNL1POQOZxgGN062L8QN5ChlPoMhPyIzzPEsyyMTpn3xOFjG-McaAgxQcZuRh3Q3Bf2JDHwfXYKBb37_jnu6G0XXuS4_O93TZvvjgxteOjp6OQbuebjf31PpAGz1qalodo7POHN4vyJnVbcTF8c7J88310-ou2exu16vlJgGAMk9MXfBSW1nlTNZMGFZr20xLK1uUJRYcBZPaoMwBm7pCYQznotQcgVfaIhNzsvrtNcHHGNCqIbhOh70Cpg5S6iilfqTUPyk1SalJSnwDyHhlLA" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "issn" : [ "2254-4143", "2254-4143" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20190517" ],
-                "enddate" : [ "20190517" ]
-              },
-              "display" : {
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "ispartof" : [ "3C tecnología, 2019-05-17, p.142-165" ],
-                "type" : [ "article" ],
-                "source" : [ "Publicly Available Content Database", "Alma/SFX Local Collection" ],
-                "creator" : [ "Singh, Prabhat Ranjan ; Moussa, Diallo ; Shengwu, Xiong ; Singh, Bikram Prasad" ],
-                "identifier" : [ "ISSN: 2254-4143", "EISSN: 2254-4143", "DOI: 10.17993/3ctecno.2019.specialissue2.142-165" ],
-                "language" : [ "eng" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "creatorcontrib" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-11175-cb627af98509b03c0bafd2258f677e62e309ace951edb8e3cc2237a2e128afe03" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "3C tecnología" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improved+Spider+Monkey+Optimization+Algorithm+to+train+MLP+for+data+classification&rft.jtitle=3C+tecnolog%C3%ADa&rft.au=Singh%2C+Prabhat+Ranjan&rft.date=2019-05-17&rft.spage=142&rft.epage=165&rft.pages=142-165&rft.issn=2254-4143&rft.eissn=2254-4143&rft_id=info:doi/10.17993%2F3ctecno.2019.specialissue2.142-165&rft_dat=<crossref>10_17993_3ctecno_2019_specialissue2_142_165</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_17993_3ctecno_2019_specialissue2_142_165"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "174",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "100",
-            "PC_SEARCH_TIME_TOTAL" : "274",
+            "PC_SEARCH_CALL_TIME" : "939",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "36",
+            "PC_SEARCH_TIME_TOTAL" : "976",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 0,
-            "COMBINED_SEARCH_TIME" : 6,
+            "BUILD_COMBINED_RESULTS_MAP" : 977,
+            "COMBINED_SEARCH_TIME" : 982,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 0
+            "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ {
             "name" : "jtitle",
@@ -1290,36 +722,36 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "78"
+              "count" : "82"
             } ]
           }, {
             "name" : "topic",
             "values" : [ {
               "value" : "Algorithms",
-              "count" : "40"
+              "count" : "43"
             }, {
               "value" : "Science & Technology",
-              "count" : "33"
+              "count" : "35"
             }, {
               "value" : "Engineering",
-              "count" : "31"
+              "count" : "33"
             }, {
               "value" : "Optimization",
-              "count" : "30"
+              "count" : "33"
             }, {
               "value" : "Technology",
-              "count" : "30"
+              "count" : "32"
+            }, {
+              "value" : "Mathematical Optimization",
+              "count" : "18"
             }, {
               "value" : "Swarm Intelligence",
+              "count" : "17"
+            }, {
+              "value" : "Monkeys",
               "count" : "16"
             }, {
               "value" : "Computer Science",
-              "count" : "15"
-            }, {
-              "value" : "Mathematical Optimization",
-              "count" : "15"
-            }, {
-              "value" : "Monkeys",
               "count" : "15"
             }, {
               "value" : "Optimization Algorithms",
@@ -1328,17 +760,17 @@ http_interactions:
               "value" : "Spider Monkey Optimization",
               "count" : "14"
             }, {
+              "value" : "Engineering, Electrical & Electronic",
+              "count" : "13"
+            }, {
               "value" : "Optimierungsalgorithmus",
               "count" : "13"
             }, {
-              "value" : "Engineering, Electrical & Electronic",
+              "value" : "Analysis",
               "count" : "12"
             }, {
               "value" : "Artificial Intelligence",
               "count" : "11"
-            }, {
-              "value" : "Analysis",
-              "count" : "10"
             }, {
               "value" : "Computational Intelligence",
               "count" : "10"
@@ -1347,19 +779,19 @@ http_interactions:
               "count" : "10"
             }, {
               "value" : "Physical Sciences",
-              "count" : "9"
+              "count" : "10"
+            }, {
+              "value" : "Genetic Algorithms",
+              "count" : "8"
             }, {
               "value" : "Optimierungsproblem",
               "count" : "8"
-            }, {
-              "value" : "Computer Science, Artificial Intelligence",
-              "count" : "7"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "articles",
-              "count" : "50"
+              "count" : "54"
             }, {
               "value" : "book_chapters",
               "count" : "12"
@@ -1377,31 +809,40 @@ http_interactions:
             "name" : "domain",
             "values" : [ {
               "value" : "Advanced Technologies & Aerospace Collection",
-              "count" : "25"
+              "count" : "28"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "24"
+              "count" : "26"
             }, {
               "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
-              "count" : "19"
+              "count" : "20"
             }, {
               "value" : "SpringerLink Contemporary (1997 - Present)",
-              "count" : "18"
+              "count" : "19"
             }, {
               "value" : "Publicly Available Content Database",
-              "count" : "14"
+              "count" : "16"
             }, {
               "value" : "ABI/INFORM Collection",
+              "count" : "14"
+            }, {
+              "value" : "Academic Search Complete",
               "count" : "13"
             }, {
               "value" : "Ebook Central Perpetual and DDA",
               "count" : "12"
             }, {
-              "value" : "Academic Search Complete",
-              "count" : "11"
-            }, {
               "value" : "Springer Book Series",
               "count" : "9"
+            }, {
+              "value" : "Wiley Online Library All Journals",
+              "count" : "8"
+            }, {
+              "value" : "Wiley Online Library Journals + OA Offset 2015-2017",
+              "count" : "8"
+            }, {
+              "value" : "Wiley Online Library Full Collection 2016",
+              "count" : "8"
             }, {
               "value" : "SpringerLink ebooks - Engineering (Contemporary)",
               "count" : "7"
@@ -1409,7 +850,7 @@ http_interactions:
               "value" : "SpringerLink ebooks - Engineering (Archive and Contemporary)",
               "count" : "7"
             }, {
-              "value" : "Wiley Online Library All Journals",
+              "value" : "Wiley Online Library All Backfiles",
               "count" : "6"
             }, {
               "value" : "Journals Consult",
@@ -1421,19 +862,10 @@ http_interactions:
               "value" : "ScienceDirect Journals (Transactional Access)",
               "count" : "6"
             }, {
-              "value" : "Wiley Online Library Journals + OA Offset 2015-2017",
-              "count" : "6"
-            }, {
               "value" : "Factiva",
               "count" : "6"
             }, {
-              "value" : "Wiley Online Library Full Collection 2016",
-              "count" : "6"
-            }, {
-              "value" : "Wiley Online Library All Backfiles",
-              "count" : "5"
-            }, {
-              "value" : "SpringerLINK Archive - Computer Science",
+              "value" : "Agricultural & Environmental Science Collection",
               "count" : "5"
             } ]
           }, {
@@ -1443,19 +875,19 @@ http_interactions:
               "count" : "22"
             }, {
               "value" : "peer_reviewed",
-              "count" : "43"
+              "count" : "45"
             }, {
               "value" : "online_resources",
-              "count" : "78"
+              "count" : "82"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "30 days back",
-              "count" : "1"
+              "count" : "2"
             }, {
               "value" : "90 days back",
-              "count" : "4"
+              "count" : "5"
             } ]
           }, {
             "name" : "creationdate",
@@ -1479,12 +911,12 @@ http_interactions:
               "count" : "12"
             }, {
               "value" : "2020",
-              "count" : "18"
+              "count" : "20"
             }, {
               "value" : "2021",
-              "count" : "11"
+              "count" : "15"
             } ]
           } ]
         }
-  recorded_at: Mon, 10 May 2021 15:48:04 GMT
+  recorded_at: Mon, 17 May 2021 15:18:51 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/no_results_primo.yml
+++ b/test/vcr_cassettes/no_results_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcornandorangejuice&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcornandorangejuice&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       X-Exl-Api-Remaining:
-      - '549959'
+      - '549997'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -33,9 +33,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '517'
+      - '521'
       Date:
-      - Thu, 29 Apr 2021 19:24:17 GMT
+      - Mon, 17 May 2021 15:06:03 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -52,16 +52,16 @@ http_interactions:
           "highlights" : { },
           "docs" : [ ],
           "timelog" : {
-            "CALL_SOLR_GET_IDS_LIST" : "64",
+            "CALL_SOLR_GET_IDS_LIST" : "887",
             "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "0",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "72",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "892",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 73,
-            "COMBINED_SEARCH_TIME" : 75,
+            "BUILD_COMBINED_RESULTS_MAP" : 894,
+            "COMBINED_SEARCH_TIME" : 897,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 0
+            "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Thu, 29 Apr 2021 19:24:18 GMT
+  recorded_at: Mon, 17 May 2021 15:06:03 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/physical_book_primo.yml
+++ b/test/vcr_cassettes/physical_book_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549995'
+      - '549994'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -35,9 +35,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '7911'
+      - '7953'
       Date:
-      - Fri, 30 Apr 2021 20:05:30 GMT
+      - Mon, 17 May 2021 15:06:26 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -90,7 +90,7 @@ http_interactions:
                 "originalsourceid" : [ "001349272-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.020787686" ]
+                "score" : [ "0.020869972" ]
               },
               "addata" : {
                 "aulast" : [ "Barsky" ],
@@ -195,6 +195,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -231,24 +232,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "13",
-            "CALL_SOLR_GET_IDS_LIST" : "5734",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "329",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "2",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
-            "RETRIVE_FROM_DB_RECORDS" : "7",
-            "RETRIVE_FROM_DB_RELATIONS" : "1",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "293",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "36",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "61",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "6157",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "280",
+            "CALL_SOLR_GET_IDS_LIST" : "2693",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "396",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "147",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "39",
+            "RETRIVE_FROM_DB_RECORDS" : "74",
+            "RETRIVE_FROM_DB_RELATIONS" : "17",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "197",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "199",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "125",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "3511",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 6211,
-            "COMBINED_SEARCH_TIME" : 6215,
+            "BUILD_COMBINED_RESULTS_MAP" : 0,
+            "COMBINED_SEARCH_TIME" : 3,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 0
+            "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Fri, 30 Apr 2021 20:05:30 GMT
+  recorded_at: Mon, 17 May 2021 15:06:26 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo.yml
+++ b/test/vcr_cassettes/popcorn_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549993'
+      - '549996'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Fri, 30 Apr 2021 20:23:46 GMT
+      - Mon, 17 May 2021 15:06:06 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -49,7 +49,7 @@ http_interactions:
             "totalResultsPC" : -1,
             "total" : 132,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "description" : [ "POPCORN" ],
@@ -86,7 +86,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "2.9350756E-4" ]
+                "score" : [ "2.950539E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -186,6 +186,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -246,7 +247,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573078" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -288,6 +289,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -326,7 +328,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573061" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -368,6 +370,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -406,7 +409,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573073" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -448,6 +451,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -486,7 +490,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573053" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
+                "score" : [ "5.586844E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -528,406 +532,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723106761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723106761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723106761" ],
-                "recordid" : [ "alma9933019723106761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573064" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573064" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Ireland" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9064624205021560521" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721206761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019721206761" ],
-                "recordid" : [ "alma9933019721206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573079" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573079" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: the Netherlands" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9013384081808631136" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724706761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724706761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019724706761" ],
-                "recordid" : [ "alma9933019724706761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573048" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573048" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Asia-Pacific" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9070104524867762023" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722806761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722806761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019722806761" ],
-                "recordid" : [ "alma9933019722806761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573067" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573067" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Mexico" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9050063563168056425" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723906761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723906761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723906761" ],
-                "recordid" : [ "alma9933019723906761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573056" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.553539E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573056" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Europe" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9061988140408692301" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -947,24 +552,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "93",
-            "CALL_SOLR_GET_IDS_LIST" : "351",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "483",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "53",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "3",
-            "RETRIVE_FROM_DB_RECORDS" : "28",
-            "RETRIVE_FROM_DB_RELATIONS" : "3",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "237",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "246",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "350",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "1292",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "513",
+            "CALL_SOLR_GET_IDS_LIST" : "1051",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "977",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "169",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "84",
+            "RETRIVE_FROM_DB_RECORDS" : "232",
+            "RETRIVE_FROM_DB_RELATIONS" : "24",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "499",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "478",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "334",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "2890",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 1329,
-            "COMBINED_SEARCH_TIME" : 1334,
+            "BUILD_COMBINED_RESULTS_MAP" : 2912,
+            "COMBINED_SEARCH_TIME" : 2916,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 0
+            "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Fri, 30 Apr 2021 20:23:46 GMT
+  recorded_at: Mon, 17 May 2021 15:06:07 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo_articles.yml
+++ b/test/vcr_cassettes/popcorn_primo_articles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549999'
+      - '549996'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Fri, 16 Apr 2021 14:42:13 GMT
+      - Mon, 17 May 2021 15:06:14 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,10 +46,10 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 131890,
-            "total" : 131890,
+            "totalResultsPC" : 132266,
+            "total" : 132266,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "snippet" : [ "popcorn" ],
@@ -59,76 +59,76 @@ http_interactions:
           "docs" : [ {
             "pnx" : {
               "sort" : {
-                "title" : [ "Popcorn" ],
-                "creationdate" : [ "201611" ]
+                "creationdate" : [ "201611" ],
+                "title" : [ "Popcorn" ]
               },
               "control" : {
                 "recordid" : [ "cdi_crossref_primary_10_1088_2058_7058_29_11_46" ],
                 "sourcerecordid" : [ "10_1088_2058_7058_29_11_46" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c790-4ffb71fa678ae1427e5c8fc4dc8faddf186b598d2c7bf03781c03b21824f685e3" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9j8tKBDEQRQtRtB39Af8hdlWelaUMvmBAF7MP6XQKFLWHZOXfO43i5ly4i8u5ADeEt4TMo0bHKhwx6jgSjdafwPBfnsKA0RnFjt0FXPb-jkjeshvg_HU5lKV9XcGZ5I9er_9yA_uH-_32Se1eHp-3dztVQkRlRaZAkn3gXMnqUF1hKXY-Ms-zEPvJRZ51CZOgCUwFzaSJtRXPrpoN6N_Z0pbeW5V0aG-fuX0nwrQ-Sat0WqWTjokoWW9-AAIdOhI" ],
+                "addsrcrecordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "crossref" ],
-                "score" : [ "0.0218413" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "title" : [ "Popcorn", "Physics world" ],
-                "creationdate" : [ "2016" ],
-                "recordid" : [ "eNo9j8tKBDEQRQtRtB39Af8hdlWelaUMvmBAF7MP6XQKFLWHZOXfO43i5ly4i8u5ADeEt4TMo0bHKhwx6jgSjdafwPBfnsKA0RnFjt0FXPb-jkjeshvg_HU5lKV9XcGZ5I9er_9yA_uH-_32Se1eHp-3dztVQkRlRaZAkn3gXMnqUF1hKXY-Ms-zEPvJRZ51CZOgCUwFzaSJtRXPrpoN6N_Z0pbeW5V0aG-fuX0nwrQ-Sat0WqWTjokoWW9-AAIdOhI" ],
-                "recordtype" : [ "article" ],
-                "rsrctype" : [ "article" ],
-                "issn" : [ "0953-8585", "2058-7058" ],
-                "fulltext" : [ "true" ],
-                "startdate" : [ "201611" ],
-                "enddate" : [ "201611" ],
-                "scope" : [ "CITATION", "AAYXX" ]
-              },
-              "display" : {
-                "title" : [ "Popcorn" ],
-                "language" : [ "eng" ],
-                "source" : [ "Alma/SFX Local Collection" ],
-                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
-                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.021811698" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
+                "issn" : [ "0953-8585" ],
                 "jtitle" : [ "Physics world" ],
                 "genre" : [ "article" ],
-                "issn" : [ "0953-8585" ],
-                "pages" : [ "42-42" ],
-                "eissn" : [ "2058-7058" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1088/2058-7058/29/11/46" ],
                 "atitle" : [ "Popcorn" ],
                 "date" : [ "2016-11" ],
                 "risdate" : [ "2016" ],
                 "volume" : [ "29" ],
                 "issue" : [ "11" ],
                 "spage" : [ "42" ],
-                "epage" : [ "42" ]
+                "epage" : [ "42" ],
+                "pages" : [ "42-42" ],
+                "eissn" : [ "2058-7058" ],
+                "ristype" : [ "JOUR" ],
+                "doi" : [ "10.1088/2058-7058/29/11/46" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2016" ],
+                "title" : [ "Popcorn", "Physics world" ],
+                "recordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "AAYXX", "CITATION" ],
+                "issn" : [ "0953-8585", "2058-7058" ],
+                "fulltext" : [ "true" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "201611" ],
+                "enddate" : [ "201611" ]
+              },
+              "display" : {
+                "title" : [ "Popcorn" ],
+                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
+                "type" : [ "article" ],
+                "source" : [ "Alma/SFX Local Collection" ],
+                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
+                "language" : [ "eng" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2016" ],
+                "rsrctype" : [ "articles" ],
                 "language" : [ "eng" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c790-4ffb71fa678ae1427e5c8fc4dc8faddf186b598d2c7bf03781c03b21824f685e3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Physics world" ]
               }
@@ -148,7 +148,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -163,79 +163,29 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Baryonic popcorn" ],
                 "creationdate" : [ "201211" ],
+                "title" : [ "Baryonic popcorn" ],
                 "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ]
               },
               "control" : {
                 "recordid" : [ "cdi_crossref_primary_10_1007_JHEP11_2012_047" ],
                 "sourcerecordid" : [ "2398248625" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpNjz1PwzAQhi0EEqUgsbEiscAQeuePOB6hKhRUCQaYrTg5o1YQB5sO_Pu6pAKme6V77uNh7AzhGgH05HE-e0a85ID8CqTeYyMEbopKarP_Lx-yo5RWAKjQwIid3tbxO3TL5rwPfRNid8wOfP2e6GRXx-z1bvYynReLp_uH6c2iQKEqXZi29kpgKR2RB1VRq8gZjs7ItjayBu2JK1U6jlxIqZByg6rSee6MQRJjdjHs7WP4XFP6squwjl0-abkwFZdVyVWmJgPVxJBSJG_7uPzIL1sEu9W2g7bdatus_TeRMtm9Ufyd-EFQoIBdRKtAo9gAAc1WHw" ],
+                "addsrcrecordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2398248625" ],
-                "score" : [ "0.020163124" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
-                "creationdate" : [ "2012" ],
-                "recordid" : [ "eNpNjz1PwzAQhi0EEqUgsbEiscAQeuePOB6hKhRUCQaYrTg5o1YQB5sO_Pu6pAKme6V77uNh7AzhGgH05HE-e0a85ID8CqTeYyMEbopKarP_Lx-yo5RWAKjQwIid3tbxO3TL5rwPfRNid8wOfP2e6GRXx-z1bvYynReLp_uH6c2iQKEqXZi29kpgKR2RB1VRq8gZjs7ItjayBu2JK1U6jlxIqZByg6rSee6MQRJjdjHs7WP4XFP6squwjl0-abkwFZdVyVWmJgPVxJBSJG_7uPzIL1sEu9W2g7bdatus_TeRMtm9Ufyd-EFQoIBdRKtAo9gAAc1WHw" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
-                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "issn" : [ "1029-8479", "1029-8479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "J. High Energ. Phys" ],
-                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
-                "startdate" : [ "201211" ],
-                "enddate" : [ "201211" ],
-                "scope" : [ "CITATION", "AAYXX", "AZQEC", "PQEST", "ARAPS", "P62", "BENPR", "DWQXO", "P5Z", "PIMPY", "HCIFZ", "8FE", "ABUWG", "BGLVJ", "8FG", "PQQKQ", "PQUKI" ]
-              },
-              "display" : {
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "title" : [ "Baryonic popcorn" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
-                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
-                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
-                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
-                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.020141866" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
+                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "issn" : [ "1029-8479" ],
+                "oa" : [ "free_for_read" ],
                 "jtitle" : [ "The journal of high energy physics" ],
                 "genre" : [ "article" ],
-                "issn" : [ "1029-8479" ],
-                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "pages" : [ "1-85" ],
-                "eissn" : [ "1029-8479" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Berlin/Heidelberg" ],
-                "pub" : [ "Springer-Verlag" ],
-                "doi" : [ "10.1007/JHEP11(2012)047" ],
                 "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
                 "atitle" : [ "Baryonic popcorn" ],
                 "stitle" : [ "J. High Energ. Phys" ],
@@ -245,18 +195,68 @@ http_interactions:
                 "issue" : [ "11" ],
                 "spage" : [ "1" ],
                 "epage" : [ "85" ],
-                "oa" : [ "free_for_read" ]
+                "pages" : [ "1-85" ],
+                "eissn" : [ "1029-8479" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Berlin/Heidelberg" ],
+                "pub" : [ "Springer-Verlag" ],
+                "doi" : [ "10.1007/JHEP11(2012)047" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2012" ],
+                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
+                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
+                "recordtype" : [ "article" ],
+                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
+                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ],
+                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "issn" : [ "1029-8479", "1029-8479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "J. High Energ. Phys" ],
+                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "201211" ],
+                "enddate" : [ "201211" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
+              },
+              "display" : {
+                "title" : [ "Baryonic popcorn" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
+                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
+                "type" : [ "article" ],
+                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
+                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
+                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "language" : [ "eng" ],
+                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
+                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ],
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2012" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "Solitons Monopoles and Instantons", "AdS-CFT Correspondence", "Quantum Physics", "Quantum Field Theories, String Theory", "Classical and Quantum Gravitation, Relativity Theory", "Physics", "Phase Diagram of QCD", "Elementary Particles, Quantum Field Theory", "Flavor (particle physics)", "Lattices", "Chains", "Phase transitions", "Density", "Instantons", "Baryons", "Multilayers", "Gauge theory", "Ferromagnetism", "Configurations", "Nuclear matter", "Crystal structure", "Branes", "Solid phases" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "CrossRef", "ProQuest Central Essentials", "ProQuest One Academic Eastern Edition", "Advanced Technologies & Aerospace Collection", "ProQuest Advanced Technologies & Aerospace Collection", "ProQuest Central", "ProQuest Central Korea", "Advanced Technologies & Aerospace Database", "Publicly Available Content Database", "SciTech Premium Collection", "ProQuest SciTech Collection", "ProQuest Central (Alumni Edition)", "Technology Collection", "ProQuest Technology Collection", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
+                "collection" : [ "CrossRef", "ProQuest SciTech Collection", "ProQuest Technology Collection", "ProQuest Central (Alumni Edition)", "Advanced Technologies & Aerospace Collection", "ProQuest Central Essentials", "ProQuest Central", "Technology Collection", "ProQuest Central Korea", "SciTech Premium Collection", "Advanced Technologies & Aerospace Database", "ProQuest Advanced Technologies & Aerospace Collection", "Publicly Available Content Database", "ProQuest One Academic Eastern Edition", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "The journal of high energy physics" ]
               }
@@ -276,14 +276,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ],
-                "citedby" : [ "FETCH-LOGICAL-13587-9daf53164beef058ed5eb921b94da94a07fe2556b21234451e94de86bf2b991e3" ]
+                "citing" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
+                "citedby" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ]
               },
               "timesCited" : { }
             },
@@ -291,81 +291,30 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "creationdate" : [ "20200717" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ]
               },
               "control" : {
                 "recordid" : [ "cdi_proquest_miscellaneous_2407314819" ],
-                "sourcerecordid" : [ "2407314819" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "sourcerecordid" : [ "2424628284" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqF0UFv0zAUB3ALgdgYXDkiS1yGRIv97MTJcUSUVprUHXaPHOeZZkrtYjtMvfER-Iz7JHNpGRIX5IOtp5__etKfkLeczTlj8MnsNmYODBhjnJfPyDmXop6pUvLnp7cEUZyRVzHeZVMxxV-SMwGyqIoCzsn92tG0QbrwYavT4B319vfgxu-MD44uRv3DB-0ShY_i4eevz1PSDvsskV42S9Gs81mKD3Rw9Mpg0mOPm32PmTbeJT24wX2jK5cwxITjqANdGYyvyQurx4hvTvcFuV18uW2Ws-v111VzdT0zgpV81hWoe8sBFbO1qUwpwNpeQdVpo5QBMJ3WFdpSsRoKJnvZIyuE7aSSnRHiglweY3fBf58wpnY7RHNYw6GfYguSKcFlxetM3_9D7_wUXF4uK5AlVFDJrOZHZYKPMaBtd2HY6rBvOWsPjbSHRtqnRvKHd6fYqdti_8T_VJBBfQT3w4j7_8S1zc2y-Rv-CBm1mHs" ],
+                "addsrcrecordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2424628284" ],
-                "score" : [ "0.019135173" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
-                "creationdate" : [ "2020" ],
-                "recordid" : [ "eNqF0UFv0zAUB3ALgdgYXDkiS1yGRIv97MTJcUSUVprUHXaPHOeZZkrtYjtMvfER-Iz7JHNpGRIX5IOtp5__etKfkLeczTlj8MnsNmYODBhjnJfPyDmXop6pUvLnp7cEUZyRVzHeZVMxxV-SMwGyqIoCzsn92tG0QbrwYavT4B319vfgxu-MD44uRv3DB-0ShY_i4eevz1PSDvsskV42S9Gs81mKD3Rw9Mpg0mOPm32PmTbeJT24wX2jK5cwxITjqANdGYyvyQurx4hvTvcFuV18uW2Ws-v111VzdT0zgpV81hWoe8sBFbO1qUwpwNpeQdVpo5QBMJ3WFdpSsRoKJnvZIyuE7aSSnRHiglweY3fBf58wpnY7RHNYw6GfYguSKcFlxetM3_9D7_wUXF4uK5AlVFDJrOZHZYKPMaBtd2HY6rBvOWsPjbSHRtqnRvKHd6fYqdti_8T_VJBBfQT3w4j7_8S1zc2y-Rv-CBm1mHs" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
-                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "issn" : [ "1439-4235", "1439-7641" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Chemphyschem" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "startdate" : [ "20200717" ],
-                "enddate" : [ "20200717" ],
-                "scope" : [ "CVF", "NPM", "EIF", "CUY", "ECM", "CGR", "CITATION", "AAYXX", "K9.", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
-                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
-                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
-                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.019118225" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Chemphyschem" ],
-                "genre" : [ "article" ],
+                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
                 "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
                 "issn" : [ "1439-4235" ],
                 "addtitle" : [ "Chemphyschem" ],
-                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
-                "pages" : [ "1531-1540" ],
-                "eissn" : [ "1439-7641" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Germany" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/cphc.202000116" ],
-                "tpages" : [ "10" ],
+                "jtitle" : [ "Chemphyschem" ],
+                "genre" : [ "article" ],
                 "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
                 "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
                 "date" : [ "2020-07-17" ],
@@ -373,18 +322,69 @@ http_interactions:
                 "volume" : [ "21" ],
                 "issue" : [ "14" ],
                 "spage" : [ "1531" ],
-                "epage" : [ "1540" ]
+                "epage" : [ "1540" ],
+                "pages" : [ "1531-1540" ],
+                "eissn" : [ "1439-7641" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Germany" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/cphc.202000116" ],
+                "tpages" : [ "10" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2020" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
+                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ],
+                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
+                "issn" : [ "1439-4235", "1439-7641" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Chemphyschem" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20200717" ],
+                "enddate" : [ "20200717" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
+              },
+              "display" : {
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
+                "type" : [ "article" ],
+                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
+                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
+                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2020" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "non-equilibrium processes", "interstellar synthesis", "IR spectroscopy", "mass spectroscopy", "complex organic molecules", "Acetaldehyde - chemistry", "Cold Temperature", "Flavoring Agents - chemical synthesis", "Ultraviolet Rays", "Models, Chemical", "Free Radicals - chemistry", "Deuterium - chemistry", "Diacetyl - chemical synthesis", "Acetaldehyde - radiation effects", "Extraterrestrial Environment - chemistry", "Deep space", "Molecular structure", "Molecular clouds", "Galactic cosmic rays", "Substitution reactions", "Amino acids", "Ice", "Aldehydes", "Cosmic rays", "Acetaldehyde", "Complexity", "Organic chemistry", "Ionizing radiation", "Meteorites", "Star formation", "Photoionization", "Interstellar chemistry", "Astrochemistry", "Chemical synthesis", "Interstellar matter", "Index Medicus" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "MEDLINE (Ovid)", "PubMed", "MEDLINE", "MEDLINE", "MEDLINE", "Medline", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
+                "collection" : [ "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Chemphyschem" ]
               }
@@ -404,13 +404,13 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c3061-b5eadf12e70f9c8c632ffd728bac77c22cbaa8ef67092504d4de053fb474bc33" ],
+                "citing" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "citedby" : [ ]
               },
               "timesCited" : { }
@@ -419,78 +419,29 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "creationdate" : [ "20180105" ],
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ]
               },
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A521493458" ],
                 "sourcerecordid" : [ "A521493458" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqFkM9OwzAMxisEEtPYlXNeoCNJ03_cxrTBpA2mAecqTZ0R1CZV0grtxoE34A15EjINbUfsgy3b3yf5FwTXBI8JxvSGg27GFJMUE0LwWTAgCWFhkjF8fuwjehmMnHvHPlhOcBQNgq-1aYWxGi20a5WFCq2NNb1DKy6sEVDXfc0tmnJbGn2LNrxV_qSXUuktmvPSKsE7ZTSS1jRoowQgriu06ByatG39t3VIabRU3Zvqm5_P7-e-lr1Fd7zrwCpwV8GF5LWD0V8dBq_z2cv0IVw-3S-mk2VIGM1wyGSZR4IlUEJegohyhllVlSlQKZNY-i9plcURSyFPBZC4lAwAQ55QGjMgNBoG44PvltdQKC1NZ7nwWUGjhNEglZ9PYkpYHrE4Owk8C-csyKK1quF2VxBc7LkXe-7FkbsX5AfBh3fa_XNdTGaPq5P2FwvRiaY" ],
+                "addsrcrecordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A521493458" ],
-                "score" : [ "0.018670669" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
-                "creationdate" : [ "2018" ],
-                "recordid" : [ "eNqFkM9OwzAMxisEEtPYlXNeoCNJ03_cxrTBpA2mAecqTZ0R1CZV0grtxoE34A15EjINbUfsgy3b3yf5FwTXBI8JxvSGg27GFJMUE0LwWTAgCWFhkjF8fuwjehmMnHvHPlhOcBQNgq-1aYWxGi20a5WFCq2NNb1DKy6sEVDXfc0tmnJbGn2LNrxV_qSXUuktmvPSKsE7ZTSS1jRoowQgriu06ByatG39t3VIabRU3Zvqm5_P7-e-lr1Fd7zrwCpwV8GF5LWD0V8dBq_z2cv0IVw-3S-mk2VIGM1wyGSZR4IlUEJegohyhllVlSlQKZNY-i9plcURSyFPBZC4lAwAQ55QGjMgNBoG44PvltdQKC1NZ7nwWUGjhNEglZ9PYkpYHrE4Owk8C-csyKK1quF2VxBc7LkXe-7FkbsX5AfBh3fa_XNdTGaPq5P2FwvRiaY" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
-                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "issn" : [ "1614-6832", "1614-6840" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "startdate" : [ "20180105" ],
-                "enddate" : [ "20180105" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "publisher" : [ "Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
-                "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
-                "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
-                "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.018662874" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Advanced energy materials" ],
-                "genre" : [ "article" ],
+                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
                 "issn" : [ "1614-6832" ],
-                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "pages" : [ "1701110-n/a" ],
-                "eissn" : [ "1614-6840" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/aenm.201701110" ],
-                "tpages" : [ "8" ],
+                "jtitle" : [ "Advanced energy materials" ],
+                "genre" : [ "article" ],
                 "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
                 "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
                 "date" : [ "2018-01-05" ],
@@ -498,18 +449,67 @@ http_interactions:
                 "volume" : [ "8" ],
                 "issue" : [ "1" ],
                 "spage" : [ "1701110" ],
-                "epage" : [ "n/a" ]
+                "epage" : [ "n/a" ],
+                "pages" : [ "1701110-n/a" ],
+                "eissn" : [ "1614-6840" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/aenm.201701110" ],
+                "tpages" : [ "8" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2018" ],
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
+                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "recordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
+                "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "issn" : [ "1614-6832", "1614-6840" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20180105" ],
+                "enddate" : [ "20180105" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+              },
+              "display" : {
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "publisher" : [ "Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
+                "type" : [ "article" ],
+                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
+                "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
+                "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2018" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "biomass‐derived porous carbons", "lithium–sulfur batteries", "cathodes", "nanostructures", "metal–carbon composites", "Sulfur compounds", "Electrical conductivity", "Electrochemistry", "Porosity", "Batteries", "Sulfur", "Electric properties" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Advanced energy materials" ]
               }
@@ -529,14 +529,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ],
-                "citedby" : [ "FETCH-LOGICAL-14280-4fb93c46ebe9bec39404ddb7e2ff65f1612d85347e97ce15bf4ee0e962254e123" ]
+                "citing" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
+                "citedby" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ]
               },
               "timesCited" : { }
             },
@@ -544,95 +544,95 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "creationdate" : [ "20140815" ],
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "author" : [ "Moreta, Cristina ; Tena, María Teresa" ]
               },
               "control" : {
                 "recordid" : [ "cdi_gale_infotracacademiconefile_A375736650" ],
                 "sourcerecordid" : [ "A375736650" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3503-5cd834cab94a649b1fc87b95fb5aa6d48e70dc72d08a7130176da5eab6da26f63" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9UbuO1TAQTQESy4U_oHBDtwl2Hk5ug7RantJKNFBbE3uc67uOnbUTRLr9B76Phi_B2ay2RC5mdHzOmVeWvWG0YJTxd-dCnoIfoSgpqwvKC8q6Z9kFpSXLj7ytXmQvYzxTylralhfZnw84YxiNg9l4R7wmEwZtFx82CBUBe7taAtKoSIwj0gd3SSY_bQkBp57yHoZIetQ-4AMOOhknvr81biD9SrSXS0yOi50DRL8kTvTWqL_3v625W4wi-Cv9yK2RS_II7cPMfggwndYH47sFVFgmbzGfzYhbz9qa4TSTEWIkcUI5JxHOYX2VPddgI75-jIfsx6eP36-_5DffPn-9vrrJZdXQKm-k6qpaQn-sgdfHnmnZtf2x0X0DwFXdYUuVbEtFO2hZlXbHFTQIfQol17w6ZMXuO4BFYZz22yDpKRyN9A61SfhV1TZtxXkqecjqXSCDjzGgFlMwI4RVMCq2O4qz2EcX2x0F5SLdMcne7rIJogSrAzhp4pO27HgiU5Z473cepqF_GgwiSoNOojIhbUcob_5f6B_A58Bk" ],
+                "addsrcrecordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A375736650" ],
-                "score" : [ "0.018272474" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=28601401$$DView record in Pascal Francis" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
-                "creationdate" : [ "2014" ],
-                "recordid" : [ "eNp9UbuO1TAQTQESy4U_oHBDtwl2Hk5ug7RantJKNFBbE3uc67uOnbUTRLr9B76Phi_B2ay2RC5mdHzOmVeWvWG0YJTxd-dCnoIfoSgpqwvKC8q6Z9kFpSXLj7ytXmQvYzxTylralhfZnw84YxiNg9l4R7wmEwZtFx82CBUBe7taAtKoSIwj0gd3SSY_bQkBp57yHoZIetQ-4AMOOhknvr81biD9SrSXS0yOi50DRL8kTvTWqL_3v625W4wi-Cv9yK2RS_II7cPMfggwndYH47sFVFgmbzGfzYhbz9qa4TSTEWIkcUI5JxHOYX2VPddgI75-jIfsx6eP36-_5DffPn-9vrrJZdXQKm-k6qpaQn-sgdfHnmnZtf2x0X0DwFXdYUuVbEtFO2hZlXbHFTQIfQol17w6ZMXuO4BFYZz22yDpKRyN9A61SfhV1TZtxXkqecjqXSCDjzGgFlMwI4RVMCq2O4qz2EcX2x0F5SLdMcne7rIJogSrAzhp4pO27HgiU5Z473cepqF_GgwiSoNOojIhbUcob_5f6B_A58Bk" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "issn" : [ "0021-9673" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V", "Elsevier" ],
-                "startdate" : [ "20140815" ],
-                "enddate" : [ "20140815" ],
-                "scope" : [ "IQODW", "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "publisher" : [ "Amsterdam: Elsevier B.V" ],
-                "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
-                "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
-                "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
-                "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "score" : [ "0.018273484" ]
               },
               "addata" : {
-                "format" : [ "journal" ],
+                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
+                "issn" : [ "0021-9673" ],
                 "jtitle" : [ "Journal of Chromatography A" ],
                 "genre" : [ "article" ],
-                "issn" : [ "0021-9673" ],
-                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "pages" : [ "211-218" ],
-                "coden" : [ "JOCRAM" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Amsterdam" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
                 "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
                 "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
                 "date" : [ "2014-08-15" ],
                 "risdate" : [ "2014" ],
                 "volume" : [ "1355" ],
                 "spage" : [ "211" ],
-                "epage" : [ "218" ]
+                "epage" : [ "218" ],
+                "pages" : [ "211-218" ],
+                "coden" : [ "JOCRAM" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Amsterdam" ],
+                "pub" : [ "Elsevier B.V" ],
+                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
+                "format" : [ "journal" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=28601401$$DView record in Pascal Francis" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "creationdate" : [ "2014" ],
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
+                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "recordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
+                "recordtype" : [ "article" ],
+                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ],
+                "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "issn" : [ "0021-9673" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Elsevier B.V", "Elsevier" ],
+                "rsrctype" : [ "article" ],
+                "startdate" : [ "20140815" ],
+                "enddate" : [ "20140815" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+              },
+              "display" : {
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "publisher" : [ "Amsterdam: Elsevier B.V" ],
+                "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
+                "type" : [ "article" ],
+                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
+                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
+                "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "language" : [ "eng" ],
+                "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
+                "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
                 "creationdate" : [ "2014" ],
-                "language" : [ "eng" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "topic" : [ "Packaging", "Quadrupole-time of flight mass spectrometry", "Liquid chromatography", "Perfluorinated alkyl acids", "Focused ultrasound solid–liquid extraction", "Popcorn", "Fundamental and applied biological sciences. Psychology", "Food industries", "Biological and medical sciences", "Cereal and baking product industries", "Corn", "Ammonium perfluorooctanoate", "Mass spectrometry", "Analysis" ],
                 "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
                 "collection" : [ "Pascal-Francis", "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3503-5cd834cab94a649b1fc87b95fb5aa6d48e70dc72d08a7130176da5eab6da26f63" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Journal of Chromatography A" ]
               }
@@ -652,7 +652,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -664,651 +664,37 @@ http_interactions:
               "timesCited" : { }
             },
             "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A375736650"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "creationdate" : [ "202102" ],
-                "author" : [ "Rafee, Shameer ; Killeen, Ronan P ; Tubridy, Niall" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_2454123461" ],
-                "sourcerecordid" : [ "2454123461" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kM1Kw0AQxxdRbK2-gUiOXhL3K5usB6EGv6CgBz0vm80ENzTZutsI3voY-np9ElNSr56GYX7_GeaH0DnBCcFEXDWJbpsWqoRiihMsE0z4AZqSNE3jjAh6iKYYYxpLxtkEnYTQDC2WqThGE8awJEyyKSLbzfeLWxnnu-3mJ7JdtH6H6NZr211H86jQfYCodj4qXFf3wbruFB3VehngbF9n6O3-7rV4jBfPD0_FfBEbImkWlyCBZ6SiZY2loFVV6koYxolOgekcZyI3gkgwLGc5MK6znJUlAGE1zpmu2AxdjntX3n30ENaqtcHAcqk7cH1QlKecUMYFGVA-osa7EDzUauVtq_2XIljtZKlGjbLUTpbCUg2yhtjF_kJf7mZ_oT87A3AzAjD8-WnBq2AsdAYq68GsVeXs_xd-Ab2QfDw" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "2454123461" ],
-                "score" : [ "0.01815351" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion", "The American journal of medicine" ],
-                "creationdate" : [ "2021" ],
-                "recordid" : [ "eNp9kM1Kw0AQxxdRbK2-gUiOXhL3K5usB6EGv6CgBz0vm80ENzTZutsI3voY-np9ElNSr56GYX7_GeaH0DnBCcFEXDWJbpsWqoRiihMsE0z4AZqSNE3jjAh6iKYYYxpLxtkEnYTQDC2WqThGE8awJEyyKSLbzfeLWxnnu-3mJ7JdtH6H6NZr211H86jQfYCodj4qXFf3wbruFB3VehngbF9n6O3-7rV4jBfPD0_FfBEbImkWlyCBZ6SiZY2loFVV6koYxolOgekcZyI3gkgwLGc5MK6znJUlAGE1zpmu2AxdjntX3n30ENaqtcHAcqk7cH1QlKecUMYFGVA-osa7EDzUauVtq_2XIljtZKlGjbLUTpbCUg2yhtjF_kJf7mZ_oT87A3AzAjD8-WnBq2AsdAYq68GsVeXs_xd-Ab2QfDw" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "rsrctype" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-9231-8133", "https://orcid.org/0000-0002-0756-3135" ],
-                "creator" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "subject" : [ "Hemangioma, Cavernous, Central Nervous System - surgery ; Young Adult ; Hemangioma, Cavernous, Central Nervous System - diagnosis ; Confusion - etiology ; Hemangioma, Cavernous, Central Nervous System - pathology ; Humans ; Index Medicus ; Abridged Index Medicus" ],
-                "issn" : [ "0002-9343", "1555-7162" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Am J Med" ],
-                "general" : [ "Elsevier Inc" ],
-                "startdate" : [ "202102" ],
-                "enddate" : [ "202102" ],
-                "scope" : [ "CVF", "NPM", "EIF", "CUY", "ECM", "CGR", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "title" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Rafee, Shameer ; Killeen, Ronan P ; Tubridy, Niall" ],
-                "subject" : [ "Hemangioma, Cavernous, Central Nervous System - surgery ; Young Adult ; Hemangioma, Cavernous, Central Nervous System - diagnosis ; Confusion - etiology ; Hemangioma, Cavernous, Central Nervous System - pathology ; Humans ; Index Medicus ; Abridged Index Medicus" ],
-                "source" : [ "Alma/SFX Local Collection", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: Elsevier Inc" ],
-                "ispartof" : [ "The American journal of medicine, 2021-02, Vol.134 (2), p.216-217" ],
-                "identifier" : [ "ISSN: 0002-9343", "EISSN: 1555-7162", "DOI: 10.1016/j.amjmed.2020.09.014", "PMID: 33091393" ],
-                "rights" : [ "2020 Elsevier Inc." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "The American journal of medicine" ],
-                "genre" : [ "article" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-9231-8133", "https://orcid.org/0000-0002-0756-3135" ],
-                "issn" : [ "0002-9343" ],
-                "addtitle" : [ "Am J Med" ],
-                "pages" : [ "216-217" ],
-                "eissn" : [ "1555-7162" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "Elsevier Inc" ],
-                "doi" : [ "10.1016/j.amjmed.2020.09.014" ],
-                "au" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "atitle" : [ "‘Popcorn’ in the Brain: A Cause for Confusion" ],
-                "date" : [ "2021-02" ],
-                "risdate" : [ "2021" ],
-                "volume" : [ "134" ],
-                "issue" : [ "2" ],
-                "spage" : [ "216" ],
-                "epage" : [ "217" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2021" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Rafee, Shameer", "Killeen, Ronan P", "Tubridy, Niall" ],
-                "topic" : [ "Hemangioma, Cavernous, Central Nervous System - surgery", "Young Adult", "Hemangioma, Cavernous, Central Nervous System - diagnosis", "Confusion - etiology", "Hemangioma, Cavernous, Central Nervous System - pathology", "Humans", "Index Medicus", "Abridged Index Medicus" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "MEDLINE (Ovid)", "PubMed", "MEDLINE", "MEDLINE", "MEDLINE", "Medline", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "The American journal of medicine" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=%E2%80%98Popcorn%E2%80%99+in+the+Brain%3A+A+Cause+for+Confusion&rft.jtitle=The+American+journal+of+medicine&rft.au=Rafee%2C+Shameer&rft.date=2021-02&rft.volume=134&rft.issue=2&rft.spage=216&rft.epage=217&rft.pages=216-217&rft.issn=0002-9343&rft.eissn=1555-7162&rft_id=info:doi/10.1016%2Fj.amjmed.2020.09.014&rft.pub=Elsevier+Inc&rft.place=United+States&rft_dat=<proquest_cross>2454123461</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c1927-be9e471d2bf0962ddbad6c341a5e3a80768c619ec3838e34a783bbee13f083ad3" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_2454123461"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "creationdate" : [ "201708" ],
-                "author" : [ "Canfora, Fabrizio ; Tallarita, Gianni" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_doaj_primary_oai_doaj_org_article_ca6c27608a414e0484c23159f93cb0b7" ],
-                "sourcerecordid" : [ "S0550321317301967" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12051-2c631b1ebca7d2be2e5dde20bf2e0fb2cc5ce6abe5093b09d5d69df6f3ee04e73" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9kFtOwzAQRS0EEqWwBrIAEsZ27DSfpeJRqYiPwrflxwQc0iSyU6SuhAWxMRJAzM9I92qORoeQSwoZBSqv66zd26Z_O0STMaBFBjIDoEdkRhcFT6mQ7JjMQAhIOaP8lJzFWMM4ki9m5OZx3ww-3b4fws53bUy6Nlm6Lfv63LKrJOhhDHWT7HQfE926pO9624U2GYJuo5_aeE5OKt1EvPjbc_Jyd_u8ekg3T_fr1XKTUgaCpsxKTg1FY3XhmEGGwjlkYCqGUBlmrbAotUEBJTdQOuFk6SpZcUTIseBzsv7luk7Xqg9-p8NBddqrn6ALr0qHwdsGldXSskLCQuc0H68XuWWcirIquTVgJtbyl4Xjwx8eg4rWY2vR-YB2GIleUVCTYFWrf8FqEqxAqlEw_waviXPt" ],
-                "sourcetype" : [ "Open Website" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_doaj_" ],
-                "score" : [ "0.018152272" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions", "Nuclear physics. B" ],
-                "creationdate" : [ "2017" ],
-                "recordid" : [ "eNo9kFtOwzAQRS0EEqWwBrIAEsZ27DSfpeJRqYiPwrflxwQc0iSyU6SuhAWxMRJAzM9I92qORoeQSwoZBSqv66zd26Z_O0STMaBFBjIDoEdkRhcFT6mQ7JjMQAhIOaP8lJzFWMM4ki9m5OZx3ww-3b4fws53bUy6Nlm6Lfv63LKrJOhhDHWT7HQfE926pO9624U2GYJuo5_aeE5OKt1EvPjbc_Jyd_u8ekg3T_fr1XKTUgaCpsxKTg1FY3XhmEGGwjlkYCqGUBlmrbAotUEBJTdQOuFk6SpZcUTIseBzsv7luk7Xqg9-p8NBddqrn6ALr0qHwdsGldXSskLCQuc0H68XuWWcirIquTVgJtbyl4Xjwx8eg4rWY2vR-YB2GIleUVCTYFWrf8FqEqxAqlEw_waviXPt" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH", "DOA" ],
-                "creatorcontrib" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "issn" : [ "0550-3213", "1873-1562" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V", "Elsevier" ],
-                "startdate" : [ "201708" ],
-                "enddate" : [ "201708" ],
-                "scope" : [ "AAFTH", "6I.", "DOA" ]
-              },
-              "display" : {
-                "description" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "title" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Canfora, Fabrizio ; Tallarita, Gianni" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Directory of Open Access Journals", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "Elsevier PhysicsDirect Journals", "Elsevier:ScienceDirect:Open Access", "Backfile Package - Mathematics 1995-2004 [BFJMAT9504]", "ScienceDirect Government Edition", "Elsevier:ScienceDirect:Mathematics Subject Collection:2018" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Nuclear physics. B, 2017-08, Vol.921 (C), p.394-410" ],
-                "identifier" : [ "ISSN: 0550-3213", "EISSN: 1873-1562", "DOI: 10.1016/j.nuclphysb.2017.06.001" ],
-                "rights" : [ "2017 The Author(s)" ],
-                "snippet" : [ "... with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Nuclear physics. B" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0550-3213" ],
-                "abstract" : [ "By combining two different techniques to construct multi-soliton solutions of the (3+1)-dimensional Skyrme model, the generalized hedgehog and the rational map ansatz, we find multi-Skyrmion configurations in AdS2×S2. We construct Skyrmionic multi-layered configurations such that the total Baryon charge is the product of the number of kinks along the radial AdS2 direction and the degree of the rational map. We show that, for fixed total Baryon charge, as one increases the charge density on ∂(AdS2×S2), it becomes increasingly convenient energetically to have configurations with more peaks in the radial AdS2 direction but a lower degree of the rational map. This has a direct relation with the so-called holographic popcorn transitions in which, when the charge density is high, multi-layered configurations with low charge on each layer are favored over configurations with few layers but with higher charge on each layer. The case in which the geometry is M2×S2 can also be analyzed." ],
-                "pages" : [ "394-410" ],
-                "eissn" : [ "1873-1562" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.nuclphysb.2017.06.001" ],
-                "au" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "atitle" : [ "Multi-Skyrmions on AdS2×S2, rational maps and popcorn transitions" ],
-                "date" : [ "2017-08" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "921" ],
-                "issue" : [ "C" ],
-                "spage" : [ "394" ],
-                "epage" : [ "410" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2017" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Canfora, Fabrizio", "Tallarita, Gianni" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "Directory of Open Access Journals" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12051-2c631b1ebca7d2be2e5dde20bf2e0fb2cc5ce6abe5093b09d5d69df6f3ee04e73" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Nuclear physics. B" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_doaj_&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Multi-Skyrmions+on+AdS2%C3%97S2%2C+rational+maps+and+popcorn+transitions&rft.jtitle=Nuclear+physics.+B&rft.au=Canfora%2C+Fabrizio&rft.date=2017-08&rft.volume=921&rft.issue=C&rft.spage=394&rft.epage=410&rft.pages=394-410&rft.issn=0550-3213&rft.eissn=1873-1562&rft_id=info:doi/10.1016%2Fj.nuclphysb.2017.06.001&rft.pub=Elsevier+B.V&rft_dat=<elsevier_doaj_>S0550321317301967</elsevier_doaj_>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_doaj_primary_oai_doaj_org_article_ca6c27608a414e0484c23159f93cb0b7"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "creationdate" : [ "20120228" ],
-                "author" : [ "Edgar, Jonathan A ; McDonagh, Andrew M ; Cortie, Michael B" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_924964320" ],
-                "sourcerecordid" : [ "924964320" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNptkL9OwzAQhy0EoqUw8ALIC0IMAduJnXiEihak8kcCJLbIdmyRKrGLnQzd-iDwcn0SjAqdkIez7r77SfcBcIzRBUYEX1pLUEoLNt8BQ8xTlqCCve1u_xQPwEEIc4RoXuRsHwwISVEc5kNwPXG-FV3tLHQGTl1TwQdhnXdVgHIJBXzunHoXoasVXK8-n9xCOW_Xqy94r2Pf1qE9BHtGNEEf_dYReJ3cvIxvk9nj9G58NUtwijhLChwf1ySTRsjMZDkhWCIsOUWUmopxyU3FuaRScVJwkglCK8qwNkWVSi3SETjb5C68--h16Mq2Dko3jbDa9aGMK5xlaVQxAucbUnkXgtemXPi6FX5ZYlT-GCu3xiJ78pvay1ZXW_JPUQRON4BQoZy73tt45D9B3xBUcrY" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "924964320" ],
-                "score" : [ "0.018080851" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism", "ACS nano" ],
-                "creationdate" : [ "2012" ],
-                "recordid" : [ "eNptkL9OwzAQhy0EoqUw8ALIC0IMAduJnXiEihak8kcCJLbIdmyRKrGLnQzd-iDwcn0SjAqdkIez7r77SfcBcIzRBUYEX1pLUEoLNt8BQ8xTlqCCve1u_xQPwEEIc4RoXuRsHwwISVEc5kNwPXG-FV3tLHQGTl1TwQdhnXdVgHIJBXzunHoXoasVXK8-n9xCOW_Xqy94r2Pf1qE9BHtGNEEf_dYReJ3cvIxvk9nj9G58NUtwijhLChwf1ySTRsjMZDkhWCIsOUWUmopxyU3FuaRScVJwkglCK8qwNkWVSi3SETjb5C68--h16Mq2Dko3jbDa9aGMK5xlaVQxAucbUnkXgtemXPi6FX5ZYlT-GCu3xiJ78pvay1ZXW_JPUQRON4BQoZy73tt45D9B3xBUcrY" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "issn" : [ "1936-0851", "1936-086X" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "ACS Nano" ],
-                "general" : [ "American Chemical Society" ],
-                "startdate" : [ "20120228" ],
-                "enddate" : [ "20120228" ],
-                "scope" : [ "NPM", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "title" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Edgar, Jonathan A ; McDonagh, Andrew M ; Cortie, Michael B" ],
-                "source" : [ "American Chemical Society Single Title Subscriptions", "ACS Publications", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: American Chemical Society" ],
-                "ispartof" : [ "ACS nano, 2012-02-28, Vol.6 (2), p.1116-1125" ],
-                "identifier" : [ "ISSN: 1936-0851", "EISSN: 1936-086X", "DOI: 10.1021/nn203586j", "PMID: 22301937" ],
-                "rights" : [ "Copyright © 2012 American Chemical Society" ],
-                "snippet" : [ ".... Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn...", ".... Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, \"popcorn\"-like mechanism of growth, in which individual..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "ACS nano" ],
-                "genre" : [ "article" ],
-                "issn" : [ "1936-0851" ],
-                "addtitle" : [ "ACS Nano" ],
-                "abstract" : [ "Gold nanorods have significant technological potential and are of broad interest to the nanotechnology community. The discovery of the seeded, wet-chemical synthetic process to produce them may be regarded as a landmark in the control of metal nanoparticle shape. However, the mechanism by which the initial spherical gold seeds acquire anisotropy is a critical, yet poorly understood, factor. Here we examine the very early stages of rod growth using a combination of techniques including cryogenic transmission electron microscopy, optical spectroscopy, and computational modeling. Reconciliation of the available experimental observations can only be achieved by invoking a stochastic, “popcorn”-like mechanism of growth, in which individual seeds lie quiescent for some time before suddenly and rapidly growing into rods. This is quite different from the steady, concurrent growth of nanorods that has been previously generally assumed. Furthermore we propose that the shape is controlled by the ratio of surface energy of rod sides to rod ends, with values of this quantity in the range of 0.3–0.8 indicated for typical growth solutions." ],
-                "pages" : [ "1116-1125" ],
-                "eissn" : [ "1936-086X" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "American Chemical Society" ],
-                "doi" : [ "10.1021/nn203586j" ],
-                "au" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "atitle" : [ "Formation of Gold Nanorods by a Stochastic “Popcorn” Mechanism" ],
-                "date" : [ "2012-02-28" ],
-                "risdate" : [ "2012" ],
-                "volume" : [ "6" ],
-                "issue" : [ "2" ],
-                "spage" : [ "1116" ],
-                "epage" : [ "1125" ],
-                "oa" : [ "free_for_read" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2012" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Edgar, Jonathan A", "McDonagh, Andrew M", "Cortie, Michael B" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "PubMed", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "ACS nano" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Formation+of+Gold+Nanorods+by+a+Stochastic+%E2%80%9CPopcorn%E2%80%9D+Mechanism&rft.jtitle=ACS+nano&rft.au=Edgar%2C+Jonathan+A&rft.date=2012-02-28&rft.volume=6&rft.issue=2&rft.spage=1116&rft.epage=1125&rft.pages=1116-1125&rft.issn=1936-0851&rft.eissn=1936-086X&rft_id=info:doi/10.1021%2Fnn203586j&rft.pub=American+Chemical+Society&rft.place=United+States&rft_dat=<proquest_cross>924964320</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-13096-818189e24bfab4f47221b01b95055fd69b9fd99b5bc928924a25d561ef8d3bea3" ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_924964320"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "creationdate" : [ "20190220" ],
-                "author" : [ "Lim, Suh-Ciuan ; Chan, Cheng-Ying ; Chen, Kuan-Ting ; Tuan, Hsing-Yu" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A569709825" ],
-                "sourcerecordid" : [ "A569709825" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c3443-c0079cdcabdfeae9cef90da4e646888c639ed0d31ed91e4352660fd284cd31913" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqFkcGKFDEQhoMoOK4-gznqoXuTTne6-zgsugoLK6jnUJtUpjNkkibJLPRr-MRmHPEqFahQ5P-pLz8h7zlrOePy9tiiR12gnrZjfGo5b_nQvSA7Po2iEdMwvyQ7xrhoejnJ1-RNzkfG2ChHtiO_vm-hLJhdptHSNa46ptDkBVY09ADeu_OpWT0UF84n-uEevhXxkQYIcYVUnPaYKWS6uMPiN4rWOu0wFArB0FzgySP9s16KGgr4LZdMbUx02UyKBwwUn6M_FxcDTVgZ6uUteWXBZ3z3t9-Qn58__bj70jw83n-92z80WvS9aHRFmLXR8GQsAs4a7cwM9Cgr5jRpKWY0zAiOZubYi6GTklnTTb2uw5mLG9JefSsmKhdsLAl0LYMnp2NA6-p8P8h5ZPPUDVUwXgU6xZwTWrUmd4K0Kc7UJQt1VP-yUJcsFOeqZlGV-6sSK8-zw6Ty5Zs0Gpfqe2Wi-6_Hb2NPm44" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_cross" ],
-                "galeid" : [ "A569709825" ],
-                "score" : [ "0.01805773" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction", "Electrochimica acta" ],
-                "creationdate" : [ "2019" ],
-                "recordid" : [ "eNqFkcGKFDEQhoMoOK4-gznqoXuTTne6-zgsugoLK6jnUJtUpjNkkibJLPRr-MRmHPEqFahQ5P-pLz8h7zlrOePy9tiiR12gnrZjfGo5b_nQvSA7Po2iEdMwvyQ7xrhoejnJ1-RNzkfG2ChHtiO_vm-hLJhdptHSNa46ptDkBVY09ADeu_OpWT0UF84n-uEevhXxkQYIcYVUnPaYKWS6uMPiN4rWOu0wFArB0FzgySP9s16KGgr4LZdMbUx02UyKBwwUn6M_FxcDTVgZ6uUteWXBZ3z3t9-Qn58__bj70jw83n-92z80WvS9aHRFmLXR8GQsAs4a7cwM9Cgr5jRpKWY0zAiOZubYi6GTklnTTb2uw5mLG9JefSsmKhdsLAl0LYMnp2NA6-p8P8h5ZPPUDVUwXgU6xZwTWrUmd4K0Kc7UJQt1VP-yUJcsFOeqZlGV-6sSK8-zw6Ty5Zs0Gpfqe2Wi-6_Hb2NPm44" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "subject" : [ "Nanoparticles ; Hydrogen evolution reaction ; Platinum alloy ; Fuel cell ; Popcorn-shaped ; Intermetallic compounds ; Catalysts ; Hydrogen ; Fuel cells ; Green technology ; Platinum alloys" ],
-                "issn" : [ "0013-4686", "1873-3859" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier Ltd", "Elsevier B.V" ],
-                "startdate" : [ "20190220" ],
-                "enddate" : [ "20190220" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ]
-              },
-              "display" : {
-                "description" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "title" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Lim, Suh-Ciuan ; Chan, Cheng-Ying ; Chen, Kuan-Ting ; Tuan, Hsing-Yu" ],
-                "subject" : [ "Nanoparticles ; Hydrogen evolution reaction ; Platinum alloy ; Fuel cell ; Popcorn-shaped ; Intermetallic compounds ; Catalysts ; Hydrogen ; Fuel cells ; Green technology ; Platinum alloys" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "publisher" : [ "Elsevier Ltd" ],
-                "ispartof" : [ "Electrochimica acta, 2019-02-20, Vol.297, p.288-296" ],
-                "identifier" : [ "ISSN: 0013-4686", "EISSN: 1873-3859", "DOI: 10.1016/j.electacta.2018.11.152" ],
-                "rights" : [ "2018 Elsevier Ltd", "COPYRIGHT 2019 Elsevier B.V." ],
-                "snippet" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Electrochimica acta" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0013-4686" ],
-                "abstract" : [ "The hydrogen evolution reaction (HER) holds great promise for clean energy, where electrocatalysts for HER perform as the cathode reaction of water splitting is the critical reaction process on fuel cell. In spite of the rapid growth of alternative materials, platinum (Pt)-based or platinum alloy materials are still the most efficient catalysts for HER. Here, we report a hot-solvent synthesis for producing pop-corn shaped gallium-platinum (GaPt3) nanoparticles, which exhibits intermetallic behavior with abundant uneven surfaces that guarantee the extensive catalytic active edge sites. The electrochemical catalytic activity of GaPt3-based electrode towards HER was demonstrated for the first time, resulting an outstanding performance of only 27 mV overpotential to achieve the 10 mA/cm2 current density and a Tafel slope of 43.3 mV/dec. (vs. RHE) in acidic media, which is rather superior to that of commercial Pt catalysts and a relatively low overpotential (<80 mV) was obtained even operated at large area (5 cm2). Moreover, cycling tests for 10000-cycle CV sweep (−0.3 to 0.2 V vs. RHE) and durability test for 48 h were applied and the performance remains still, thus giving the confirmation to the long-lasting feature of GaPt3 nanoparticles.\nThe GaPt3 nanoparticles with pop-corn like appearance were prepared via hot-solvent synthesis for the first time, exhibit high-performance catalytic and long-lasting properties as HER electrodes. [Display omitted]" ],
-                "pages" : [ "288-296" ],
-                "eissn" : [ "1873-3859" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier Ltd" ],
-                "doi" : [ "10.1016/j.electacta.2018.11.152" ],
-                "au" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "atitle" : [ "Synthesis of popcorn-shaped gallium-platinum (GaPt3) nanoparticles as highly efficient and stable electrocatalysts for hydrogen evolution reaction" ],
-                "date" : [ "2019-02-20" ],
-                "risdate" : [ "2019" ],
-                "volume" : [ "297" ],
-                "spage" : [ "288" ],
-                "epage" : [ "296" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Lim, Suh-Ciuan", "Chan, Cheng-Ying", "Chen, Kuan-Ting", "Tuan, Hsing-Yu" ],
-                "topic" : [ "Nanoparticles", "Hydrogen evolution reaction", "Platinum alloy", "Fuel cell", "Popcorn-shaped", "Intermetallic compounds", "Catalysts", "Hydrogen", "Fuel cells", "Green technology", "Platinum alloys" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3443-c0079cdcabdfeae9cef90da4e646888c639ed0d31ed91e4352660fd284cd31913" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Electrochimica acta" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Synthesis+of+popcorn-shaped+gallium-platinum+%28GaPt3%29+nanoparticles+as+highly+efficient+and+stable+electrocatalysts+for+hydrogen+evolution+reaction&rft.jtitle=Electrochimica+acta&rft.au=Lim%2C+Suh-Ciuan&rft.date=2019-02-20&rft.volume=297&rft.spage=288&rft.epage=296&rft.pages=288-296&rft.issn=0013-4686&rft.eissn=1873-3859&rft_id=info:doi/10.1016%2Fj.electacta.2018.11.152&rft.pub=Elsevier+Ltd&rft_dat=<gale_cross>A569709825</gale_cross>&svc_dat=viewit&rft_galeid=A569709825"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A569709825"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "creationdate" : [ "20160816" ],
-                "author" : [ "Liang, Ting ; Chen, Chunlin ; Li, Xing ; Zhang, Jian" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_1812224163" ],
-                "sourcerecordid" : [ "1812224163" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kE1Lw0AQhhdRbK3-A5E9eknd7yQ3JdYPKLSgnpfdZFNSmmycbYT-e7e09ehhGBied2b3QeiWkikljD6YMkw3plu1QwNTZQnNJT9DYyoZSWTG0nM0JqngSSoUH6GrENaEkJyL_BKNWCqkpBkfo8el70sPXfLsoPlxFV568EPAhQHrO1x7wLPOwWqHP7YezMph01W4WLBI9NsB3DW6qM0muJtjn6Cvl9ln8ZbMF6_vxdM8MUxylVS2TJ2shXWWiFhVKSlXaW7KlCtGBZG2VnFoGKtlVjkmVW4rFkHJmRWWT9D9YW8P_ntwYavbJpRuExW4-GBNM8oYE1TxiIoDWoIPAVyte2haAztNid6709GdPrnTR3cxdne8MNjWVX-hk6wIkAOwj6_9AF388P87fwGsXH17" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "proquest_cross" ],
-                "pqid" : [ "1812224163" ],
-                "score" : [ "0.018024664" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "description" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture", "Langmuir" ],
-                "creationdate" : [ "2016" ],
-                "recordid" : [ "eNp9kE1Lw0AQhhdRbK3-A5E9eknd7yQ3JdYPKLSgnpfdZFNSmmycbYT-e7e09ehhGBied2b3QeiWkikljD6YMkw3plu1QwNTZQnNJT9DYyoZSWTG0nM0JqngSSoUH6GrENaEkJyL_BKNWCqkpBkfo8el70sPXfLsoPlxFV568EPAhQHrO1x7wLPOwWqHP7YezMph01W4WLBI9NsB3DW6qM0muJtjn6Cvl9ln8ZbMF6_vxdM8MUxylVS2TJ2shXWWiFhVKSlXaW7KlCtGBZG2VnFoGKtlVjkmVW4rFkHJmRWWT9D9YW8P_ntwYavbJpRuExW4-GBNM8oYE1TxiIoDWoIPAVyte2haAztNid6709GdPrnTR3cxdne8MNjWVX-hk6wIkAOwj6_9AF388P87fwGsXH17" ],
-                "recordtype" : [ "article" ],
-                "creatorcontrib" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "rsrctype" : [ "article" ],
-                "creator" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "subject" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage ; Index Medicus" ],
-                "issn" : [ "0743-7463", "1520-5827" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Langmuir" ],
-                "general" : [ "American Chemical Society" ],
-                "startdate" : [ "20160816" ],
-                "enddate" : [ "20160816" ],
-                "scope" : [ "NPM", "CITATION", "AAYXX", "7X8" ]
-              },
-              "display" : {
-                "description" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "title" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "language" : [ "eng" ],
-                "creator" : [ "Liang, Ting ; Chen, Chunlin ; Li, Xing ; Zhang, Jian" ],
-                "subject" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage ; Index Medicus" ],
-                "source" : [ "Alma/SFX Local Collection", "ACS Publications", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "publisher" : [ "United States: American Chemical Society" ],
-                "ispartof" : [ "Langmuir, 2016-08-16, Vol.32 (32), p.8042-8049" ],
-                "identifier" : [ "ISSN: 0743-7463", "EISSN: 1520-5827", "DOI: 10.1021/acs.langmuir.6b01953", "PMID: 27455183" ],
-                "rights" : [ "Copyright © 2016 American Chemical Society" ],
-                "snippet" : [ ".... Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn..." ],
-                "type" : [ "article" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "addata" : {
-                "format" : [ "journal" ],
-                "jtitle" : [ "Langmuir" ],
-                "genre" : [ "article" ],
-                "issn" : [ "0743-7463" ],
-                "addtitle" : [ "Langmuir" ],
-                "abstract" : [ "Porous carbon materials have drawn tremendous attention due to its applications in energy storage, gas/water purification, catalyst support, and other important fields. However, producing high-performance carbons via a facile and efficient route is still a big challenge. Here we report the synthesis of microporous carbon materials by employing a steam-explosion method with subsequent potassium activation and carbonization of the obtained popcorn. The obtained carbon features a large specific surface area, high porosity, and doped nitrogen atoms. Using as an electrode material in supercapacitor, it displays a high specific capacitance of 245 F g–1 at 0.5 A g–1 and a remarkable stability of 97.8% retention after 5000 cycles at 5 A g–1. The product also exhibits a high CO2 adsorption capacity of 4.60 mmol g–1 under 1066 mbar and 25 °C. Both areal specific capacitance and specific CO2 uptake are directly proportional to the surface nitrogen content. This approach could thus enlighten the batch production of porous nitrogen-doped carbons for a wide range of energy and environmental applications." ],
-                "pages" : [ "8042-8049" ],
-                "eissn" : [ "1520-5827" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "United States" ],
-                "pub" : [ "American Chemical Society" ],
-                "doi" : [ "10.1021/acs.langmuir.6b01953" ],
-                "au" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "atitle" : [ "Popcorn-Derived Porous Carbon for Energy Storage and CO2 Capture" ],
-                "date" : [ "2016-08-16" ],
-                "risdate" : [ "2016" ],
-                "volume" : [ "32" ],
-                "issue" : [ "32" ],
-                "spage" : [ "8042" ],
-                "epage" : [ "8049" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2016" ],
-                "language" : [ "eng" ],
-                "creatorcontrib" : [ "Liang, Ting", "Chen, Chunlin", "Li, Xing", "Zhang, Jian" ],
-                "topic" : [ "Interfaces: Adsorption, Reactions, Films, Forces, Measurement Techniques, Charge Transfer, Electrochemistry, Electrocatalysis, Energy Production and Storage", "Index Medicus" ],
-                "prefilter" : [ "articles" ],
-                "rsrctype" : [ "articles" ],
-                "collection" : [ "PubMed", "CrossRef", "MEDLINE - Academic" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Langmuir" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-04-16 10:42:13&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn-Derived+Porous+Carbon+for+Energy+Storage+and+CO2+Capture&rft.jtitle=Langmuir&rft.au=Liang%2C+Ting&rft.date=2016-08-16&rft.volume=32&rft.issue=32&rft.spage=8042&rft.epage=8049&rft.pages=8042-8049&rft.issn=0743-7463&rft.eissn=1520-5827&rft_id=info:doi/10.1021%2Facs.langmuir.6b01953&rft.pub=American+Chemical+Society&rft.place=United+States&rft_dat=<proquest_cross>1812224163</proquest_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-a2536-dbc7e5f4beb04eb0dc513679ac73621405bf6dc5a22f58de2569bd2b0d532b4b3" ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_1812224163"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "630",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "63",
-            "PC_SEARCH_TIME_TOTAL" : "693",
+            "PC_SEARCH_CALL_TIME" : "663",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "39",
+            "PC_SEARCH_TIME_TOTAL" : "702",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 694,
-            "COMBINED_SEARCH_TIME" : 700,
+            "BUILD_COMBINED_RESULTS_MAP" : 0,
+            "COMBINED_SEARCH_TIME" : 4,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ {
             "name" : "jtitle",
             "values" : [ {
               "value" : "The Washington Post",
-              "count" : "7847"
+              "count" : "7878"
             }, {
               "value" : "Chicago Tribune",
-              "count" : "7573"
+              "count" : "7579"
             }, {
               "value" : "The Los Angeles Times",
-              "count" : "6313"
+              "count" : "6322"
             }, {
               "value" : "The New York Times",
-              "count" : "5965"
+              "count" : "5992"
             }, {
               "value" : "Toronto Star",
-              "count" : "3742"
+              "count" : "3743"
             }, {
               "value" : "Edmonton Journal",
-              "count" : "2825"
+              "count" : "2833"
             }, {
               "value" : "Variety",
               "count" : "2731"
@@ -1317,25 +703,25 @@ http_interactions:
               "count" : "2612"
             }, {
               "value" : "The Wall Street Journal. Eastern Edition",
-              "count" : "2598"
+              "count" : "2600"
             }, {
               "value" : "National Post",
-              "count" : "2597"
+              "count" : "2598"
             } ]
           }, {
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "131393"
+              "count" : "131767"
             }, {
               "value" : "por",
-              "count" : "248"
+              "count" : "249"
             }, {
               "value" : "spa",
-              "count" : "196"
+              "count" : "202"
             }, {
               "value" : "ger",
-              "count" : "139"
+              "count" : "141"
             }, {
               "value" : "chi",
               "count" : "88"
@@ -1358,10 +744,10 @@ http_interactions:
               "value" : "slo",
               "count" : "11"
             }, {
-              "value" : "tur",
-              "count" : "8"
-            }, {
               "value" : "ita",
+              "count" : "9"
+            }, {
+              "value" : "tur",
               "count" : "8"
             }, {
               "value" : "nor",
@@ -1389,184 +775,184 @@ http_interactions:
             "name" : "topic",
             "values" : [ {
               "value" : "Motion Pictures",
-              "count" : "6832"
+              "count" : "6843"
             }, {
               "value" : "Science & Technology",
-              "count" : "5760"
+              "count" : "5824"
             }, {
               "value" : "Life Sciences & Biomedicine",
-              "count" : "4234"
+              "count" : "4279"
             }, {
               "value" : "Marketing",
-              "count" : "4061"
+              "count" : "4190"
             }, {
               "value" : "Restaurants",
-              "count" : "4043"
+              "count" : "4076"
             }, {
               "value" : "Food",
-              "count" : "2718"
+              "count" : "2726"
             }, {
               "value" : "Humans",
-              "count" : "2388"
+              "count" : "2418"
             }, {
               "value" : "Management",
-              "count" : "2115"
+              "count" : "2124"
             }, {
               "value" : "Analysis",
-              "count" : "1789"
+              "count" : "1800"
             }, {
               "value" : "Nutrition",
               "count" : "1711"
             }, {
-              "value" : "Theaters & Cinemas",
-              "count" : "1704"
-            }, {
               "value" : "Snack Foods",
-              "count" : "1698"
+              "count" : "1708"
             }, {
               "value" : "Methods",
-              "count" : "1694"
+              "count" : "1707"
+            }, {
+              "value" : "Theaters & Cinemas",
+              "count" : "1707"
             }, {
               "value" : "Motion Picture Industry",
-              "count" : "1694"
+              "count" : "1698"
             }, {
               "value" : "Diet",
-              "count" : "1638"
+              "count" : "1643"
             }, {
               "value" : "Research",
-              "count" : "1631"
+              "count" : "1641"
             }, {
               "value" : "Social Sciences",
-              "count" : "1577"
+              "count" : "1581"
             }, {
               "value" : "Theater",
-              "count" : "1505"
+              "count" : "1508"
             }, {
               "value" : "Health Aspects",
-              "count" : "1497"
+              "count" : "1501"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "newspaper_articles",
-              "count" : "62829"
+              "count" : "62942"
             }, {
               "value" : "articles",
-              "count" : "58135"
+              "count" : "58336"
             }, {
               "value" : "reviews",
-              "count" : "3948"
+              "count" : "3968"
             }, {
               "value" : "journals",
-              "count" : "2894"
+              "count" : "2903"
             }, {
               "value" : "book_chapters",
-              "count" : "2266"
+              "count" : "2265"
             }, {
               "value" : "reference_entrys",
-              "count" : "631"
+              "count" : "632"
             }, {
               "value" : "web_resources",
-              "count" : "504"
+              "count" : "535"
             }, {
               "value" : "conference_proceedings",
-              "count" : "327"
+              "count" : "328"
             }, {
               "value" : "reports",
-              "count" : "211"
+              "count" : "213"
             }, {
               "value" : "books",
               "count" : "135"
             }, {
               "value" : "text_resources",
-              "count" : "10"
+              "count" : "9"
             } ]
           }, {
             "name" : "domain",
             "values" : [ {
               "value" : "ProQuest Historical Newspapers",
-              "count" : "131890"
+              "count" : "132266"
             }, {
               "value" : "Global Newsstream",
-              "count" : "64299"
+              "count" : "64456"
             }, {
               "value" : "Factiva",
-              "count" : "60600"
+              "count" : "60921"
             }, {
               "value" : "Nexis Uni",
-              "count" : "54076"
+              "count" : "54236"
             }, {
               "value" : "PressReader",
-              "count" : "43237"
+              "count" : "43423"
             }, {
               "value" : "Single Journals",
-              "count" : "32916"
+              "count" : "32986"
             }, {
               "value" : "ABI/INFORM Collection",
-              "count" : "30697"
+              "count" : "30745"
             }, {
               "value" : "Academic Search Complete",
-              "count" : "19284"
+              "count" : "19383"
             }, {
               "value" : "Business Source Complete",
-              "count" : "17954"
+              "count" : "17986"
             }, {
               "value" : "Factiva (Selected Full Text)",
-              "count" : "7112"
+              "count" : "7127"
             }, {
               "value" : "Agricultural & Environmental Science Collection",
-              "count" : "6669"
+              "count" : "6734"
             }, {
               "value" : "Flipster",
-              "count" : "4706"
+              "count" : "4769"
             }, {
               "value" : "Ethnic NewsWatch",
-              "count" : "4258"
+              "count" : "4266"
             }, {
               "value" : "Advanced Technologies & Aerospace Collection",
-              "count" : "3232"
+              "count" : "3261"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "3206"
+              "count" : "3219"
             }, {
               "value" : "Environmental Science Collection",
-              "count" : "2852"
+              "count" : "2890"
             }, {
               "value" : "Freely Accessible General Interest Journals",
-              "count" : "2701"
+              "count" : "2717"
             }, {
               "value" : "Freely Accessible Journals",
-              "count" : "2654"
+              "count" : "2658"
             }, {
               "value" : "Wall Street Journal Online",
-              "count" : "2601"
+              "count" : "2603"
             }, {
-              "value" : "Directory of Open Access Journals",
-              "count" : "2532"
+              "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
+              "count" : "2574"
             } ]
           }, {
             "name" : "tlevel",
             "values" : [ {
               "value" : "open_access",
-              "count" : "3809"
+              "count" : "3866"
             }, {
               "value" : "peer_reviewed",
-              "count" : "10813"
+              "count" : "10892"
             }, {
               "value" : "online_resources",
-              "count" : "131890"
+              "count" : "132266"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "07 days back",
-              "count" : "33"
-            }, {
-              "value" : "90 days back",
-              "count" : "2420"
+              "count" : "24"
             }, {
               "value" : "30 days back",
-              "count" : "1736"
+              "count" : "186"
+            }, {
+              "value" : "90 days back",
+              "count" : "2557"
             } ]
           }, {
             "name" : "creationdate",
@@ -1605,7 +991,7 @@ http_interactions:
               "count" : "89"
             }, {
               "value" : "1956",
-              "count" : "70"
+              "count" : "69"
             }, {
               "value" : "1957",
               "count" : "84"
@@ -1644,94 +1030,94 @@ http_interactions:
               "count" : "50"
             }, {
               "value" : "1969",
-              "count" : "112"
+              "count" : "115"
             }, {
               "value" : "1970",
-              "count" : "86"
+              "count" : "90"
             }, {
               "value" : "1971",
-              "count" : "74"
+              "count" : "76"
             }, {
               "value" : "1972",
-              "count" : "103"
+              "count" : "105"
             }, {
               "value" : "1973",
-              "count" : "85"
+              "count" : "87"
             }, {
               "value" : "1974",
-              "count" : "110"
+              "count" : "111"
             }, {
               "value" : "1975",
               "count" : "100"
             }, {
               "value" : "1976",
-              "count" : "82"
+              "count" : "84"
             }, {
               "value" : "1977",
-              "count" : "133"
+              "count" : "137"
             }, {
               "value" : "1978",
-              "count" : "95"
+              "count" : "101"
             }, {
               "value" : "1979",
-              "count" : "119"
+              "count" : "122"
             }, {
               "value" : "1980",
               "count" : "194"
             }, {
               "value" : "1981",
-              "count" : "237"
+              "count" : "239"
             }, {
               "value" : "1982",
-              "count" : "274"
+              "count" : "276"
             }, {
               "value" : "1983",
               "count" : "229"
             }, {
               "value" : "1984",
-              "count" : "341"
+              "count" : "342"
             }, {
               "value" : "1985",
-              "count" : "759"
+              "count" : "760"
             }, {
               "value" : "1986",
-              "count" : "933"
+              "count" : "937"
             }, {
               "value" : "1987",
-              "count" : "1176"
+              "count" : "1177"
             }, {
               "value" : "1988",
-              "count" : "1234"
+              "count" : "1235"
             }, {
               "value" : "1989",
-              "count" : "1587"
-            }, {
-              "value" : "1990",
               "count" : "1588"
             }, {
+              "value" : "1990",
+              "count" : "1589"
+            }, {
               "value" : "1991",
-              "count" : "1842"
+              "count" : "1843"
             }, {
               "value" : "1992",
               "count" : "2047"
             }, {
               "value" : "1993",
-              "count" : "1935"
+              "count" : "1937"
             }, {
               "value" : "1994",
-              "count" : "2311"
+              "count" : "2312"
             }, {
               "value" : "1995",
-              "count" : "2257"
+              "count" : "2259"
             }, {
               "value" : "1996",
-              "count" : "2892"
+              "count" : "2894"
             }, {
               "value" : "1997",
-              "count" : "2843"
+              "count" : "2844"
             }, {
               "value" : "1998",
-              "count" : "3595"
+              "count" : "3596"
             }, {
               "value" : "1999",
               "count" : "3846"
@@ -1743,66 +1129,66 @@ http_interactions:
               "count" : "4157"
             }, {
               "value" : "2002",
-              "count" : "4397"
+              "count" : "4402"
             }, {
               "value" : "2003",
-              "count" : "4581"
+              "count" : "4585"
             }, {
               "value" : "2004",
-              "count" : "4939"
+              "count" : "4942"
             }, {
               "value" : "2005",
-              "count" : "5326"
+              "count" : "5328"
             }, {
               "value" : "2006",
-              "count" : "5015"
+              "count" : "5017"
             }, {
               "value" : "2007",
-              "count" : "5234"
+              "count" : "5236"
             }, {
               "value" : "2008",
-              "count" : "5025"
+              "count" : "5026"
             }, {
               "value" : "2009",
-              "count" : "4863"
+              "count" : "4864"
             }, {
               "value" : "2010",
-              "count" : "4789"
+              "count" : "4793"
             }, {
               "value" : "2011",
-              "count" : "4591"
+              "count" : "4592"
             }, {
               "value" : "2012",
-              "count" : "5085"
+              "count" : "5089"
             }, {
               "value" : "2013",
-              "count" : "5222"
+              "count" : "5227"
             }, {
               "value" : "2014",
-              "count" : "5022"
+              "count" : "5031"
             }, {
               "value" : "2015",
-              "count" : "4679"
+              "count" : "4667"
             }, {
               "value" : "2016",
-              "count" : "4464"
+              "count" : "4523"
             }, {
               "value" : "2017",
-              "count" : "4097"
+              "count" : "4092"
             }, {
               "value" : "2018",
-              "count" : "3760"
+              "count" : "3810"
             }, {
               "value" : "2019",
-              "count" : "3796"
+              "count" : "3797"
             }, {
               "value" : "2020",
-              "count" : "2969"
+              "count" : "2978"
             }, {
               "value" : "2021",
-              "count" : "748"
+              "count" : "933"
             } ]
           } ]
         }
-  recorded_at: Fri, 16 Apr 2021 14:42:13 GMT
+  recorded_at: Mon, 17 May 2021 15:06:15 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo_books.yml
+++ b/test/vcr_cassettes/popcorn_primo_books.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549998'
+      - '549995'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Fri, 16 Apr 2021 14:42:23 GMT
+      - Mon, 17 May 2021 15:06:25 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -49,7 +49,7 @@ http_interactions:
             "totalResultsPC" : -1,
             "total" : 132,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "description" : [ "POPCORN" ],
@@ -77,8 +77,7 @@ http_interactions:
                 "dedupmemberids" : [ "9933026557106761" ],
                 "contributor" : [ "Koppmann, Ralf.$$QKoppmann, Ralf." ],
                 "place" : [ "Dordrecht :" ],
-                "version" : [ "1" ],
-                "lds01" : [ "Geography.", "Climatic changes." ]
+                "version" : [ "1" ]
               },
               "control" : {
                 "sourcerecordid" : [ "990022823660206761" ],
@@ -87,7 +86,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "3.1706036E-4" ]
+                "score" : [ "2.9496138E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -187,6 +186,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -247,7 +247,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573078" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
+                "score" : [ "5.5851083E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -289,6 +289,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -327,7 +328,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573061" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
+                "score" : [ "5.5851083E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -369,6 +370,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -407,7 +409,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573073" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
+                "score" : [ "5.5851083E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -449,6 +451,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -487,7 +490,7 @@ http_interactions:
                 "originalsourceid" : [ "991000000000573053" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
+                "score" : [ "5.5851083E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
@@ -529,406 +532,7 @@ http_interactions:
               "hasFilteredServices" : null,
               "digitalAuxiliaryMode" : false,
               "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723106761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723106761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723106761" ],
-                "recordid" : [ "alma9933019723106761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573064" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573064" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Ireland" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Ireland" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9064624205021560521" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721206761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721206761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019721206761" ],
-                "recordid" : [ "alma9933019721206761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573079" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573079" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: the Netherlands" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: the Netherlands" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9013384081808631136" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724706761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724706761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019724706761" ],
-                "recordid" : [ "alma9933019724706761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573048" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573048" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Asia-Pacific" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Asia-Pacific" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9070104524867762023" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722806761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722806761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019722806761" ],
-                "recordid" : [ "alma9933019722806761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573067" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573067" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Mexico" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Mexico" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9050063563168056425" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
-              "GetIt1" : null,
-              "physicalServiceId" : null,
-              "link" : [ {
-                "@id" : ":_0",
-                "linkType" : "thumbnail",
-                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
-                "displayLabel" : "thumbnail"
-              } ],
-              "hasD" : null
-            },
-            "enrichment" : {
-              "virtualBrowseObject" : {
-                "isVirtualBrowseEnabled" : false,
-                "callNumber" : "",
-                "callNumberBrowseField" : ""
-              }
-            }
-          }, {
-            "context" : "L",
-            "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723906761",
-            "pnx" : {
-              "display" : {
-                "source" : [ "Alma" ],
-                "type" : [ "journal" ],
-                "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723906761" ],
-                "version" : [ "1" ]
-              },
-              "control" : {
-                "sourcerecordid" : [ "9933019723906761" ],
-                "recordid" : [ "alma9933019723906761" ],
-                "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573056" ],
-                "sourcesystem" : [ "SFX" ],
-                "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.9992314E-4" ]
-              },
-              "addata" : {
-                "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
-                "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573056" ],
-                "format" : [ "journal" ],
-                "genre" : [ "journal" ],
-                "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Europe" ]
-              },
-              "sort" : {
-                "title" : [ "Popcorn Industry Profile: Europe" ],
-                "creationdate" : [ "0000" ]
-              },
-              "facets" : {
-                "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9061988140408692301" ]
-              }
-            },
-            "delivery" : {
-              "bestlocation" : null,
-              "holding" : null,
-              "electronicServices" : null,
-              "filteredByGroupServices" : null,
-              "quickAccessService" : null,
-              "deliveryCategory" : [ "Alma-E" ],
-              "serviceMode" : [ "Viewit" ],
-              "availability" : [ "not_restricted" ],
-              "availabilityLinks" : null,
-              "availabilityLinksUrl" : null,
-              "displayedAvailability" : "Not available",
-              "displayLocation" : null,
-              "additionalLocations" : null,
-              "physicalItemTextCodes" : null,
-              "feDisplayOtherLocations" : null,
-              "almaInstitutionsList" : [ ],
-              "recordInstitutionCode" : null,
-              "recordOwner" : "01MIT_INST",
-              "hasFilteredServices" : null,
-              "digitalAuxiliaryMode" : false,
-              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : null,
               "physicalServiceId" : null,
               "link" : [ {
@@ -948,24 +552,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "741",
-            "CALL_SOLR_GET_IDS_LIST" : "4825",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "1853",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "313",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "96",
-            "RETRIVE_FROM_DB_RECORDS" : "286",
-            "RETRIVE_FROM_DB_RELATIONS" : "40",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "891",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "962",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "653",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "8090",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "66",
+            "CALL_SOLR_GET_IDS_LIST" : "500",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "495",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "1",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "42",
+            "RETRIVE_FROM_DB_RECORDS" : "19",
+            "RETRIVE_FROM_DB_RELATIONS" : "2",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "389",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "106",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "152",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "1227",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 10034,
-            "COMBINED_SEARCH_TIME" : 10038,
+            "BUILD_COMBINED_RESULTS_MAP" : 1256,
+            "COMBINED_SEARCH_TIME" : 1258,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Fri, 16 Apr 2021 14:42:24 GMT
+  recorded_at: Mon, 17 May 2021 15:06:26 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/primo_chapter.yml
+++ b/test/vcr_cassettes/primo_chapter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549985'
+      - '549989'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 10 May 2021 15:48:02 GMT
+      - Mon, 17 May 2021 15:07:39 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,32 +46,32 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 78,
-            "total" : 78,
+            "totalResultsPC" : 82,
+            "total" : 82,
             "first" : 1,
-            "last" : 10
+            "last" : 5
           },
           "highlights" : {
             "snippet" : [ "Spider Monkey Optimization algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm" ],
-            "title" : [ "Spider Monkey Optimization Algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm", "Spider Monkey Optimization algorithm" ],
+            "title" : [ "Spider Monkey Optimization Algorithm", "Spider monkey optimization algorithm" ],
             "termsUnion" : [ "Spider Monkey Optimization algorithm", "Spider monkey optimization algorithm", "spider monkey optimization algorithm", "Spider Monkey Optimization Algorithm" ]
           },
           "docs" : [ {
             "pnx" : {
               "sort" : {
-                "creationdate" : [ "20180607" ],
                 "title" : [ "Spider Monkey Optimization Algorithm" ],
+                "creationdate" : [ "20180607" ],
                 "author" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_springer_books_10_1007_978_3_319_91341_4_4" ],
-                "sourcerecordid" : [ "springer_books_10_1007_978_3_319_91341_4_4" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-s1027-f9f77010fc0aa79e296c03e91dcec7a8c16ed16a8d8415c09b83f7d0d8e09ce43" ],
-                "recordtype" : [ "book_chapter" ],
-                "addsrcrecordid" : [ "eNo9kMtOwzAURM1LopR-AZss2BrujRPbd1lVFJCKugAkdpZjO8Vqm0RxNvD1hPJYjWZGGmkOY1cINwigbklpLrhA4oSiQF6Y4ohdiDE4eHXMJqglcCpBnPwXgsrTv6Kgt3M2SylWMA5KnUsxYdfPXfShz57aZhs-snU3xH38tENsm2y-27R9HN73l-ystrsUZr86Za_Lu5fFA1-t7x8X8xVPCLniNdVKAULtwFpFISfpQARC74JTVjuUwaO02usCSwdUaVErD14HIBcKMWX4s5u6Pjab0JuqbbfJIJhvBmZkYIQZn5nDZzMyEF--DEpX" ],
                 "sourcetype" : [ "Publisher" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
+                "recordid" : [ "cdi_springer_books_10_1007_978_3_319_91341_4_4" ],
+                "sourcerecordid" : [ "springer_books_10_1007_978_3_319_91341_4_4" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
+                "recordtype" : [ "book_chapter" ],
+                "addsrcrecordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
                 "sourceid" : [ "springer" ],
                 "score" : [ "0.5" ]
               },
@@ -98,16 +98,17 @@ http_interactions:
                 "format" : [ "book" ]
               },
               "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
                 "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNo9kMtOwzAURM1LopR-AZss2BrujRPbd1lVFJCKugAkdpZjO8Vqm0RxNvD1hPJYjWZGGmkOY1cINwigbklpLrhA4oSiQF6Y4ohdiDE4eHXMJqglcCpBnPwXgsrTv6Kgt3M2SylWMA5KnUsxYdfPXfShz57aZhs-snU3xH38tENsm2y-27R9HN73l-ystrsUZr86Za_Lu5fFA1-t7x8X8xVPCLniNdVKAULtwFpFISfpQARC74JTVjuUwaO02usCSwdUaVErD14HIBcKMWX4s5u6Pjab0JuqbbfJIJhvBmZkYIQZn5nDZzMyEF--DEpX" ],
+                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
+                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
                 "recordtype" : [ "book_chapter" ],
+                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
+                "creationdate" : [ "2018" ],
                 "sourceid" : [ "" ],
                 "scope" : [ "" ],
                 "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
@@ -118,22 +119,22 @@ http_interactions:
                 "rsrctype" : [ "book_chapter" ],
                 "startdate" : [ "20180607" ],
                 "enddate" : [ "20180607" ],
-                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
                 "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
               },
               "display" : {
-                "title" : [ "Spider Monkey Optimization Algorithm" ],
-                "publisher" : [ "Cham: Springer International Publishing" ],
-                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
+                "lds50" : [ "peer_reviewed" ],
                 "type" : [ "book_chapter" ],
                 "source" : [ "Springer Book Series", "Springer Intelligent Technologies and Robotics eBooks 2019 English/International" ],
                 "creator" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
+                "publisher" : [ "Cham: Springer International Publishing" ],
+                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
                 "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
                 "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
                 "language" : [ "eng" ],
+                "relation" : [ "Studies in Computational Intelligence" ],
                 "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
                 "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
-                "lds50" : [ "peer_reviewed" ],
+                "title" : [ "Spider Monkey Optimization Algorithm" ],
                 "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
               },
               "delivery" : {
@@ -141,14 +142,14 @@ http_interactions:
                 "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
+                "language" : [ "eng" ],
                 "creationdate" : [ "2018" ],
                 "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
                 "rsrctype" : [ "book_chapters" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Spider monkey optimization", "Swarm intelligence", "Numerical optimization", "Fission-fusion social structure" ],
                 "prefilter" : [ "book_chapters" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1027-f9f77010fc0aa79e296c03e91dcec7a8c16ed16a8d8415c09b83f7d0d8e09ce43" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ]
               }
@@ -168,7 +169,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -183,23 +184,23 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "creationdate" : [ "201712" ],
                 "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "author" : [ "Gupta, Kavita ; Gupta, Kavita ; Deep, Kusum ; Deep, Kusum ; Bansal, Jagdish Chand ; Bansal, Jagdish Chand" ]
+                "creationdate" : [ "201712" ],
+                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_proquest_journals_1954549491" ],
-                "sourcerecordid" : [ "A511146853" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kEtLxDAYRYso-PwB7goupWO-PCbNchCfCC7UdcjkMUanTU06i_HXm05FUUGySAjn5H65RXEMaAII8bOEEEOoQjCtMAVRoa1iDyghFadcbG_OuOJTSnaL_ZReEMLAGdkrbh86b2wsm9C-2nUZut43_l31PrSlWi5C9P1zU7oQSx3a1EflW2t-Yl0M86Vt0mGx49Qy2aPP_aB4urx4PL-u7u6vbs5nd5XGtWBVzWCKCDaaGq45RiAop6yeE0J4regcCBbaWUGdwQaoI4JrBUbNlQFilSMHxcn4bg5-W9nUy5ewim2OlCAYZVRQAZmajNRCLa30rQt5eJ2XsY3Pf7HO5_sZAwA6rRnJAoyCjiGlaJ3som9UXEtAcuhYjh3L3LEcOpYoO6ejkzLbLmz8cvBADTQGicmG_074Q2_AwZjF3us81-b9zrj_E_jvhA-yYJtk" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_proqu" ],
                 "pqid" : [ "1954549491" ],
                 "galeid" : [ "A511146853" ],
-                "score" : [ "0.09795808" ]
+                "recordid" : [ "cdi_proquest_journals_1954549491" ],
+                "sourcerecordid" : [ "A511146853" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
+                "sourceid" : [ "gale_proqu" ],
+                "score" : [ "0.09796392" ]
               },
               "addata" : {
                 "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
@@ -207,7 +208,7 @@ http_interactions:
                 "issn" : [ "1432-7643" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
                 "stitle" : [ "Soft Comput" ],
                 "date" : [ "2017-12" ],
@@ -225,19 +226,20 @@ http_interactions:
                 "format" : [ "journal" ]
               },
               "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
-                "creator" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNp9kEtLxDAYRYso-PwB7goupWO-PCbNchCfCC7UdcjkMUanTU06i_HXm05FUUGySAjn5H65RXEMaAII8bOEEEOoQjCtMAVRoa1iDyghFadcbG_OuOJTSnaL_ZReEMLAGdkrbh86b2wsm9C-2nUZut43_l31PrSlWi5C9P1zU7oQSx3a1EflW2t-Yl0M86Vt0mGx49Qy2aPP_aB4urx4PL-u7u6vbs5nd5XGtWBVzWCKCDaaGq45RiAop6yeE0J4regcCBbaWUGdwQaoI4JrBUbNlQFilSMHxcn4bg5-W9nUy5ewim2OlCAYZVRQAZmajNRCLa30rQt5eJ2XsY3Pf7HO5_sZAwA6rRnJAoyCjiGlaJ3som9UXEtAcuhYjh3L3LEcOpYoO6ejkzLbLmz8cvBADTQGicmG_074Q2_AwZjF3us81-b9zrj_E_jvhA-yYJtk" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
+                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
+                "creationdate" : [ "2017" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
                 "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "issn" : [ "1432-7643", "1433-7479" ],
                 "fulltext" : [ "true" ],
                 "addtitle" : [ "Soft Comput" ],
@@ -245,22 +247,21 @@ http_interactions:
                 "rsrctype" : [ "article" ],
                 "startdate" : [ "201712" ],
                 "enddate" : [ "201712" ],
-                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
                 "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
               },
               "display" : {
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "lds50" : [ "peer_reviewed" ],
+                "type" : [ "article" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
                 "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
                 "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)", "© ProQuest LLC All rights reserved<img src=\"https://exlibris-pub.s3.amazonaws.com/PQ_Logo.jpg\" style=\"vertical-align:middle;margin-left:7px\">" ],
-                "creator" : [ "Gupta, Kavita ; Gupta, Kavita ; Deep, Kusum ; Deep, Kusum ; Bansal, Jagdish Chand ; Bansal, Jagdish Chand" ],
                 "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
                 "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
                 "language" : [ "eng" ],
                 "rights" : [ "Springer-Verlag GmbH Germany 2017", "Springer-Verlag Berlin Heidelberg 2016", "COPYRIGHT 2017 Springer" ],
                 "snippet" : [ "...Soft Comput (2017) 21:6933–6962\nDOI 10.1007/s00500-016-2419-0\nFOUNDATIONS\nSpider monkey optimization algorithm for constrained\noptimization problems\nKavita..." ],
-                "lds50" : [ "peer_reviewed" ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
                 "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
               },
               "delivery" : {
@@ -268,15 +269,15 @@ http_interactions:
                 "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
-                "creationdate" : [ "2017" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Gupta, Kavita", "Deep, Kusum", "Deep, Kusum", "Bansal, Jagdish Chand", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
                 "language" : [ "eng" ],
+                "creationdate" : [ "2017" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "articles" ],
                 "topic" : [ "Engineering", "Deb’s technique", "CEC2006", "Computational Intelligence", "Control, Robotics, Mechatronics", "Artificial Intelligence (incl. Robotics)", "Spider monkey optimization", "CEC2010", "Mathematical Logic and Foundations", "Constrained optimization", "Monkeys", "Algorithms", "Mathematical optimization", "Analysis", "Bees", "Optimization algorithms", "Benchmarks", "Global optimization", "Swarm intelligence" ],
                 "prefilter" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)", "Soft Computing" ]
               }
@@ -296,14 +297,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ],
-                "citedby" : [ "FETCH-LOGICAL-c2895-8516032dc4d7c7201947458b33378a4b1329cfe94fd2d14f397ca1dabad13eaf3" ]
+                "citing" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
+                "citedby" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ]
               },
               "timesCited" : { }
             },
@@ -311,22 +312,22 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "creationdate" : [ "20200911" ],
                 "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "creationdate" : [ "20200911" ],
                 "author" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A648108178" ],
-                "sourcerecordid" : [ "A648108178" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNotkMtOQyEQhonRxHp5AVe8ABU4FM5Z1nprUu2imrg7QRha9BQqkBh9etGaWUwyme9P_g-hC0bHjFJ1mRnjShHKKaFK0YbIAzRiE8VJ24iXQzSiHe-I5Iwfo5Oc3yitWMdH6GMRtcVXetDB-LDGPuBVdOVTJyDX4HwAix-hfMb0nvFz_n1Z7byFhB9ieIcvvNwVv_XfuvgY8HRYx-TLZotdTLhsAM9DgRSg4Ojw06bi-QwdOT1kOP_fp-j59uZpdk8Wy7v5bLoghk0EJ8q8ug66idXCcq2dACmVlbq1XEpNHRil2KvTTeuMkOCEFcpRy7QBUTHZnKLxPnetB-h9cLEkbepY2HoTQy1X71MpWkZbptoK8D1gUsw5get3yW91-uoZ7X8t93vLfbXc_1nuZfMD1NRyeA" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A648108178" ],
-                "score" : [ "0.066328235" ]
+                "recordid" : [ "cdi_gale_infotracacademiconefile_A648108178" ],
+                "sourcerecordid" : [ "A648108178" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
+                "sourceid" : [ "gale_cross" ],
+                "score" : [ "0.06633203" ]
               },
               "addata" : {
                 "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
@@ -348,17 +349,18 @@ http_interactions:
                 "format" : [ "journal" ]
               },
               "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "creationdate" : [ "2020" ],
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
                 "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "recordid" : [ "eNotkMtOQyEQhonRxHp5AVe8ABU4FM5Z1nprUu2imrg7QRha9BQqkBh9etGaWUwyme9P_g-hC0bHjFJ1mRnjShHKKaFK0YbIAzRiE8VJ24iXQzSiHe-I5Iwfo5Oc3yitWMdH6GMRtcVXetDB-LDGPuBVdOVTJyDX4HwAix-hfMb0nvFz_n1Z7byFhB9ieIcvvNwVv_XfuvgY8HRYx-TLZotdTLhsAM9DgRSg4Ojw06bi-QwdOT1kOP_fp-j59uZpdk8Wy7v5bLoghk0EJ8q8ug66idXCcq2dACmVlbq1XEpNHRil2KvTTeuMkOCEFcpRy7QBUTHZnKLxPnetB-h9cLEkbepY2HoTQy1X71MpWkZbptoK8D1gUsw5get3yW91-uoZ7X8t93vLfbXc_1nuZfMD1NRyeA" ],
+                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
+                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX", "BSHEE" ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
+                "creationdate" : [ "2020" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
                 "issn" : [ "0929-6212", "1572-834X" ],
                 "fulltext" : [ "true" ],
@@ -366,22 +368,21 @@ http_interactions:
                 "rsrctype" : [ "article" ],
                 "startdate" : [ "20200911" ],
                 "enddate" : [ "20200911" ],
-                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
                 "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
               },
               "display" : {
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
-                "publisher" : [ "Springer" ],
-                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
+                "lds50" : [ "peer_reviewed" ],
                 "type" : [ "article" ],
                 "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
                 "creator" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
+                "publisher" : [ "Springer" ],
+                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
                 "identifier" : [ "ISSN: 0929-6212", "EISSN: 1572-834X", "DOI: 10.1007/s11277-020-07703-6" ],
                 "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
                 "language" : [ "eng" ],
                 "rights" : [ "COPYRIGHT 2021 Springer" ],
                 "snippet" : [ ".... By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA..." ],
-                "lds50" : [ "peer_reviewed" ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
                 "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
               },
               "delivery" : {
@@ -389,15 +390,15 @@ http_interactions:
                 "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
+                "language" : [ "eng" ],
                 "creationdate" : [ "2020" ],
                 "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
                 "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Information networks", "Monkeys", "Computer networks", "Engineering schools", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Wireless personal communications" ]
               }
@@ -417,13 +418,13 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c1542-7cbf9e95da4d2aaf4e667d6a8d266a0fec771bfa38fc46ef4d47f0d1ace4e9563" ],
+                "citing" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "citedby" : [ ]
               },
               "timesCited" : { }
@@ -432,21 +433,21 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "creationdate" : [ "2015" ],
                 "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "creationdate" : [ "2015" ],
                 "author" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2015_08_504" ],
-                "sourcerecordid" : [ "S1877050915026393" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kLFOwzAQhi0EEhX0CVj8Agnnxo6dgaFULSAVFQk6W459AZc2juwIqTw9acvAxC13w32_fn2E3DDIGbDydpN3MdiUT4CJHFQugJ-REVNSZiCgOv9zX5JxShsYplCqYnJE5gvft5gSvTcJHX0Jyfc-tHTdOdMj9S197bzDSJ9D-4l7uup6v_Pf5vg03b6H6PuP3TW5aMw24fh3X5H1Yv42e8yWq4en2XSZsaLgMqssR-tsCdyqCW9Eg6xxshSiUMYYmDSiLHnFuFSVgbqWrhailpViADVzThVXpDjl2hhSitjoLvqdiXvNQB9k6I0-ytAHGRqUHmQM1N2JwqHal8eok_XYWnQ-ou21C_5f_gfv2WkK" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
+                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2015_08_504" ],
+                "sourcerecordid" : [ "S1877050915026393" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
                 "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.066328235" ]
+                "score" : [ "0.06633203" ]
               },
               "addata" : {
                 "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
@@ -469,18 +470,19 @@ http_interactions:
                 "format" : [ "journal" ]
               },
               "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "creationdate" : [ "2015" ],
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
                 "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "recordid" : [ "eNp9kLFOwzAQhi0EEhX0CVj8Agnnxo6dgaFULSAVFQk6W459AZc2juwIqTw9acvAxC13w32_fn2E3DDIGbDydpN3MdiUT4CJHFQugJ-REVNSZiCgOv9zX5JxShsYplCqYnJE5gvft5gSvTcJHX0Jyfc-tHTdOdMj9S197bzDSJ9D-4l7uup6v_Pf5vg03b6H6PuP3TW5aMw24fh3X5H1Yv42e8yWq4en2XSZsaLgMqssR-tsCdyqCW9Eg6xxshSiUMYYmDSiLHnFuFSVgbqWrhailpViADVzThVXpDjl2hhSitjoLvqdiXvNQB9k6I0-ytAHGRqUHmQM1N2JwqHal8eok_XYWnQ-ou21C_5f_gfv2WkK" ],
+                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
+                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
                 "recordtype" : [ "article" ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
+                "creationdate" : [ "2015" ],
                 "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
+                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ],
                 "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
                 "issn" : [ "1877-0509", "1877-0509" ],
                 "fulltext" : [ "true" ],
@@ -488,22 +490,21 @@ http_interactions:
                 "rsrctype" : [ "article" ],
                 "startdate" : [ "2015" ],
                 "enddate" : [ "2015" ],
-                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
                 "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
               },
               "display" : {
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
+                "lds50" : [ "peer_reviewed" ],
                 "type" : [ "article" ],
                 "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
                 "creator" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
+                "publisher" : [ "Elsevier B.V" ],
+                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
                 "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2015.08.504" ],
                 "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
                 "language" : [ "eng" ],
                 "rights" : [ "2015 The Authors" ],
                 "snippet" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired..." ],
-                "lds50" : [ "peer_reviewed" ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
                 "oa" : [ "free_for_read" ],
                 "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
               },
@@ -512,15 +513,15 @@ http_interactions:
                 "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
+                "language" : [ "eng" ],
                 "creationdate" : [ "2015" ],
                 "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
                 "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Engineering optimization problems", "fission-fusion social structure", "Nature Inspired Algorithms", "Swarm intelligence", "Spider Monkey Optimization Algorithm" ],
                 "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
+                "collection" : [ "ScienceDirect Open Access Titles", "Elsevier:ScienceDirect:Open Access", "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Procedia computer science" ]
               }
@@ -540,14 +541,14 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
             "extras" : {
               "citationTrails" : {
                 "citing" : [ ],
-                "citedby" : [ "FETCH-LOGICAL-13347-9c4ecdc604c824f5fe1fd765538aaa02f5664914789a0bb7db55b798100b1dd83" ]
+                "citedby" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ]
               },
               "timesCited" : { }
             },
@@ -555,22 +556,22 @@ http_interactions:
           }, {
             "pnx" : {
               "sort" : {
-                "creationdate" : [ "201705" ],
                 "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "creationdate" : [ "201705" ],
                 "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A491502847" ],
-                "sourcerecordid" : [ "A491502847" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12628-49cdf08056271eddc7487514e58c6139354e0cde7e87bfa641a9c95245c812153" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpHgdO3aOUcWjUqFCpefIdZzWkNiREx7lB_ht3JYLu4dd7eyOZgehayATiHGjvXUToETCCRoBy0QiM0ZO0YhIyhKRp_wcXfT9KyEEUiZH6GfWdsF_WLfBw9bgudeqwUujgt7iYm0bO-ywr_Gys5UJ-NG7N7PDi26wrf1Wg_UOF83GBztsW7zq9zTP76oKEdK46CL1l22Pe7UPeOW0d_0QlHWm-kdzic5q1fTm6q-O0eru9mX6kMwX97NpMU-AZlQmLNdVTSThGRVgqkoLJgUHZrjUGaTxP2aIrowwUqxrlTFQuc45ZVxLoMDTMZoceTeqMaV1tY9qdMzKtDaKM7WN84LlwAmVTMQDOB58RmBXdiH-E3YlkHJveLk3vDwYXk4Xs6dDl_4CByB4Ow" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_wiley" ],
                 "galeid" : [ "A491502847" ],
-                "score" : [ "0.06524447" ]
+                "recordid" : [ "cdi_gale_infotracacademiconefile_A491502847" ],
+                "sourcerecordid" : [ "A491502847" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
+                "sourceid" : [ "gale_wiley" ],
+                "score" : [ "0.06524757" ]
               },
               "addata" : {
                 "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
@@ -594,16 +595,17 @@ http_interactions:
                 "format" : [ "journal" ]
               },
               "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
                 "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpHgdO3aOUcWjUqFCpefIdZzWkNiREx7lB_ht3JYLu4dd7eyOZgehayATiHGjvXUToETCCRoBy0QiM0ZO0YhIyhKRp_wcXfT9KyEEUiZH6GfWdsF_WLfBw9bgudeqwUujgt7iYm0bO-ywr_Gys5UJ-NG7N7PDi26wrf1Wg_UOF83GBztsW7zq9zTP76oKEdK46CL1l22Pe7UPeOW0d_0QlHWm-kdzic5q1fTm6q-O0eru9mX6kMwX97NpMU-AZlQmLNdVTSThGRVgqkoLJgUHZrjUGaTxP2aIrowwUqxrlTFQuc45ZVxLoMDTMZoceTeqMaV1tY9qdMzKtDaKM7WN84LlwAmVTMQDOB58RmBXdiH-E3YlkHJveLk3vDwYXk4Xs6dDl_4CByB4Ow" ],
+                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
+                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
                 "recordtype" : [ "article" ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
+                "creationdate" : [ "2017" ],
                 "scope" : [ "BSHEE" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "issn" : [ "0824-7935", "1467-8640" ],
@@ -612,22 +614,21 @@ http_interactions:
                 "rsrctype" : [ "article" ],
                 "startdate" : [ "201705" ],
                 "enddate" : [ "201705" ],
-                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
                 "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
               },
               "display" : {
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "publisher" : [ "Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
+                "lds50" : [ "peer_reviewed" ],
                 "type" : [ "article" ],
                 "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
                 "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
+                "publisher" : [ "Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
                 "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
                 "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
                 "language" : [ "eng" ],
                 "rights" : [ "2016 Wiley Periodicals, Inc.", "COPYRIGHT 2017 Blackwell Publishers Ltd." ],
                 "snippet" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm..." ],
-                "lds50" : [ "peer_reviewed" ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
                 "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
               },
               "delivery" : {
@@ -635,15 +636,15 @@ http_interactions:
                 "delcategory" : [ "Remote Search Resource" ]
               },
               "facets" : {
+                "language" : [ "eng" ],
                 "creationdate" : [ "2017" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
                 "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization", "Lennard–Jones problem", "Usage", "Monkeys", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
                 "collection" : [ "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12628-49cdf08056271eddc7487514e58c6139354e0cde7e87bfa641a9c95245c812153" ],
+                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Computational intelligence" ]
               }
@@ -663,7 +664,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -675,584 +676,14 @@ http_interactions:
               "timesCited" : { }
             },
             "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A491502847"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "20181110" ],
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "author" : [ "Kumar, Sandeep ; Sharma, Basudev ; Sharma, Vivek Kumar ; Poonia, Ramesh C" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1007_s12065_018_0186_9" ],
-                "sourcerecordid" : [ "10_1007_s12065_018_0186_9" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNo9kMtOwzAURC0EEqXwAez8A4brPPxYVhUvqRKb7oNr36SGJo5sZ1G-npQiFqOZxdyr0SHknsMDB5CPiRcgagZcnSSYviCL2StWay4v_zPoa3KT0ieAKEBWC_KxmnLoTUZHU_AHOkZ03mYfBjolP3R0ZzoWWtaiyVPERM3gqN2bkL2lafQOI-3D8IVHGsbse_9tfo_NoQvR531_S65ac0h49-dLsn1-2q5f2eb95W292jArBLB5_Q41OgG8BCm1MbYulNOysK6uSmi1U4XSysytVmoUmheItuKqdkraslwSfn5rY0gpYtuM0fcmHhsOzYlQcybUzHROEo0ufwArd1st" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.06390624" ]
-              },
-              "addata" : {
-                "orcidid" : [ "https://orcid.org/0000-0001-8054-2405" ],
-                "issn" : [ "1864-5909" ],
-                "jtitle" : [ "Evolutionary intelligence" ],
-                "genre" : [ "article" ],
-                "au" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "atitle" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "date" : [ "2018-11-10" ],
-                "risdate" : [ "2018" ],
-                "eissn" : [ "1864-5917" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1007/s12065-018-0186-9" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm", "Evolutionary intelligence" ],
-                "creator" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "recordid" : [ "eNo9kMtOwzAURC0EEqXwAez8A4brPPxYVhUvqRKb7oNr36SGJo5sZ1G-npQiFqOZxdyr0SHknsMDB5CPiRcgagZcnSSYviCL2StWay4v_zPoa3KT0ieAKEBWC_KxmnLoTUZHU_AHOkZ03mYfBjolP3R0ZzoWWtaiyVPERM3gqN2bkL2lafQOI-3D8IVHGsbse_9tfo_NoQvR531_S65ac0h49-dLsn1-2q5f2eb95W292jArBLB5_Q41OgG8BCm1MbYulNOysK6uSmi1U4XSysytVmoUmheItuKqdkraslwSfn5rY0gpYtuM0fcmHhsOzYlQcybUzHROEo0ufwArd1st" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "orcidid" : [ "https://orcid.org/0000-0001-8054-2405" ],
-                "issn" : [ "1864-5909", "1864-5917" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20181110" ],
-                "enddate" : [ "20181110" ]
-              },
-              "display" : {
-                "title" : [ "Automated soil prediction using bag-of-features and chaotic spider monkey optimization algorithm" ],
-                "ispartof" : [ "Evolutionary intelligence, 2018-11-10" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Kumar, Sandeep ; Sharma, Basudev ; Sharma, Vivek Kumar ; Poonia, Ramesh C" ],
-                "identifier" : [ "ISSN: 1864-5909", "EISSN: 1864-5917", "DOI: 10.1007/s12065-018-0186-9" ],
-                "language" : [ "eng" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2018" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Sharma, Basudev", "Sharma, Vivek Kumar", "Poonia, Ramesh C" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Evolutionary intelligence" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Automated+soil+prediction+using+bag-of-features+and+chaotic+spider+monkey+optimization+algorithm&rft.jtitle=Evolutionary+intelligence&rft.au=Kumar%2C+Sandeep&rft.date=2018-11-10&rft.issn=1864-5909&rft.eissn=1864-5917&rft_id=info:doi/10.1007%2Fs12065-018-0186-9&rft_dat=<crossref>10_1007_s12065_018_0186_9</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-LOGICAL-c660-120be9ed60130779aac528d972cd5430f9d82898abe9f79e6912eec4185d87c33" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1007_s12065_018_0186_9"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "201705" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1111_coin_12081" ],
-                "sourcerecordid" : [ "10_1111_coin_12081" ],
-                "originalsourceid" : [ "FETCH-crossref_primary_10_1111_coin_120813" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqVj81KxDAUhYMoWH82PsFdCx2TaZ2pyyKKA4rIOOsS03R6tc0NN1GsL-Br26obl57NWZzDB58QJ0rO1JgzQ-hmai4LtSMSlS-WabHI5a5IZDHP0-VFdr4vDkJ4llKqLC8S8bnqPdMbui3E1sItGd3B2mo2LZRP2GEcgBpYe6wtwx25FzvAvY_Y44eOSA7KbkuMse1hEybMw6uueZwMlH5Ev2P_82uIYeMMuRBZo7P1H8yR2Gt0F-zxbx-K0-urx8ub1DCFwLapPI8kHiolq0m1mlSrb9XsX-cvLItezw" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.063295685" ]
-              },
-              "addata" : {
-                "issn" : [ "0824-7935" ],
-                "jtitle" : [ "Computational intelligence" ],
-                "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "date" : [ "2017-05" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "33" ],
-                "issue" : [ "2" ],
-                "spage" : [ "210" ],
-                "epage" : [ "240" ],
-                "pages" : [ "210-240" ],
-                "eissn" : [ "1467-8640" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1111/coin.12081" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization: Improving the Local Search Ability of SMO Using QA", "Computational intelligence" ],
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNqVj81KxDAUhYMoWH82PsFdCx2TaZ2pyyKKA4rIOOsS03R6tc0NN1GsL-Br26obl57NWZzDB58QJ0rO1JgzQ-hmai4LtSMSlS-WabHI5a5IZDHP0-VFdr4vDkJ4llKqLC8S8bnqPdMbui3E1sItGd3B2mo2LZRP2GEcgBpYe6wtwx25FzvAvY_Y44eOSA7KbkuMse1hEybMw6uueZwMlH5Ev2P_82uIYeMMuRBZo7P1H8yR2Gt0F-zxbx-K0-urx8ub1DCFwLapPI8kHiolq0m1mlSrb9XsX-cvLItezw" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "issn" : [ "0824-7935", "1467-8640" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201705" ],
-                "enddate" : [ "201705" ]
-              },
-              "display" : {
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization: Improving the Local Search Ability of SMO Using QA" ],
-                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
-                "language" : [ "eng" ],
-                "lds50" : [ "peer_reviewed" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2017" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-crossref_primary_10_1111_coin_120813" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Computational intelligence" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft_dat=<crossref>10_1111_coin_12081</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ "FETCH-crossref_primary_10_1111_coin_120813" ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1111_coin_12081"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "author" : [ "Rani, R. Ranjani ; Ramyachitra, D" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2018_10_358" ],
-                "sourcerecordid" : [ "S1877050918320544" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-12543-474d325cb71cf555026d88971220a31edb4874af4b7851318ba89a8602647b53" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kMFOAjEQhhujiQR5Ai99gV3bbUvLwQPZCJpAOIBem27bxeKyu2kXDTy9hdXEk3OZyeT__8x8ANxjlGKExw-7tPWNDmmGsIiblDBxBQZYcJ4ghibXf-ZbMAphh2IRISaYD8DX0mnfKO_VEeaq1tbDua0tnFnVHbyFa1tZ3bmmhq_B1Vu4bp2JmmVTf9gjXLWd27uTugim1bbxrnvfQ1Wb37C8UiG40ulec-hD3pZ34KZUVbCjnz4Em9nTJn9OFqv5Sz5dJDhjlCSUU0MypguOdckYQ9nYxMs5zjKkCLamoIJTVdKCC4YJFoUSEyXGUUd5wcgQkD42PhmCt6Vsvdsrf5QYyTM9uZMXevJM77yM9KLrsXfZeNmns14G7Wz8xzgfaUjTuH_93z-BedI" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06325995" ]
-              },
-              "addata" : {
-                "abstract" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ],
-                "issn" : [ "1877-0509" ],
-                "oa" : [ "free_for_read" ],
-                "jtitle" : [ "Procedia computer science" ],
-                "genre" : [ "article" ],
-                "au" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "atitle" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "date" : [ "2018" ],
-                "risdate" : [ "2018" ],
-                "volume" : [ "143" ],
-                "spage" : [ "108" ],
-                "epage" : [ "116" ],
-                "pages" : [ "108-116" ],
-                "eissn" : [ "1877-0509" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.procs.2018.10.358" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM", "Procedia computer science" ],
-                "creator" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "recordid" : [ "eNp9kMFOAjEQhhujiQR5Ai99gV3bbUvLwQPZCJpAOIBem27bxeKyu2kXDTy9hdXEk3OZyeT__8x8ANxjlGKExw-7tPWNDmmGsIiblDBxBQZYcJ4ghibXf-ZbMAphh2IRISaYD8DX0mnfKO_VEeaq1tbDua0tnFnVHbyFa1tZ3bmmhq_B1Vu4bp2JmmVTf9gjXLWd27uTugim1bbxrnvfQ1Wb37C8UiG40ulec-hD3pZ34KZUVbCjnz4Em9nTJn9OFqv5Sz5dJDhjlCSUU0MypguOdckYQ9nYxMs5zjKkCLamoIJTVdKCC4YJFoUSEyXGUUd5wcgQkD42PhmCt6Vsvdsrf5QYyTM9uZMXevJM77yM9KLrsXfZeNmns14G7Wz8xzgfaUjTuH_93z-BedI" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "issn" : [ "1877-0509", "1877-0509" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2018" ],
-                "enddate" : [ "2018" ],
-                "subject" : [ "Feature Selection ; Spider Monkey Optimization ; Support Vector Machine ; Microarray Cancer Gene Expression ; Classification" ],
-                "description" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ]
-              },
-              "display" : {
-                "title" : [ "Microarray Cancer Gene Feature Selection Using Spider Monkey Optimization Algorithm and Cancer Classification using SVM" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia computer science, 2018, Vol.143, p.108-116" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Rani, R. Ranjani ; Ramyachitra, D" ],
-                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2018.10.358" ],
-                "subject" : [ "Feature Selection ; Spider Monkey Optimization ; Support Vector Machine ; Microarray Cancer Gene Expression ; Classification" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2018" ],
-                "snippet" : [ ".... This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "The microarray cancer gene expression data is used for classifying the cancer disease. This work focuses on two objectives, first is the cancer gene feature selection by employing a new swarm intelligence technique, namely Spider Monkey Optimization algorithm in order to minimize the number of features in cancer data. The second objective is to classify cancer data by employing the subset of gene features obtained by the first objective. The proposed method has experimented with various benchmark cancer datasets and it reveals that the proposed method outperforms all other existing techniques in terms of the minimum number of features and maximum classification accuracy." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2018" ],
-                "creatorcontrib" : [ "Rani, R. Ranjani", "Ramyachitra, D" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "topic" : [ "Feature Selection", "Spider Monkey Optimization", "Support Vector Machine", "Microarray Cancer Gene Expression", "Classification" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-12543-474d325cb71cf555026d88971220a31edb4874af4b7851318ba89a8602647b53" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Procedia computer science" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Microarray+Cancer+Gene+Feature+Selection+Using+Spider+Monkey+Optimization+Algorithm+and+Cancer+Classification+using+SVM&rft.jtitle=Procedia+computer+science&rft.au=Rani%2C+R.+Ranjani&rft.date=2018&rft.volume=143&rft.spage=108&rft.epage=116&rft.pages=108-116&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2018.10.358&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050918320544</elsevier_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procs_2018_10_358"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "author" : [ "Wang, Zhengya ; Mumtaz, Jabir ; Zhang, Li ; Yue, Lei" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procir_2019_04_075" ],
-                "sourcerecordid" : [ "S2212827119306894" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-11931-c3017c05527bd0c3917682dfc02eaf53beddcf0fcc23b1b8ca88b9cc032c1d383" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kE1LxDAQhoMouKz7DzzkD7Tmo922F2Fd_IKVFdRzSCfJmrVpQlIW1l9vl3rw5FxmYOZ9GB6ErinJKaHLm30eogcbc0Zok5MiJ1V5hmaMUZbVrKLnf-ZLtEhpT8aqCsIpm6GwCqGzIAfre-wNlj22bgQetMJvwSod8Yvvv_QRb8Ngnf2eLmW389EOnw4bHzF4F3yv-wHLlOyud6dxhLSddtj2-HV9d9po13bHK3RhZJf04rfP0cfD_fv6KdtsH5_Xq01GacNpBpzQCkhZsqpVBHhDq2XNlAHCtDQlb7VSYIgBYLylbQ2yrtsGgHAGVPGaz1ExcSH6lKI2IkTrZDwKSsRJnNiLSZw4iROkEKO4MXY7xfT428HqKBJY3YNWNmoYhPL2f8APZyB7eQ" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06181559" ]
-              },
-              "addata" : {
-                "abstract" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ],
-                "issn" : [ "2212-8271" ],
-                "oa" : [ "free_for_read" ],
-                "jtitle" : [ "Procedia CIRP" ],
-                "genre" : [ "article" ],
-                "au" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "atitle" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "date" : [ "2019" ],
-                "risdate" : [ "2019" ],
-                "volume" : [ "83" ],
-                "spage" : [ "266" ],
-                "epage" : [ "271" ],
-                "pages" : [ "266-271" ],
-                "eissn" : [ "2212-8271" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.procir.2019.04.075" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly", "Procedia CIRP" ],
-                "creator" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "recordid" : [ "eNp9kE1LxDAQhoMouKz7DzzkD7Tmo922F2Fd_IKVFdRzSCfJmrVpQlIW1l9vl3rw5FxmYOZ9GB6ErinJKaHLm30eogcbc0Zok5MiJ1V5hmaMUZbVrKLnf-ZLtEhpT8aqCsIpm6GwCqGzIAfre-wNlj22bgQetMJvwSod8Yvvv_QRb8Ngnf2eLmW389EOnw4bHzF4F3yv-wHLlOyud6dxhLSddtj2-HV9d9po13bHK3RhZJf04rfP0cfD_fv6KdtsH5_Xq01GacNpBpzQCkhZsqpVBHhDq2XNlAHCtDQlb7VSYIgBYLylbQ2yrtsGgHAGVPGaz1ExcSH6lKI2IkTrZDwKSsRJnNiLSZw4iROkEKO4MXY7xfT428HqKBJY3YNWNmoYhPL2f8APZyB7eQ" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "AAFTH", "6I.", "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "issn" : [ "2212-8271", "2212-8271" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2019" ],
-                "enddate" : [ "2019" ],
-                "subject" : [ "Printed circuit board assembly ; component assignment ; Spider Monkey Optimizaton algorithm ; Product Services" ],
-                "description" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ]
-              },
-              "display" : {
-                "title" : [ "Application of an improved Spider Monkey Optimization algorithm for component assignment problem in PCB assembly" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia CIRP, 2019, Vol.83, p.266-271" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Wang, Zhengya ; Mumtaz, Jabir ; Zhang, Li ; Yue, Lei" ],
-                "identifier" : [ "ISSN: 2212-8271", "EISSN: 2212-8271", "DOI: 10.1016/j.procir.2019.04.075" ],
-                "subject" : [ "Printed circuit board assembly ; component assignment ; Spider Monkey Optimizaton algorithm ; Product Services" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2019" ],
-                "snippet" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm,..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "This paper presents a new optimization method for printed circuit board assembly (PCBA) process based on improved spider monkey optimization (SMO) algorithm, and a production model for PCBA is created. The proposed method proves to be suitable for product-service system(PSS). PCBA process mainly consists of three parts. First is the assignment of PCB, second is the assignment of machines, the last is the component assignment problem. In this research, the SMO algorithm is applied on optimization of component assignment which is divided into two stages: local leader phase (LLP) and global leader phase (GLP). In the first stage, the electronic components are assigned to the feeders by GLP. In the second stage, the component placement sequence, which is apparently known as a travelling salesman problem (TSP), is determined by LLP. Numerical experiments are performed to compare the performance of SMO algorithm with others under various experimental settings, the results show that the proposed method is more effective than other traditional methods. A production model is created with the proposed method, which is calimed to be able to increase the efficiency of the product services." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "creatorcontrib" : [ "Wang, Zhengya", "Mumtaz, Jabir", "Zhang, Li", "Yue, Lei" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "topic" : [ "Printed circuit board assembly", "component assignment", "Spider Monkey Optimizaton algorithm", "Product Services" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "Elsevier:ScienceDirect:Open Access", "ScienceDirect Open Access Titles", "CrossRef" ],
-                "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-11931-c3017c05527bd0c3917682dfc02eaf53beddcf0fcc23b1b8ca88b9cc032c1d383" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "Procedia CIRP" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Application+of+an+improved+Spider+Monkey+Optimization+algorithm+for+component+assignment+problem+in+PCB+assembly&rft.jtitle=Procedia+CIRP&rft.au=Wang%2C+Zhengya&rft.date=2019&rft.volume=83&rft.spage=266&rft.epage=271&rft.pages=266-271&rft.issn=2212-8271&rft.eissn=2212-8271&rft_id=info:doi/10.1016%2Fj.procir.2019.04.075&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S2212827119306894</elsevier_cross>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procir_2019_04_075"
-          }, {
-            "pnx" : {
-              "sort" : {
-                "creationdate" : [ "20190517" ],
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "author" : [ "Singh, Prabhat Ranjan ; Moussa, Diallo ; Shengwu, Xiong ; Singh, Bikram Prasad" ]
-              },
-              "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_17993_3ctecno_2019_specialissue2_142_165" ],
-                "sourcerecordid" : [ "10_17993_3ctecno_2019_specialissue2_142_165" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-11175-cb627af98509b03c0bafd2258f677e62e309ace951edb8e3cc2237a2e128afe03" ],
-                "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNpV0EtLAzEUBeAgCpba_5C9zJibzCvLUnwUWio-1iGTudHozGRIRqH-esfaha7uWVwOh4-QS2AplFKKK2FGNL1POQOZxgGN062L8QN5ChlPoMhPyIzzPEsyyMTpn3xOFjG-McaAgxQcZuRh3Q3Bf2JDHwfXYKBb37_jnu6G0XXuS4_O93TZvvjgxteOjp6OQbuebjf31PpAGz1qalodo7POHN4vyJnVbcTF8c7J88310-ou2exu16vlJgGAMk9MXfBSW1nlTNZMGFZr20xLK1uUJRYcBZPaoMwBm7pCYQznotQcgVfaIhNzsvrtNcHHGNCqIbhOh70Cpg5S6iilfqTUPyk1SalJSnwDyHhlLA" ],
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.051464017" ]
-              },
-              "addata" : {
-                "issn" : [ "2254-4143" ],
-                "jtitle" : [ "3C tecnología" ],
-                "genre" : [ "article" ],
-                "au" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "atitle" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "date" : [ "2019-05-17" ],
-                "risdate" : [ "2019" ],
-                "spage" : [ "142" ],
-                "epage" : [ "165" ],
-                "pages" : [ "142-165" ],
-                "eissn" : [ "2254-4143" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.17993/3ctecno.2019.specialissue2.142-165" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2019" ],
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification", "3C tecnología" ],
-                "creator" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "recordid" : [ "eNpV0EtLAzEUBeAgCpba_5C9zJibzCvLUnwUWio-1iGTudHozGRIRqH-esfaha7uWVwOh4-QS2AplFKKK2FGNL1POQOZxgGN062L8QN5ChlPoMhPyIzzPEsyyMTpn3xOFjG-McaAgxQcZuRh3Q3Bf2JDHwfXYKBb37_jnu6G0XXuS4_O93TZvvjgxteOjp6OQbuebjf31PpAGz1qalodo7POHN4vyJnVbcTF8c7J88310-ou2exu16vlJgGAMk9MXfBSW1nlTNZMGFZr20xLK1uUJRYcBZPaoMwBm7pCYQznotQcgVfaIhNzsvrtNcHHGNCqIbhOh70Cpg5S6iilfqTUPyk1SalJSnwDyHhlLA" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CITATION", "AAYXX" ],
-                "creatorcontrib" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "issn" : [ "2254-4143", "2254-4143" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20190517" ],
-                "enddate" : [ "20190517" ]
-              },
-              "display" : {
-                "title" : [ "Improved Spider Monkey Optimization Algorithm to train MLP for data classification" ],
-                "ispartof" : [ "3C tecnología, 2019-05-17, p.142-165" ],
-                "type" : [ "article" ],
-                "source" : [ "Publicly Available Content Database", "Alma/SFX Local Collection" ],
-                "creator" : [ "Singh, Prabhat Ranjan ; Moussa, Diallo ; Shengwu, Xiong ; Singh, Bikram Prasad" ],
-                "identifier" : [ "ISSN: 2254-4143", "EISSN: 2254-4143", "DOI: 10.17993/3ctecno.2019.specialissue2.142-165" ],
-                "language" : [ "eng" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
-              },
-              "facets" : {
-                "creationdate" : [ "2019" ],
-                "creatorcontrib" : [ "Singh, Prabhat Ranjan", "Moussa, Diallo", "Shengwu, Xiong", "Singh, Bikram Prasad" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
-                "prefilter" : [ "articles" ],
-                "collection" : [ "CrossRef" ],
-                "toplevel" : [ "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-11175-cb627af98509b03c0bafd2258f677e62e309ace951edb8e3cc2237a2e128afe03" ],
-                "frbrtype" : [ "5" ],
-                "jtitle" : [ "3C tecnología" ]
-              }
-            },
-            "delivery" : {
-              "link" : [ {
-                "@id" : "_:0",
-                "linkType" : "http://purl.org/pnx/linkType/thumbnail",
-                "linkURL" : "syndetics_thumb_exl",
-                "displayLabel" : "thumbnail"
-              } ],
-              "deliveryCategory" : [ "Remote Search Resource" ],
-              "availability" : [ "fulltext" ],
-              "displayLocation" : false,
-              "additionalLocations" : false,
-              "physicalItemTextCodes" : "",
-              "feDisplayOtherLocations" : false,
-              "displayedAvailability" : "true",
-              "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-10 11:48:03&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improved+Spider+Monkey+Optimization+Algorithm+to+train+MLP+for+data+classification&rft.jtitle=3C+tecnolog%C3%ADa&rft.au=Singh%2C+Prabhat+Ranjan&rft.date=2019-05-17&rft.spage=142&rft.epage=165&rft.pages=142-165&rft.issn=2254-4143&rft.eissn=2254-4143&rft_id=info:doi/10.17993%2F3ctecno.2019.specialissue2.142-165&rft_dat=<crossref>10_17993_3ctecno_2019_specialissue2_142_165</crossref>&svc_dat=viewit"
-            },
-            "context" : "PC",
-            "adaptor" : "Primo Central",
-            "extras" : {
-              "citationTrails" : {
-                "citing" : [ ],
-                "citedby" : [ ]
-              },
-              "timesCited" : { }
-            },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_17993_3ctecno_2019_specialissue2_142_165"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "174",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "100",
-            "PC_SEARCH_TIME_TOTAL" : "274",
+            "PC_SEARCH_CALL_TIME" : "451",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "42",
+            "PC_SEARCH_TIME_TOTAL" : "493",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 276,
-            "COMBINED_SEARCH_TIME" : 286,
+            "BUILD_COMBINED_RESULTS_MAP" : 494,
+            "COMBINED_SEARCH_TIME" : 501,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
@@ -1293,36 +724,36 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "78"
+              "count" : "82"
             } ]
           }, {
             "name" : "topic",
             "values" : [ {
               "value" : "Algorithms",
-              "count" : "40"
+              "count" : "43"
             }, {
               "value" : "Science & Technology",
-              "count" : "33"
+              "count" : "35"
             }, {
               "value" : "Engineering",
-              "count" : "31"
+              "count" : "33"
             }, {
               "value" : "Optimization",
-              "count" : "30"
+              "count" : "33"
             }, {
               "value" : "Technology",
-              "count" : "30"
+              "count" : "32"
+            }, {
+              "value" : "Mathematical Optimization",
+              "count" : "18"
             }, {
               "value" : "Swarm Intelligence",
+              "count" : "17"
+            }, {
+              "value" : "Monkeys",
               "count" : "16"
             }, {
               "value" : "Computer Science",
-              "count" : "15"
-            }, {
-              "value" : "Mathematical Optimization",
-              "count" : "15"
-            }, {
-              "value" : "Monkeys",
               "count" : "15"
             }, {
               "value" : "Optimization Algorithms",
@@ -1331,17 +762,17 @@ http_interactions:
               "value" : "Spider Monkey Optimization",
               "count" : "14"
             }, {
+              "value" : "Engineering, Electrical & Electronic",
+              "count" : "13"
+            }, {
               "value" : "Optimierungsalgorithmus",
               "count" : "13"
             }, {
-              "value" : "Engineering, Electrical & Electronic",
+              "value" : "Analysis",
               "count" : "12"
             }, {
               "value" : "Artificial Intelligence",
               "count" : "11"
-            }, {
-              "value" : "Analysis",
-              "count" : "10"
             }, {
               "value" : "Computational Intelligence",
               "count" : "10"
@@ -1350,19 +781,19 @@ http_interactions:
               "count" : "10"
             }, {
               "value" : "Physical Sciences",
-              "count" : "9"
+              "count" : "10"
+            }, {
+              "value" : "Genetic Algorithms",
+              "count" : "8"
             }, {
               "value" : "Optimierungsproblem",
               "count" : "8"
-            }, {
-              "value" : "Computer Science, Artificial Intelligence",
-              "count" : "7"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "articles",
-              "count" : "50"
+              "count" : "54"
             }, {
               "value" : "book_chapters",
               "count" : "12"
@@ -1380,31 +811,40 @@ http_interactions:
             "name" : "domain",
             "values" : [ {
               "value" : "Advanced Technologies & Aerospace Collection",
-              "count" : "25"
+              "count" : "28"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "24"
+              "count" : "26"
             }, {
               "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
-              "count" : "19"
+              "count" : "20"
             }, {
               "value" : "SpringerLink Contemporary (1997 - Present)",
-              "count" : "18"
+              "count" : "19"
             }, {
               "value" : "Publicly Available Content Database",
-              "count" : "14"
+              "count" : "16"
             }, {
               "value" : "ABI/INFORM Collection",
+              "count" : "14"
+            }, {
+              "value" : "Academic Search Complete",
               "count" : "13"
             }, {
               "value" : "Ebook Central Perpetual and DDA",
               "count" : "12"
             }, {
-              "value" : "Academic Search Complete",
-              "count" : "11"
-            }, {
               "value" : "Springer Book Series",
               "count" : "9"
+            }, {
+              "value" : "Wiley Online Library All Journals",
+              "count" : "8"
+            }, {
+              "value" : "Wiley Online Library Journals + OA Offset 2015-2017",
+              "count" : "8"
+            }, {
+              "value" : "Wiley Online Library Full Collection 2016",
+              "count" : "8"
             }, {
               "value" : "SpringerLink ebooks - Engineering (Contemporary)",
               "count" : "7"
@@ -1412,7 +852,7 @@ http_interactions:
               "value" : "SpringerLink ebooks - Engineering (Archive and Contemporary)",
               "count" : "7"
             }, {
-              "value" : "Wiley Online Library All Journals",
+              "value" : "Wiley Online Library All Backfiles",
               "count" : "6"
             }, {
               "value" : "Journals Consult",
@@ -1424,19 +864,10 @@ http_interactions:
               "value" : "ScienceDirect Journals (Transactional Access)",
               "count" : "6"
             }, {
-              "value" : "Wiley Online Library Journals + OA Offset 2015-2017",
-              "count" : "6"
-            }, {
               "value" : "Factiva",
               "count" : "6"
             }, {
-              "value" : "Wiley Online Library Full Collection 2016",
-              "count" : "6"
-            }, {
-              "value" : "Wiley Online Library All Backfiles",
-              "count" : "5"
-            }, {
-              "value" : "SpringerLINK Archive - Computer Science",
+              "value" : "Agricultural & Environmental Science Collection",
               "count" : "5"
             } ]
           }, {
@@ -1446,19 +877,19 @@ http_interactions:
               "count" : "22"
             }, {
               "value" : "peer_reviewed",
-              "count" : "43"
+              "count" : "45"
             }, {
               "value" : "online_resources",
-              "count" : "78"
+              "count" : "82"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "30 days back",
-              "count" : "1"
+              "count" : "2"
             }, {
               "value" : "90 days back",
-              "count" : "4"
+              "count" : "5"
             } ]
           }, {
             "name" : "creationdate",
@@ -1482,12 +913,12 @@ http_interactions:
               "count" : "12"
             }, {
               "value" : "2020",
-              "count" : "18"
+              "count" : "20"
             }, {
               "value" : "2021",
-              "count" : "11"
+              "count" : "15"
             } ]
           } ]
         }
-  recorded_at: Mon, 10 May 2021 15:48:04 GMT
+  recorded_at: Mon, 17 May 2021 15:07:39 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### Why these changes are being introduced:

We will be replacing EDS with Primo, so our Bento search should display
results from the Primo Search API.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-1776

#### How this addresses that need:

* Uses primo_search feature flag to conditionally display Primo search
results.
* Adds limit param to Primo search so we can control the number of
results in the Bento view.

#### Side effects of this change:

* All VCR cassettes for tests related to the Primo Search API have
been regenerated due to the new param.
* The PRIMO_SEARCH env variable is now type cast as a boolean to allow
for clearer enabling/disabling of the feature flag. (I.e., if it is set
to true, Bento returns Primo results; if set to false, Bento returns
EDS results).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
