### PR TITLE
Implement stakeholder feedback for IMP-2008

### DIFF
--- a/app/models/normalize_primo_articles.rb
+++ b/app/models/normalize_primo_articles.rb
@@ -37,8 +37,16 @@ class NormalizePrimoArticles
     "#{@record['pnx']['addata']['date'].join('')}, pp. #{@record['pnx']['addata']['pages'].join('')}"
   end
 
+  # Here we are converting the Alma link resolver URL provided by the Primo 
+  # Search API to redirect to the Primo UI. This is done for UX purposes, 
+  # as the regular Alma link resolver URLs redirect to a plaintext 
+  # disambiguation page.
   def openurl
     return unless @record['delivery']['almaOpenurl']
-    @record['delivery']['almaOpenurl']
+    primo_openurl = ['https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=',
+                     ENV['EXL_INST_ID'], '&vid=', ENV['PRIMO_VID'],'&'].join('')
+    link_resolver_url = @record['delivery']['almaOpenurl'].gsub('https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?',
+                                                                primo_openurl)
+    [link_resolver_url, '&u.ignore_date_coverage=true'].join('')
   end
 end

--- a/app/models/normalize_primo_books.rb
+++ b/app/models/normalize_primo_books.rb
@@ -54,8 +54,9 @@ class NormalizePrimoBooks
     return unless @record['delivery']['deliveryCategory']
     mms_id = @record['pnx']['display']['mms'].first
     if @record['delivery']['deliveryCategory'].include?('Alma-E')
-      [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=', ENV['EXL_INST_ID'],
-      '&vid=', ENV['PRIMO_VID'], '&rft.mms_id=', mms_id].join('')
+      [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=', 
+       ENV['EXL_INST_ID'], '&vid=', ENV['PRIMO_VID'], '&rft.mms_id=', mms_id,
+       '&u.ignore_date_coverage=true'].join('')
     end
   end
 end

--- a/test/models/normalize_primo_articles_test.rb
+++ b/test/models/normalize_primo_articles_test.rb
@@ -91,7 +91,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
 
   test 'constructs full-text links as expected' do
     result = popcorn_articles['results'].first
-    assert_equal 'https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit',
+    assert_equal 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit&u.ignore_date_coverage=true',
                   result.openurl
   end
 

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -96,7 +96,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
 
   test 'constructs full-text links as expected' do
     result = popcorn_books['results'].first
-    assert_equal "https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&rft.mms_id=990022823660206761",
+    assert_equal "https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&rft.mms_id=990022823660206761&u.ignore_date_coverage=true",
                  result.openurl
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

* Full-text links for CDI records lead to a disambiguation page with no
styling.
* Some records' links include a link to the eresource's table of contents,
but not to the full-text.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2008

#### How this addresses that need:

* Modifies the openurl call in the `almaOpenUrl` field to redirect to the
Primo UI.
* Adds `u.ignore_date_coverage` param to all openurl links so full-text
links display instead of ToC links.

#### Side effects of this change:

This assumes consistency in the `almaOpenUrl` field in the Primo Search API response. If a CDI record does not have the standard base URL in this
field, then the full-text link will likely fail.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
