### PR TITLE
IMP-2055 Remove hyphens from subject links

### DIFF
--- a/app/models/normalize_primo_books.rb
+++ b/app/models/normalize_primo_books.rb
@@ -36,6 +36,8 @@ class NormalizePrimoBooks
   end
 
   def subject_link(subj)
+    # We need to remove hyphens to accommodate Primo's subject browse
+    subj = subj.split('--').map { |el| el.strip }.join(' ') if subj.include?('--')
     [ENV['MIT_PRIMO_URL'], '/discovery/browse?browseQuery=', 
      subj, '&browseScope=subject.1&vid=', ENV['PRIMO_VID']].join('')
   end

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -69,6 +69,13 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     assert_nil result.subjects
   end
 
+  test 'removes hyphens from subject links' do
+    result = physical_book['results'].first
+    assert_equal ['Linguists -- United States',
+                  'https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Linguists United States&browseScope=subject.1&vid=FAKE_PRIMO_VID'],
+                 result.subjects.second
+  end
+
   test 'constructs locations as expected' do
     result = physical_book['results'].first
     assert_equal [['Library Storage Annex Off Campus Collection', 


### PR DESCRIPTION
#### Why these changes are being introduced:

Relevance in the Primo subject browse is poor for queries that include
hyphens. This is a problem because compound subjects in library metadata
are divided with hyphens.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2056

#### How this addresses that need:

This removes hyphens from compound subject links.

#### Side effects of this change:

We are still displaying hyphens in the UI, so there's a risk for
confusion when the linked Primo subject browse query is punctuated
differently.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
