### PR TITLE
IMP-2055 Update Primo API scopes and fix 'view more' links

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,12 @@ custom hint metadata.
 - `MAX_AUTHORS`: the maximum number of authors displayed in any record.
   If exceeded, 'et al' will be appended after this number.
 - `PRIMO_SEARCH`: toggles feature flag to use Primo instead of EDS.
-- `PRIMO_SEARCH_API_KEY`: the Primo Search API key.
-- `PRIMO_SEARCH_API_URL`: the root URL for the Primo Search API.
+- `PRIMO_API_KEY`: the Primo API key.
+- `PRIMO_API_URL`: the server URL for the Primo API.
 - `PRIMO_VID`: our Primo 'view ID'.
+- `PRIMO_TAB`: the value of the Primo `tab` param for Bento.
+- `PRIMO_MAIN_VIEW_TAB` the value of the `tab` param for the Primo UI 
+main search view. (This is used for links to Primo searches.)
 - `PRIMO_BOOK_SCOPE`: assigned to the `scope` param of a Primo Search 
 API endpoint to limit the search to local/Alma (Books+) results.
 - `PRIMO_ARTICLE_SCOPE`: assigned to the `scope` param of a Primo Search 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,7 +47,7 @@ class SearchController < ApplicationController
 
   # Array of search endpoints that are supported
   def valid_targets
-    %w[articles books google timdex alma cdi]
+    %w[articles books google timdex catalog cdi]
   end
 
   # Formatted date used in creating cache keys
@@ -90,7 +90,7 @@ class SearchController < ApplicationController
   end
 
   def primo_scope
-    params[:target] == 'alma' ? ENV['PRIMO_BOOK_SCOPE'] : ENV['PRIMO_ARTICLE_SCOPE']
+    params[:target] == 'catalog' ? ENV['PRIMO_BOOK_SCOPE'] : ENV['PRIMO_ARTICLE_SCOPE']
   end
 
   # Searches Google Custom Search

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -8,7 +8,7 @@ module SearchHelper
       'website'
     elsif params[:target] == 'timdex'
       'archives and manuscripts'
-    elsif params[:target] == 'alma'
+    elsif params[:target] == 'catalog'
       'books'
     elsif params[:target] == 'cdi'
       'articles'

--- a/app/models/normalize_primo.rb
+++ b/app/models/normalize_primo.rb
@@ -21,7 +21,8 @@ class NormalizePrimo
 
   def primo_ui_view_more(q)
     [ENV['MIT_PRIMO_URL'], '/discovery/search?query=any,contains,', q,
-     '&tab=bento&scope=', @type, '&vid=', ENV['PRIMO_VID']].join('')
+     '&tab=', ENV['PRIMO_MAIN_VIEW_TAB'],'&search_scope=', @type, '&vid=', 
+     ENV['PRIMO_VID']].join('')
   end
 
   def extract_results(results, norm)
@@ -36,7 +37,7 @@ class NormalizePrimo
     common = NormalizePrimoCommon.new(record, @type)
     result = Result.new(common.title, common.link)
     result = common.common_metadata(result)
-    result = if @type == 'alma'
+    result = if @type == ENV['PRIMO_BOOK_SCOPE']
                NormalizePrimoBooks.new(record).book_metadata(result)
              else
                NormalizePrimoArticles.new(record).article_metadata(result)

--- a/app/models/search_primo.rb
+++ b/app/models/search_primo.rb
@@ -1,20 +1,22 @@
 # Searches Primosearch API and formats results into {Result} object
 #
 # == Required Environment Variables:
-# - PRIMO_SEARCH_API_URL
-# - PRIMO_SEARCH_API_KEY
+# - PRIMO_API_URL
+# - PRIMO_API_KEY
 # - PRIMO_VID
+# - PRIMO_TAB
 #
 
 class SearchPrimo
   attr_reader :results
 
-  PRIMO_SEARCH_API_URL = ENV['PRIMO_SEARCH_API_URL'].freeze
-  PRIMO_SEARCH_API_KEY = ENV['PRIMO_SEARCH_API_KEY']
+  PRIMO_API_URL = ENV['PRIMO_API_URL'].freeze
+  PRIMO_API_KEY = ENV['PRIMO_API_KEY']
   PRIMO_VID = ENV['PRIMO_VID']
+  PRIMO_TAB = ENV['PRIMO_TAB']
 
   def initialize
-    @primo_http = HTTP.persistent(PRIMO_SEARCH_API_URL)
+    @primo_http = HTTP.persistent(PRIMO_API_URL)
     @results = {}
   end
 
@@ -37,8 +39,8 @@ class SearchPrimo
   # This is subject to change. Right now we are just using the required 
   # params and assuming that no operators are used.
   def search_url(term, scope, per_page)
-    [PRIMO_SEARCH_API_URL, '/primo/v1/search?q=any,contains,', 
-      clean_term(term), '&vid=', PRIMO_VID, '&tab=bento&scope=', scope,
-      '&limit=', per_page, '&apikey=', PRIMO_SEARCH_API_KEY].join('')
+    [PRIMO_API_URL, '/search?q=any,contains,', clean_term(term), '&vid=', 
+      PRIMO_VID, '&tab=', PRIMO_TAB, '&scope=', scope, '&limit=', 
+      per_page, '&apikey=', PRIMO_API_KEY].join('')
   end
 end

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -25,7 +25,7 @@
     <% if result.type %>
       <span class="result-type"><span class="sr">Type: </span><%= result.type %></span>
     <% end %>
-    <% if result.year.present? && (params[:target] == 'books' || params[:target] ==  'alma') %>
+    <% if result.year.present? && (params[:target] == 'books' || params[:target] == ENV['PRIMO_BOOK_SCOPE']) %>
       <span class="result-year">Published <%= result.year %></span>
     <% end %>
   </p>
@@ -36,7 +36,7 @@
         <% result.truncated_authors.each do |author| %>
         <span class="result-author">
           <% next if author[0] == nil %>
-          <% if params[:target] == 'alma' || params[:target] == 'cdi' %>
+          <% if params[:target] == ENV['PRIMO_BOOK_SCOPE'] || params[:target] == ENV['PRIMO_ARTICLE_SCOPE'] %>
             <%= link_to(author[0], author[1], data: {type: "Author"}) unless author == "et al" %>
           <% else %>
             <%= link_to(author[0], search_prefix + author[1], data: {type: "Author"} ) unless author == "et al" %>
@@ -79,7 +79,7 @@
         <ul class="list-subjects">
         <% result.truncated_subjects.each do |subject| %>
           <li class="result-subjectheading">
-            <% if params[:target] == 'alma' %>
+            <% if params[:target] == ENV['PRIMO_BOOK_SCOPE'] %>
               <%= link_to(subject[0], subject[1], data: {type: "Subject"} ) %>
             <% else %>
               <%= link_to(subject[0], search_prefix + subject[1], data: {type: "Subject"} ) %>

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -8,9 +8,9 @@
     <span class="title">Found: </span>
 
     <% if Flipflop.enabled? :primo_search %>
-      <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="alma">Books+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+      <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="<%= ENV['PRIMO_BOOK_SCOPE'] %>">Books+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
 
-      <a href="#box-articles_content" data-type="Jump to articles"><span class="results-summary-item" data-region="cdi">Articles+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
+      <a href="#box-articles_content" data-type="Jump to articles"><span class="results-summary-item" data-region="<%= ENV['PRIMO_ARTICLE_SCOPE'] %>">Articles+ <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
     <% else %>
       <a href="#box-books_content" data-type="Jump to books"><span class="results-summary-item" data-region="books">Books and media <span class="count"><i class="fa fa-spinner fa-spin"></i></span></span></a>
 
@@ -53,9 +53,9 @@
 
 <script>
   <% if Flipflop.enabled? :primo_search %>
-    <%= render partial: "trigger_search", locals: { target: 'cdi', id: 'articles_content'} %>
+    <%= render partial: "trigger_search", locals: { target: ENV['PRIMO_ARTICLE_SCOPE'], id: 'articles_content'} %>
 
-    <%= render partial: "trigger_search", locals: { target: 'alma', id: 'books_content'} %>
+    <%= render partial: "trigger_search", locals: { target: ENV['PRIMO_BOOK_SCOPE'], id: 'books_content'} %>
   <% else %>
     <%= render partial: "trigger_search", locals: { target: 'articles', id: 'articles_content'} %>
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,11 +31,12 @@ Rails.application.configure do
 
   ENV['EXL_INST_ID'] = '01MIT_INST'
   ENV['PRIMO_SEARCH'] = 'true'
-  ENV['PRIMO_SEARCH_API_URL'] = 'https://another_fake_server.example.com'
-  ENV['PRIMO_SEARCH_API_KEY'] = 'FAKE_PRIMO_SEARCH_API_KEY'
+  ENV['PRIMO_API_URL'] = 'https://another_fake_server.example.com/v1'
+  ENV['PRIMO_API_KEY'] = 'FAKE_PRIMO_API_KEY'
   ENV['PRIMO_VID'] = 'FAKE_PRIMO_VID'
-  ENV['PRIMO_BOOK_SCOPE'] = 'alma'
-  ENV['PRIMO_ARTICLE_SCOPE'] = 'cdi'
+  ENV['PRIMO_TAB'] = 'FAKE_PRIMO_TAB'
+  ENV['PRIMO_BOOK_SCOPE'] = 'FAKE_PRIMO_BOOK_SCOPE'
+  ENV['PRIMO_ARTICLE_SCOPE'] = 'FAKE_PRIMO_ARTICLE_SCOPE'
   ENV['MIT_PRIMO_URL'] = 'https://mit.primo.exlibrisgroup.com'
   ENV['SYNDETICS_PRIMO_URL'] = 'https://syndetics.com/index.php?client=primo'
 

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -53,7 +53,7 @@ class SearchTest < ActionDispatch::IntegrationTest
   test 'Primo local results are populated' do
     VCR.use_cassette('popcorn primo books',
                      allow_playback_repeats: true) do
-      get '/search/search_boxed?q=popcorn&target=alma'
+      get '/search/search_boxed?q=popcorn&target=catalog'
       assert_response :success
       assert_select('a.bento-link') do |value|
         assert value.text.include?('Atmospheric Measurements during POPCORN')

--- a/test/models/normalize_primo_articles_test.rb
+++ b/test/models/normalize_primo_articles_test.rb
@@ -89,9 +89,13 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
     assert_equal 'volume 2012', result.citation
   end
 
+  # Note: after regenerating the cassette for this test, you will need to 
+  # copy the openurl params from the 'almaOpenUrl' element of the first 
+  # result in the response. This is because a timestamp is included in 
+  # the openurl call and will change with each API call.
   test 'constructs full-text links as expected' do
     result = popcorn_articles['results'].first
-    assert_equal 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit&u.ignore_date_coverage=true',
+    assert_equal 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit&u.ignore_date_coverage=true',
                   result.openurl
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,14 +76,25 @@ VCR.configure do |config|
     (ENV['GOOGLE_CUSTOM_SEARCH_ID']).to_s
   end
 
-  config.filter_sensitive_data('https://another_fake_server.example.com') do
-    (ENV['PRIMO_SEARCH_API_URL']).to_s
+  # The only sensitive data here is the API key, but filtering these makes 
+  # for less frequent cassette regeneration and thus less test suite maintenance.
+  config.filter_sensitive_data('https://another_fake_server.example.com/v1') do
+    (ENV['PRIMO_API_URL']).to_s
   end
-  config.filter_sensitive_data('FAKE_PRIMO_SEARCH_API_KEY') do
-    (ENV['PRIMO_SEARCH_API_KEY']).to_s
+  config.filter_sensitive_data('FAKE_PRIMO_API_KEY') do
+    (ENV['PRIMO_API_KEY']).to_s
   end
   config.filter_sensitive_data('FAKE_PRIMO_VID') do
     (ENV['PRIMO_VID']).to_s
+  end
+  config.filter_sensitive_data('FAKE_PRIMO_TAB') do
+    (ENV['PRIMO_TAB']).to_s
+  end
+  config.filter_sensitive_data('FAKE_PRIMO_BOOK_SCOPE') do
+    (ENV['PRIMO_BOOK_SCOPE']).to_s
+  end
+  config.filter_sensitive_data('FAKE_PRIMO_ARTICLE_SCOPE') do
+    (ENV['PRIMO_ARTICLE_SCOPE']).to_s
   end
 end
 

--- a/test/vcr_cassettes/local_journal_primo.yml
+++ b/test/vcr_cassettes/local_journal_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Journal%20of%20heat%20transfer&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,Journal%20of%20heat%20transfer&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549993'
+      - '549968'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:23 GMT
+      - Wed, 19 May 2021 14:29:36 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -45,9 +45,9 @@ http_interactions:
       string: |-
         {
           "info" : {
-            "totalResultsLocal" : 89,
+            "totalResultsLocal" : 90,
             "totalResultsPC" : -1,
-            "total" : 89,
+            "total" : 90,
             "first" : 1,
             "last" : 5
           },
@@ -73,6 +73,8 @@ http_interactions:
                 "format" : [ "v. : ill. ; 29 cm." ],
                 "identifier" : [ "$$CLC$$V   61019573 //r892;$$CISSN$$V0022-1481;$$COCLC$$V(OCoLC)01782922;$$COCLC$$V(OCoLC)01713702;$$COCLC$$V(OCoLC)09764105" ],
                 "creationdate" : [ "c1959-" ],
+                "lds07" : [ "TA1 JHTRAO 01782922 01713702 09764105    61019573 //r892 0022-1481" ],
+                "lds09" : [ "New York, N.Y. : American Society of Mechanical Engineers,    1959   nyu" ],
                 "publisher" : [ "New York, N.Y. : American Society of Mechanical Engineers", "Vol. 81, no. 1 (Feb. 1959)-" ],
                 "mms" : [ "990002935920206761" ],
                 "dedupmemberids" : [ "9933112204206761" ],
@@ -91,7 +93,7 @@ http_interactions:
                 "originalsourceid" : [ "000293592-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.31791705" ]
+                "score" : [ "0.32407373" ]
               },
               "addata" : {
                 "stitle" : [ "J. heat transfer" ],
@@ -286,6 +288,8 @@ http_interactions:
                 "format" : [ "ill., diagrs. 25 cm." ],
                 "identifier" : [ "$$CLC$$V   64009791;$$CISSN$$V0017-9310;$$COCLC$$V(OCoLC)01753576" ],
                 "creationdate" : [ "1960" ],
+                "lds07" : [ "536.205 QC320 IJHMAK 01753576    64009791 0017-9310" ],
+                "lds09" : [ "Oxford, Pergamon Press.    1960   enk" ],
                 "publisher" : [ "Oxford, New York, Pergamon Press.", "v. 1-   June 1960-" ],
                 "mms" : [ "990002819760206761" ],
                 "dedupmemberids" : [ "9933113796606761" ],
@@ -303,7 +307,7 @@ http_interactions:
                 "originalsourceid" : [ "000281976-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.00488179" ]
+                "score" : [ "0.0050428086" ]
               },
               "addata" : {
                 "stitle" : [ "Int. j. heat mass transfer" ],
@@ -515,7 +519,7 @@ http_interactions:
                 "originalsourceid" : [ "000368998-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.011505032" ]
+                "score" : [ "0.011899742" ]
               },
               "addata" : {
                 "stitle" : [ "J. thermophys. heat transf." ],
@@ -639,7 +643,7 @@ http_interactions:
               }, {
                 "@id" : ":_1",
                 "linkType" : "linktorsrc",
-                "linkURL" : "http://catalog.hathitrust.org/api/volumes/oclc/13392807.html",
+                "linkURL" : "http://FAKE_PRIMO_BOOK_SCOPE.hathitrust.org/api/volumes/oclc/13392807.html",
                 "displayLabel" : "Hathi Trust"
               }, {
                 "@id" : ":_2",
@@ -674,6 +678,8 @@ http_interactions:
                 "subject" : [ "Heat -- Transmission", "Mass transfer" ],
                 "identifier" : [ "$$CLC$$V  2007233083;$$COCLC$$V(OCoLC)53039733;$$CISSN$$V0094-4548" ],
                 "creationdate" : [ "1974-1982" ],
+                "lds07" : [ "QC319.8 53039733   2007233083" ],
+                "lds09" : [ "[New York] : Pergamon Press,   1982   1974  1982   nyu" ],
                 "publisher" : [ "New York : Pergamon Press", "Vol. 1, issue 1 (July/Aug. 1974)-v. 9, no. 6 (Nov./Dec. 1982)." ],
                 "mms" : [ "990014388330206761" ],
                 "dedupmemberids" : [ "990002819670206761", "9933075826906761" ],
@@ -692,7 +698,7 @@ http_interactions:
                 "originalsourceid" : [ "001438833-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0030544077" ]
+                "score" : [ "0.0032253282" ]
               },
               "addata" : {
                 "date" : [ "1974 - 1982", "1974-1982" ],
@@ -914,6 +920,8 @@ http_interactions:
                 "format" : [ "v. : ill. ; 24-29 cm." ],
                 "identifier" : [ "$$CLC$$Vsc 89034080;$$COCLC$$V(OCoLC)19731523" ],
                 "creationdate" : [ "19?? - 1958" ],
+                "lds07" : [ "19731523 sc 89034080" ],
+                "lds09" : [ "New York, N.Y. : American Society of Mechanical Engineers,   1958   19uu  1958   nyu" ],
                 "publisher" : [ "New York, N.Y. : American Society of Mechanical Engineers", "-v. 80, no. 8 (Nov. 1958)." ],
                 "mms" : [ "990003005480206761" ],
                 "contributor" : [ "American Society of Mechanical Engineers.$$QAmerican Society of Mechanical Engineers." ],
@@ -931,7 +939,7 @@ http_interactions:
                 "originalsourceid" : [ "000300548-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.0029876889" ]
+                "score" : [ "0.0031155648" ]
               },
               "addata" : {
                 "addtitle" : [ "Transactions of American Society of Mechanical Engineers", "Transactions of the ASME", "Transactions of the American Society of Mechanical Engineers" ],
@@ -1066,24 +1074,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "473",
-            "CALL_SOLR_GET_IDS_LIST" : "1727",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "3913",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "143",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "3",
-            "RETRIVE_FROM_DB_RECORDS" : "52",
-            "RETRIVE_FROM_DB_RELATIONS" : "72",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "3216",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "697",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "333",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "6465",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "133",
+            "CALL_SOLR_GET_IDS_LIST" : "5232",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "720",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "2",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "22",
+            "RETRIVE_FROM_DB_RELATIONS" : "32",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "520",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "200",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "152",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "6250",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 6568,
-            "COMBINED_SEARCH_TIME" : 6573,
+            "BUILD_COMBINED_RESULTS_MAP" : 6330,
+            "COMBINED_SEARCH_TIME" : 6336,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:24 GMT
+  recorded_at: Wed, 19 May 2021 14:29:36 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo.yml
+++ b/test/vcr_cassettes/missing_fields_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549998'
+      - '549959'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -35,9 +35,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '7959'
+      - '8051'
       Date:
-      - Mon, 17 May 2021 15:06:01 GMT
+      - Wed, 19 May 2021 15:19:08 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -66,6 +66,8 @@ http_interactions:
                 "subject" : [ "Chomsky, Noam", "Linguists -- United States" ],
                 "format" : [ "363 p. : ill. ; 23 cm." ],
                 "identifier" : [ "$$CISBN$$V8976820444;$$COCLC$$V(OCoLC)61400624" ],
+                "lds07" : [ "61400624 8976820444" ],
+                "lds09" : [ "Sŏul-si : Gŭrinbi,    1998   ko" ],
                 "lds04" : [ "Off Campus Collection copy from Noam Chomsky collection, with inscription." ],
                 "publisher" : [ "Sŏul-si : Gŭrinbi", "서울시 : 그린비" ],
                 "mms" : [ "990013492720206761" ],
@@ -84,7 +86,7 @@ http_interactions:
                 "originalsourceid" : [ "001349272-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.020869972" ]
+                "score" : [ "0.021095378" ]
               },
               "addata" : {
                 "aulast" : [ "Barsky" ],
@@ -226,24 +228,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "280",
-            "CALL_SOLR_GET_IDS_LIST" : "2693",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "396",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "147",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "39",
-            "RETRIVE_FROM_DB_RECORDS" : "74",
-            "RETRIVE_FROM_DB_RELATIONS" : "17",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "197",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "199",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "125",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "3511",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "69",
+            "CALL_SOLR_GET_IDS_LIST" : "2656",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "309",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "48",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "12",
+            "RETRIVE_FROM_DB_RELATIONS" : "3",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "225",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "84",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "79",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "3137",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 5226,
-            "COMBINED_SEARCH_TIME" : 5229,
+            "BUILD_COMBINED_RESULTS_MAP" : 0,
+            "COMBINED_SEARCH_TIME" : 4,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 0
+            "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:01 GMT
+  recorded_at: Wed, 19 May 2021 15:19:08 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_articles.yml
+++ b/test/vcr_cassettes/missing_fields_primo_articles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcorn&scope=FAKE_PRIMO_ARTICLE_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549997'
+      - '549971'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:13 GMT
+      - Wed, 19 May 2021 14:29:19 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,8 +46,8 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 132266,
-            "total" : 132266,
+            "totalResultsPC" : 132284,
+            "total" : 132284,
             "first" : 1,
             "last" : 5
           },
@@ -63,7 +63,7 @@ http_interactions:
                 "title" : [ "Popcorn" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1088_2058_7058_29_11_46" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1088_2058_7058_29_11_46" ],
                 "sourcerecordid" : [ "10_1088_2058_7058_29_11_46" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "recordtype" : [ "article" ],
@@ -72,21 +72,7 @@ http_interactions:
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "crossref" ],
-                "score" : [ "0.021811698" ]
-              },
-              "addata" : {
-                "issn" : [ "0953-8585" ],
-                "genre" : [ "article" ],
-                "atitle" : [ "Popcorn" ],
-                "date" : [ "2016-11" ],
-                "risdate" : [ "2016" ],
-                "spage" : [ "42" ],
-                "epage" : [ "42" ],
-                "pages" : [ "42-42" ],
-                "eissn" : [ "2058-7058" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1088/2058-7058/29/11/46" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.021807468" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -98,36 +84,50 @@ http_interactions:
                 "title" : [ "Popcorn", "Physics world" ],
                 "recordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION" ],
+                "rsrctype" : [ "article" ],
                 "issn" : [ "0953-8585", "2058-7058" ],
                 "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "201611" ],
-                "enddate" : [ "201611" ]
+                "enddate" : [ "201611" ],
+                "scope" : [ "AAYXX", "CITATION" ]
               },
               "display" : {
                 "title" : [ "Popcorn" ],
-                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
-                "type" : [ "article" ],
-                "source" : [ "Alma/SFX Local Collection" ],
-                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
                 "language" : [ "eng" ],
+                "source" : [ "Alma/SFX Local Collection" ],
+                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
+                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
+                "type" : [ "article" ],
                 "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "genre" : [ "article" ],
+                "issn" : [ "0953-8585" ],
+                "spage" : [ "42" ],
+                "epage" : [ "42" ],
+                "pages" : [ "42-42" ],
+                "eissn" : [ "2058-7058" ],
+                "ristype" : [ "JOUR" ],
+                "doi" : [ "10.1088/2058-7058/29/11/46" ],
+                "atitle" : [ "Popcorn" ],
+                "date" : [ "2016-11" ],
+                "risdate" : [ "2016" ]
+              },
               "facets" : {
                 "creationdate" : [ "2016" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Physics world" ]
+                "jtitle" : [ "Physics world" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -155,16 +155,16 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1088_2058_7058_29_11_46"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1088_2058_7058_29_11_46"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
                 "creationdate" : [ "201211" ],
-                "title" : [ "Baryonic popcorn" ],
-                "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ]
+                "title" : [ "Baryonic popcorn" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1007_JHEP11_2012_047" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1007_JHEP11_2012_047" ],
                 "sourcerecordid" : [ "2398248625" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "recordtype" : [ "article" ],
@@ -174,20 +174,58 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2398248625" ],
-                "score" : [ "0.020141866" ]
+                "score" : [ "0.020139625" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "creationdate" : [ "2012" ],
+                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
+                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
+                "recordtype" : [ "article" ],
+                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
+                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "issn" : [ "1029-8479", "1029-8479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "J. High Energ. Phys" ],
+                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
+                "startdate" : [ "201211" ],
+                "enddate" : [ "201211" ],
+                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ]
+              },
+              "display" : {
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "title" : [ "Baryonic popcorn" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
+                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
+                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
+                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
+                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "issn" : [ "1029-8479" ],
-                "oa" : [ "free_for_read" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "The journal of high energy physics" ],
                 "genre" : [ "article" ],
-                "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "atitle" : [ "Baryonic popcorn" ],
-                "stitle" : [ "J. High Energ. Phys" ],
-                "date" : [ "2012-11" ],
-                "risdate" : [ "2012" ],
-                "volume" : [ "2012" ],
+                "issn" : [ "1029-8479" ],
+                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
                 "spage" : [ "1" ],
                 "epage" : [ "85" ],
                 "pages" : [ "1-85" ],
@@ -196,64 +234,26 @@ http_interactions:
                 "cop" : [ "Berlin/Heidelberg" ],
                 "pub" : [ "Springer-Verlag" ],
                 "doi" : [ "10.1007/JHEP11(2012)047" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2012" ],
-                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
-                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
-                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ],
-                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "issn" : [ "1029-8479", "1029-8479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "J. High Energ. Phys" ],
-                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201211" ],
-                "enddate" : [ "201211" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
-              },
-              "display" : {
-                "title" : [ "Baryonic popcorn" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
-                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
-                "type" : [ "article" ],
-                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
-                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "language" : [ "eng" ],
-                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
-                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "atitle" : [ "Baryonic popcorn" ],
+                "stitle" : [ "J. High Energ. Phys" ],
+                "date" : [ "2012-11" ],
+                "risdate" : [ "2012" ],
+                "volume" : [ "2012" ],
+                "oa" : [ "free_for_read" ]
               },
               "facets" : {
                 "creationdate" : [ "2012" ],
                 "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Solitons Monopoles and Instantons", "AdS-CFT Correspondence", "Quantum Physics", "Quantum Field Theories, String Theory", "Classical and Quantum Gravitation, Relativity Theory", "Physics", "Phase Diagram of QCD", "Elementary Particles, Quantum Field Theory", "Flavor (particle physics)", "Lattices", "Chains", "Phase transitions", "Density", "Instantons", "Baryons", "Multilayers", "Gauge theory", "Ferromagnetism", "Configurations", "Nuclear matter", "Crystal structure", "Branes", "Solid phases" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "ProQuest SciTech Collection", "ProQuest Technology Collection", "ProQuest Central (Alumni Edition)", "Advanced Technologies & Aerospace Collection", "ProQuest Central Essentials", "ProQuest Central", "Technology Collection", "ProQuest Central Korea", "SciTech Premium Collection", "Advanced Technologies & Aerospace Database", "ProQuest Advanced Technologies & Aerospace Collection", "Publicly Available Content Database", "ProQuest One Academic Eastern Edition", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "The journal of high energy physics" ]
+                "jtitle" : [ "The journal of high energy physics" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -271,7 +271,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:20&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -282,17 +282,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1007_JHEP11_2012_047"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1007_JHEP11_2012_047"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
                 "creationdate" : [ "20200717" ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ]
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ]
               },
               "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_2407314819" ],
-                "sourcerecordid" : [ "2424628284" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_2407314819" ],
+                "sourcerecordid" : [ "2407314819" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
@@ -301,21 +301,59 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2424628284" ],
-                "score" : [ "0.019118225" ]
+                "score" : [ "0.019115865" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "creationdate" : [ "2020" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
+                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
+                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "issn" : [ "1439-4235", "1439-7641" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Chemphyschem" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "startdate" : [ "20200717" ],
+                "enddate" : [ "20200717" ],
+                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ]
+              },
+              "display" : {
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
+                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
+                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
+                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "format" : [ "journal" ],
+                "jtitle" : [ "Chemphyschem" ],
+                "genre" : [ "article" ],
                 "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
                 "issn" : [ "1439-4235" ],
                 "addtitle" : [ "Chemphyschem" ],
-                "jtitle" : [ "Chemphyschem" ],
-                "genre" : [ "article" ],
-                "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "date" : [ "2020-07-17" ],
-                "risdate" : [ "2020" ],
-                "volume" : [ "21" ],
-                "issue" : [ "14" ],
+                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
                 "spage" : [ "1531" ],
                 "epage" : [ "1540" ],
                 "pages" : [ "1531-1540" ],
@@ -324,64 +362,26 @@ http_interactions:
                 "cop" : [ "Germany" ],
                 "pub" : [ "Wiley Subscription Services, Inc" ],
                 "doi" : [ "10.1002/cphc.202000116" ],
-                "tpages" : [ "10" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2020" ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
-                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ],
-                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
-                "issn" : [ "1439-4235", "1439-7641" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Chemphyschem" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20200717" ],
-                "enddate" : [ "20200717" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
-              },
-              "display" : {
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
-                "type" : [ "article" ],
-                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
-                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
-                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "date" : [ "2020-07-17" ],
+                "risdate" : [ "2020" ],
+                "volume" : [ "21" ],
+                "issue" : [ "14" ],
+                "tpages" : [ "10" ]
               },
               "facets" : {
                 "creationdate" : [ "2020" ],
                 "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "non-equilibrium processes", "interstellar synthesis", "IR spectroscopy", "mass spectroscopy", "complex organic molecules", "Acetaldehyde - chemistry", "Cold Temperature", "Flavoring Agents - chemical synthesis", "Ultraviolet Rays", "Models, Chemical", "Free Radicals - chemistry", "Deuterium - chemistry", "Diacetyl - chemical synthesis", "Acetaldehyde - radiation effects", "Extraterrestrial Environment - chemistry", "Deep space", "Molecular structure", "Molecular clouds", "Galactic cosmic rays", "Substitution reactions", "Amino acids", "Ice", "Aldehydes", "Cosmic rays", "Acetaldehyde", "Complexity", "Organic chemistry", "Ionizing radiation", "Meteorites", "Star formation", "Photoionization", "Interstellar chemistry", "Astrochemistry", "Chemical synthesis", "Interstellar matter", "Index Medicus" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Chemphyschem" ]
+                "jtitle" : [ "Chemphyschem" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -399,7 +399,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:20&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -410,16 +410,16 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_2407314819"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_2407314819"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
                 "creationdate" : [ "20180105" ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ]
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A521493458" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A521493458" ],
                 "sourcerecordid" : [ "A521493458" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "recordtype" : [ "article" ],
@@ -429,29 +429,7 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A521493458" ],
-                "score" : [ "0.018662874" ]
-              },
-              "addata" : {
-                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
-                "issn" : [ "1614-6832" ],
-                "jtitle" : [ "Advanced energy materials" ],
-                "genre" : [ "article" ],
-                "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "date" : [ "2018-01-05" ],
-                "risdate" : [ "2018" ],
-                "volume" : [ "8" ],
-                "issue" : [ "1" ],
-                "spage" : [ "1701110" ],
-                "epage" : [ "n/a" ],
-                "pages" : [ "1701110-n/a" ],
-                "eissn" : [ "1614-6840" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/aenm.201701110" ],
-                "tpages" : [ "8" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.018661754" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -459,54 +437,76 @@ http_interactions:
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "creationdate" : [ "2018" ],
                 "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
-                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
                 "recordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "rsrctype" : [ "article" ],
                 "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
                 "issn" : [ "1614-6832", "1614-6840" ],
                 "fulltext" : [ "true" ],
                 "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "20180105" ],
                 "enddate" : [ "20180105" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
               },
               "display" : {
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
                 "publisher" : [ "Wiley Subscription Services, Inc" ],
                 "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
-                "type" : [ "article" ],
-                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
                 "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "language" : [ "eng" ],
                 "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
                 "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "jtitle" : [ "Advanced energy materials" ],
+                "genre" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "issn" : [ "1614-6832" ],
+                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
+                "spage" : [ "1701110" ],
+                "epage" : [ "n/a" ],
+                "pages" : [ "1701110-n/a" ],
+                "eissn" : [ "1614-6840" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/aenm.201701110" ],
+                "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "date" : [ "2018-01-05" ],
+                "risdate" : [ "2018" ],
+                "volume" : [ "8" ],
+                "issue" : [ "1" ],
+                "tpages" : [ "8" ]
+              },
               "facets" : {
                 "creationdate" : [ "2018" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "biomass‐derived porous carbons", "lithium–sulfur batteries", "cathodes", "nanostructures", "metal–carbon composites", "Sulfur compounds", "Electrical conductivity", "Electrochemistry", "Porosity", "Batteries", "Sulfur", "Electric properties" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Advanced energy materials" ]
+                "jtitle" : [ "Advanced energy materials" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -524,7 +524,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:20&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -535,16 +535,16 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A521493458"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A521493458"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Moreta, Cristina ; Tena, María Teresa" ],
                 "creationdate" : [ "20140815" ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "author" : [ "Moreta, Cristina ; Tena, María Teresa" ]
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A375736650" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A375736650" ],
                 "sourcerecordid" : [ "A375736650" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "recordtype" : [ "article" ],
@@ -554,27 +554,7 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A375736650" ],
-                "score" : [ "0.018273484" ]
-              },
-              "addata" : {
-                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "issn" : [ "0021-9673" ],
-                "jtitle" : [ "Journal of Chromatography A" ],
-                "genre" : [ "article" ],
-                "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "date" : [ "2014-08-15" ],
-                "risdate" : [ "2014" ],
-                "volume" : [ "1355" ],
-                "spage" : [ "211" ],
-                "epage" : [ "218" ],
-                "pages" : [ "211-218" ],
-                "coden" : [ "JOCRAM" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Amsterdam" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.01826014" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -583,53 +563,73 @@ http_interactions:
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
                 "creationdate" : [ "2014" ],
                 "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
-                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
                 "recordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
                 "issn" : [ "0021-9673" ],
                 "fulltext" : [ "true" ],
                 "general" : [ "Elsevier B.V", "Elsevier" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "20140815" ],
                 "enddate" : [ "20140815" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ]
               },
               "display" : {
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
                 "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
                 "publisher" : [ "Amsterdam: Elsevier B.V" ],
                 "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
                 "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "language" : [ "eng" ],
                 "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
                 "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "jtitle" : [ "Journal of Chromatography A" ],
+                "genre" : [ "article" ],
+                "issn" : [ "0021-9673" ],
+                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
+                "spage" : [ "211" ],
+                "epage" : [ "218" ],
+                "pages" : [ "211-218" ],
+                "coden" : [ "JOCRAM" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Amsterdam" ],
+                "pub" : [ "Elsevier B.V" ],
+                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
+                "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "date" : [ "2014-08-15" ],
+                "risdate" : [ "2014" ],
+                "volume" : [ "1355" ]
+              },
               "facets" : {
                 "creationdate" : [ "2014" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Packaging", "Quadrupole-time of flight mass spectrometry", "Liquid chromatography", "Perfluorinated alkyl acids", "Focused ultrasound solid–liquid extraction", "Popcorn", "Fundamental and applied biological sciences. Psychology", "Food industries", "Biological and medical sciences", "Cereal and baking product industries", "Corn", "Ammonium perfluorooctanoate", "Mass spectrometry", "Analysis" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "Pascal-Francis", "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Journal of Chromatography A" ]
+                "jtitle" : [ "Journal of Chromatography A" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -647,7 +647,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:20&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -658,15 +658,15 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A375736650"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A375736650"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "663",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "39",
-            "PC_SEARCH_TIME_TOTAL" : "702",
+            "PC_SEARCH_CALL_TIME" : "126",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "62",
+            "PC_SEARCH_TIME_TOTAL" : "188",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 703,
-            "COMBINED_SEARCH_TIME" : 710,
+            "BUILD_COMBINED_RESULTS_MAP" : 190,
+            "COMBINED_SEARCH_TIME" : 199,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
@@ -674,10 +674,10 @@ http_interactions:
             "name" : "jtitle",
             "values" : [ {
               "value" : "The Washington Post",
-              "count" : "7878"
+              "count" : "7877"
             }, {
               "value" : "Chicago Tribune",
-              "count" : "7579"
+              "count" : "7580"
             }, {
               "value" : "The Los Angeles Times",
               "count" : "6322"
@@ -686,7 +686,7 @@ http_interactions:
               "count" : "5992"
             }, {
               "value" : "Toronto Star",
-              "count" : "3743"
+              "count" : "3744"
             }, {
               "value" : "Edmonton Journal",
               "count" : "2833"
@@ -698,7 +698,7 @@ http_interactions:
               "count" : "2612"
             }, {
               "value" : "The Wall Street Journal. Eastern Edition",
-              "count" : "2600"
+              "count" : "2604"
             }, {
               "value" : "National Post",
               "count" : "2598"
@@ -707,7 +707,7 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "131767"
+              "count" : "131784"
             }, {
               "value" : "por",
               "count" : "249"
@@ -716,7 +716,7 @@ http_interactions:
               "count" : "202"
             }, {
               "value" : "ger",
-              "count" : "141"
+              "count" : "142"
             }, {
               "value" : "chi",
               "count" : "88"
@@ -770,33 +770,36 @@ http_interactions:
             "name" : "topic",
             "values" : [ {
               "value" : "Motion Pictures",
-              "count" : "6843"
+              "count" : "6849"
             }, {
               "value" : "Science & Technology",
-              "count" : "5824"
+              "count" : "5815"
             }, {
               "value" : "Life Sciences & Biomedicine",
-              "count" : "4279"
+              "count" : "4272"
             }, {
               "value" : "Marketing",
-              "count" : "4190"
+              "count" : "4191"
             }, {
               "value" : "Restaurants",
               "count" : "4076"
             }, {
               "value" : "Food",
-              "count" : "2726"
+              "count" : "2727"
             }, {
               "value" : "Humans",
               "count" : "2418"
             }, {
               "value" : "Management",
-              "count" : "2124"
+              "count" : "2123"
             }, {
               "value" : "Analysis",
               "count" : "1800"
             }, {
               "value" : "Nutrition",
+              "count" : "1715"
+            }, {
+              "value" : "Theaters & Cinemas",
               "count" : "1711"
             }, {
               "value" : "Snack Foods",
@@ -805,35 +808,32 @@ http_interactions:
               "value" : "Methods",
               "count" : "1707"
             }, {
-              "value" : "Theaters & Cinemas",
-              "count" : "1707"
-            }, {
               "value" : "Motion Picture Industry",
-              "count" : "1698"
+              "count" : "1699"
             }, {
               "value" : "Diet",
-              "count" : "1643"
+              "count" : "1645"
             }, {
               "value" : "Research",
-              "count" : "1641"
+              "count" : "1636"
             }, {
               "value" : "Social Sciences",
-              "count" : "1581"
+              "count" : "1576"
             }, {
               "value" : "Theater",
-              "count" : "1508"
+              "count" : "1503"
             }, {
               "value" : "Health Aspects",
-              "count" : "1501"
+              "count" : "1500"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "newspaper_articles",
-              "count" : "62942"
+              "count" : "62949"
             }, {
               "value" : "articles",
-              "count" : "58336"
+              "count" : "58347"
             }, {
               "value" : "reviews",
               "count" : "3968"
@@ -848,7 +848,7 @@ http_interactions:
               "count" : "632"
             }, {
               "value" : "web_resources",
-              "count" : "535"
+              "count" : "534"
             }, {
               "value" : "conference_proceedings",
               "count" : "328"
@@ -857,7 +857,7 @@ http_interactions:
               "count" : "213"
             }, {
               "value" : "books",
-              "count" : "135"
+              "count" : "136"
             }, {
               "value" : "text_resources",
               "count" : "9"
@@ -866,64 +866,64 @@ http_interactions:
             "name" : "domain",
             "values" : [ {
               "value" : "ProQuest Historical Newspapers",
-              "count" : "132266"
+              "count" : "132284"
             }, {
               "value" : "Global Newsstream",
-              "count" : "64456"
+              "count" : "64463"
             }, {
               "value" : "Factiva",
-              "count" : "60921"
+              "count" : "60931"
             }, {
               "value" : "Nexis Uni",
-              "count" : "54236"
+              "count" : "54247"
             }, {
               "value" : "PressReader",
               "count" : "43423"
             }, {
               "value" : "Single Journals",
-              "count" : "32986"
+              "count" : "32877"
             }, {
               "value" : "ABI/INFORM Collection",
-              "count" : "30745"
+              "count" : "30753"
             }, {
               "value" : "Academic Search Complete",
-              "count" : "19383"
+              "count" : "19414"
             }, {
               "value" : "Business Source Complete",
-              "count" : "17986"
+              "count" : "17988"
             }, {
               "value" : "Factiva (Selected Full Text)",
-              "count" : "7127"
+              "count" : "7126"
             }, {
               "value" : "Agricultural & Environmental Science Collection",
-              "count" : "6734"
+              "count" : "6741"
             }, {
               "value" : "Flipster",
-              "count" : "4769"
+              "count" : "4779"
             }, {
               "value" : "Ethnic NewsWatch",
-              "count" : "4266"
+              "count" : "4267"
             }, {
               "value" : "Advanced Technologies & Aerospace Collection",
               "count" : "3261"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "3219"
+              "count" : "3220"
             }, {
               "value" : "Environmental Science Collection",
-              "count" : "2890"
+              "count" : "2892"
             }, {
               "value" : "Freely Accessible General Interest Journals",
-              "count" : "2717"
+              "count" : "2716"
             }, {
               "value" : "Freely Accessible Journals",
               "count" : "2658"
             }, {
               "value" : "Wall Street Journal Online",
-              "count" : "2603"
+              "count" : "2607"
             }, {
               "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
-              "count" : "2574"
+              "count" : "2579"
             } ]
           }, {
             "name" : "tlevel",
@@ -932,22 +932,22 @@ http_interactions:
               "count" : "3866"
             }, {
               "value" : "peer_reviewed",
-              "count" : "10892"
+              "count" : "10898"
             }, {
               "value" : "online_resources",
-              "count" : "132266"
+              "count" : "132284"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "07 days back",
-              "count" : "24"
-            }, {
-              "value" : "30 days back",
-              "count" : "186"
+              "count" : "18"
             }, {
               "value" : "90 days back",
-              "count" : "2557"
+              "count" : "2531"
+            }, {
+              "value" : "30 days back",
+              "count" : "204"
             } ]
           }, {
             "name" : "creationdate",
@@ -1109,16 +1109,16 @@ http_interactions:
               "count" : "2894"
             }, {
               "value" : "1997",
-              "count" : "2844"
+              "count" : "2845"
             }, {
               "value" : "1998",
               "count" : "3596"
             }, {
               "value" : "1999",
-              "count" : "3846"
+              "count" : "3847"
             }, {
               "value" : "2000",
-              "count" : "4357"
+              "count" : "4358"
             }, {
               "value" : "2001",
               "count" : "4157"
@@ -1136,31 +1136,31 @@ http_interactions:
               "count" : "5328"
             }, {
               "value" : "2006",
-              "count" : "5017"
+              "count" : "5015"
             }, {
               "value" : "2007",
-              "count" : "5236"
+              "count" : "5234"
             }, {
               "value" : "2008",
               "count" : "5026"
             }, {
               "value" : "2009",
-              "count" : "4864"
+              "count" : "4865"
             }, {
               "value" : "2010",
-              "count" : "4793"
+              "count" : "4792"
             }, {
               "value" : "2011",
-              "count" : "4592"
+              "count" : "4591"
             }, {
               "value" : "2012",
-              "count" : "5089"
+              "count" : "5088"
             }, {
               "value" : "2013",
               "count" : "5227"
             }, {
               "value" : "2014",
-              "count" : "5031"
+              "count" : "5032"
             }, {
               "value" : "2015",
               "count" : "4667"
@@ -1169,21 +1169,21 @@ http_interactions:
               "count" : "4523"
             }, {
               "value" : "2017",
-              "count" : "4092"
+              "count" : "4091"
             }, {
               "value" : "2018",
-              "count" : "3810"
+              "count" : "3808"
             }, {
               "value" : "2019",
-              "count" : "3797"
+              "count" : "3799"
             }, {
               "value" : "2020",
-              "count" : "2978"
+              "count" : "2979"
             }, {
               "value" : "2021",
-              "count" : "933"
+              "count" : "952"
             } ]
           } ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:14 GMT
+  recorded_at: Wed, 19 May 2021 14:29:20 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_books.yml
+++ b/test/vcr_cassettes/missing_fields_primo_books.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcorn&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549992'
+      - '549970'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:26 GMT
+      - Wed, 19 May 2021 14:29:25 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -84,7 +84,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "2.950539E-4" ]
+                "score" : [ "2.9529585E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -110,6 +110,26 @@ http_interactions:
               }
             },
             "delivery" : {
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "check_holdings", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
               "GetIt1" : [ {
                 "category" : "Alma-P",
                 "links" : [ {
@@ -152,42 +172,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721306761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724606761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721306761" ],
+                "mms" : [ "9933019724606761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019721306761" ],
-                "recordid" : [ "alma9933019721306761" ],
+                "sourcerecordid" : [ "9933019724606761" ],
+                "recordid" : [ "alma9933019724606761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573078" ],
+                "originalsourceid" : [ "991000000000573049" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.604109E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573078" ],
+                "oclcid" : [ "(ckb)1000000000573049" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Thailand" ]
+                "jtitle" : [ "Popcorn Industry Profile: Australia" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9003628398970808267" ]
+                "frbrgroupid" : [ "9059165500462499698" ]
               }
             },
             "delivery" : {
@@ -233,42 +253,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723406761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724306761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723406761" ],
+                "mms" : [ "9933019724306761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019723406761" ],
-                "recordid" : [ "alma9933019723406761" ],
+                "sourcerecordid" : [ "9933019724306761" ],
+                "recordid" : [ "alma9933019724306761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573061" ],
+                "originalsourceid" : [ "991000000000573052" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.604109E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573061" ],
+                "oclcid" : [ "(ckb)1000000000573052" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Greece" ]
+                "jtitle" : [ "Popcorn Industry Profile: Brazil" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9037562016405007885" ]
+                "frbrgroupid" : [ "9083335249684128851" ]
               }
             },
             "delivery" : {
@@ -314,42 +334,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722106761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724806761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722106761" ],
+                "mms" : [ "9933019724806761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019722106761" ],
-                "recordid" : [ "alma9933019722106761" ],
+                "sourcerecordid" : [ "9933019724806761" ],
+                "recordid" : [ "alma9933019724806761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573073" ],
+                "originalsourceid" : [ "991000000000573047" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.604109E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573073" ],
+                "oclcid" : [ "(ckb)1000000000573047" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: South Korea" ]
+                "jtitle" : [ "Popcorn Industry Profile: Argentina" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9004595849084473098" ]
+                "frbrgroupid" : [ "9001959784471604878" ]
               }
             },
             "delivery" : {
@@ -395,42 +415,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724206761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724506761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724206761" ],
+                "mms" : [ "9933019724506761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019724206761" ],
-                "recordid" : [ "alma9933019724206761" ],
+                "sourcerecordid" : [ "9933019724506761" ],
+                "recordid" : [ "alma9933019724506761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573053" ],
+                "originalsourceid" : [ "991000000000573050" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.604109E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573053" ],
+                "oclcid" : [ "(ckb)1000000000573050" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Chile" ]
+                "jtitle" : [ "Popcorn Industry Profile: Austria" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9007649350935717203" ]
+                "frbrgroupid" : [ "9060146011692305880" ]
               }
             },
             "delivery" : {
@@ -475,24 +495,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "513",
-            "CALL_SOLR_GET_IDS_LIST" : "1051",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "977",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "169",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "84",
-            "RETRIVE_FROM_DB_RECORDS" : "232",
-            "RETRIVE_FROM_DB_RELATIONS" : "24",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "499",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "478",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "334",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "2890",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "18",
+            "CALL_SOLR_GET_IDS_LIST" : "72",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "605",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "1",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "12",
+            "RETRIVE_FROM_DB_RELATIONS" : "1",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "496",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "109",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "188",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "899",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 0,
-            "COMBINED_SEARCH_TIME" : 4,
+            "BUILD_COMBINED_RESULTS_MAP" : 928,
+            "COMBINED_SEARCH_TIME" : 932,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:27 GMT
+  recorded_at: Wed, 19 May 2021 14:29:25 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/missing_fields_primo_chapter.yml
+++ b/test/vcr_cassettes/missing_fields_primo_chapter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=FAKE_PRIMO_ARTICLE_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549987'
+      - '549957'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:18:50 GMT
+      - Wed, 19 May 2021 15:44:31 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -64,7 +64,8 @@ http_interactions:
                 "author" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_springer_books_10_1007_978_3_319_91341_4_4" ],
+                "sourceid" : [ "springer" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_springer_books_10_1007_978_3_319_91341_4_4" ],
                 "sourcerecordid" : [ "springer_books_10_1007_978_3_319_91341_4_4" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "recordtype" : [ "book_chapter" ],
@@ -72,20 +73,58 @@ http_interactions:
                 "sourcetype" : [ "Publisher" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "springer" ],
                 "score" : [ "0.5" ]
               },
+              "search" : {
+                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "creationdate" : [ "2018" ],
+                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
+                "sourceid" : [ "" ],
+                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
+                "recordtype" : [ "book_chapter" ],
+                "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "book_chapter" ],
+                "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
+                "isbn" : [ "3319913395", "9783319913391", "3319913417", "9783319913414" ],
+                "issn" : [ "1860-949X", "1860-9503" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Springer International Publishing" ],
+                "startdate" : [ "20180607" ],
+                "enddate" : [ "20180607" ],
+                "scope" : [ "" ]
+              },
+              "display" : {
+                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "title" : [ "Spider Monkey Optimization Algorithm" ],
+                "type" : [ "book_chapter" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
+                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
+                "source" : [ "Springer Book Series", "Springer Intelligent Technologies and Robotics eBooks 2019 English/International" ],
+                "publisher" : [ "Cham: Springer International Publishing" ],
+                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
+                "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
+                "relation" : [ "Studies in Computational Intelligence" ],
+                "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
+                "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
               "addata" : {
-                "abstract" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "format" : [ "book" ],
                 "isbn" : [ "3319913395", "9783319913391" ],
                 "issn" : [ "1860-949X" ],
                 "genre" : [ "bookitem" ],
-                "au" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Spider Monkey Optimization Algorithm" ],
-                "seriestitle" : [ "Studies in Computational Intelligence" ],
-                "date" : [ "2018-06-07" ],
-                "risdate" : [ "2018" ],
-                "spage" : [ "43" ],
+                "abstract" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
                 "epage" : [ "59" ],
                 "eissn" : [ "1860-9503" ],
                 "eisbn" : [ "3319913417", "9783319913414" ],
@@ -93,61 +132,22 @@ http_interactions:
                 "cop" : [ "Cham" ],
                 "pub" : [ "Springer International Publishing" ],
                 "doi" : [ "10.1007/978-3-319-91341-4_4" ],
-                "format" : [ "book" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2018" ],
-                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
-                "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
-                "recordtype" : [ "book_chapter" ],
-                "sourceid" : [ "" ],
-                "scope" : [ "" ],
-                "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "isbn" : [ "3319913395", "9783319913391", "3319913417", "9783319913414" ],
-                "issn" : [ "1860-949X", "1860-9503" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Springer International Publishing" ],
-                "rsrctype" : [ "book_chapter" ],
-                "startdate" : [ "20180607" ],
-                "enddate" : [ "20180607" ],
-                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
-                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
-              },
-              "display" : {
-                "title" : [ "Spider Monkey Optimization Algorithm" ],
-                "publisher" : [ "Cham: Springer International Publishing" ],
-                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
-                "type" : [ "book_chapter" ],
-                "source" : [ "Springer Book Series", "Springer Intelligent Technologies and Robotics eBooks 2019 English/International" ],
-                "creator" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
-                "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
-                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
-                "language" : [ "eng" ],
-                "relation" : [ "Studies in Computational Intelligence" ],
-                "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
-                "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "atitle" : [ "Spider Monkey Optimization Algorithm" ],
+                "seriestitle" : [ "Studies in Computational Intelligence" ],
+                "date" : [ "2018-06-07" ],
+                "risdate" : [ "2018" ],
+                "spage" : [ "43" ]
               },
               "facets" : {
                 "creationdate" : [ "2018" ],
                 "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "book_chapters" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Spider monkey optimization", "Swarm intelligence", "Numerical optimization", "Fission-fusion social structure" ],
                 "prefilter" : [ "book_chapters" ],
+                "rsrctype" : [ "book_chapters" ],
+                "language" : [ "eng" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ]
               }
@@ -167,7 +167,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 11:44:31&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -178,7 +178,7 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_springer_books_10_1007_978_3_319_91341_4_4"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_springer_books_10_1007_978_3_319_91341_4_4"
           }, {
             "pnx" : {
               "sort" : {
@@ -187,7 +187,8 @@ http_interactions:
                 "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_proquest_journals_1954549491" ],
+                "sourceid" : [ "gale_proqu" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_1954549491" ],
                 "sourcerecordid" : [ "A511146853" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "recordtype" : [ "article" ],
@@ -195,25 +196,60 @@ http_interactions:
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_proqu" ],
                 "pqid" : [ "1954549491" ],
                 "galeid" : [ "A511146853" ],
-                "score" : [ "0.09796392" ]
+                "score" : [ "0.09796783" ]
+              },
+              "search" : {
+                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
+                "creationdate" : [ "2017" ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
+                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
+                "issn" : [ "1432-7643", "1433-7479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Soft Comput" ],
+                "general" : [ "Springer Berlin Heidelberg", "Springer", "Springer Nature B.V" ],
+                "startdate" : [ "201712" ],
+                "enddate" : [ "201712" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
+                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
+                "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
+                "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
+                "rights" : [ "Springer-Verlag GmbH Germany 2017", "Springer-Verlag Berlin Heidelberg 2016", "COPYRIGHT 2017 Springer" ],
+                "snippet" : [ "...Soft Comput (2017) 21:6933–6962\nDOI 10.1007/s00500-016-2419-0\nFOUNDATIONS\nSpider monkey optimization algorithm for constrained\noptimization problems\nKavita..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
+                "format" : [ "journal" ],
                 "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
                 "issn" : [ "1432-7643" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "stitle" : [ "Soft Comput" ],
-                "date" : [ "2017-12" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "21" ],
-                "issue" : [ "23" ],
-                "spage" : [ "6933" ],
+                "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
                 "epage" : [ "6962" ],
                 "pages" : [ "6933-6962" ],
                 "eissn" : [ "1433-7479" ],
@@ -221,61 +257,25 @@ http_interactions:
                 "cop" : [ "Berlin/Heidelberg" ],
                 "pub" : [ "Springer Berlin Heidelberg" ],
                 "doi" : [ "10.1007/s00500-016-2419-0" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
-                "issn" : [ "1432-7643", "1433-7479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Soft Comput" ],
-                "general" : [ "Springer Berlin Heidelberg", "Springer", "Springer Nature B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201712" ],
-                "enddate" : [ "201712" ],
-                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
-                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
-              },
-              "display" : {
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
-                "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
-                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
-                "language" : [ "eng" ],
-                "rights" : [ "Springer-Verlag GmbH Germany 2017", "Springer-Verlag Berlin Heidelberg 2016", "COPYRIGHT 2017 Springer" ],
-                "snippet" : [ "...Soft Comput (2017) 21:6933–6962\nDOI 10.1007/s00500-016-2419-0\nFOUNDATIONS\nSpider monkey optimization algorithm for constrained\noptimization problems\nKavita..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "stitle" : [ "Soft Comput" ],
+                "date" : [ "2017-12" ],
+                "risdate" : [ "2017" ],
+                "volume" : [ "21" ],
+                "issue" : [ "23" ],
+                "spage" : [ "6933" ]
               },
               "facets" : {
                 "creationdate" : [ "2017" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Engineering", "Deb’s technique", "CEC2006", "Computational Intelligence", "Control, Robotics, Mechatronics", "Artificial Intelligence (incl. Robotics)", "Spider monkey optimization", "CEC2010", "Mathematical Logic and Foundations", "Constrained optimization", "Monkeys", "Algorithms", "Mathematical optimization", "Analysis", "Bees", "Optimization algorithms", "Benchmarks", "Global optimization", "Swarm intelligence" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)", "Soft Computing" ]
               }
@@ -295,7 +295,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 11:44:31&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -306,7 +306,7 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_journals_1954549491"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_1954549491"
           }, {
             "pnx" : {
               "sort" : {
@@ -315,7 +315,8 @@ http_interactions:
                 "author" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A648108178" ],
+                "sourceid" : [ "gale_cross" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A648108178" ],
                 "sourcerecordid" : [ "A648108178" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "recordtype" : [ "article" ],
@@ -323,80 +324,79 @@ http_interactions:
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A648108178" ],
-                "score" : [ "0.06633203" ]
+                "score" : [ "0.06633455" ]
               },
-              "addata" : {
-                "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
-                "issn" : [ "0929-6212" ],
-                "jtitle" : [ "Wireless personal communications" ],
-                "genre" : [ "article" ],
-                "au" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "atitle" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
-                "date" : [ "2020-09-11" ],
-                "risdate" : [ "2020" ],
-                "volume" : [ "116" ],
-                "issue" : [ "1" ],
-                "spage" : [ "23" ],
-                "pages" : [ "23-" ],
-                "eissn" : [ "1572-834X" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Springer" ],
-                "doi" : [ "10.1007/s11277-020-07703-6" ],
-                "format" : [ "journal" ]
+              "search" : {
+                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
+                "creationdate" : [ "2020" ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
+                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
+                "issn" : [ "0929-6212", "1572-834X" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Springer" ],
+                "startdate" : [ "20200911" ],
+                "enddate" : [ "20200911" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
+                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Springer" ],
+                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
+                "identifier" : [ "ISSN: 0929-6212", "EISSN: 1572-834X", "DOI: 10.1007/s11277-020-07703-6" ],
+                "rights" : [ "COPYRIGHT 2021 Springer" ],
+                "snippet" : [ ".... By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
-              "search" : {
-                "creationdate" : [ "2020" ],
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
-                "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
-                "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "issn" : [ "0929-6212", "1572-834X" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Springer" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20200911" ],
-                "enddate" : [ "20200911" ],
-                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
-                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
-              },
-              "display" : {
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
-                "publisher" : [ "Springer" ],
-                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
-                "identifier" : [ "ISSN: 0929-6212", "EISSN: 1572-834X", "DOI: 10.1007/s11277-020-07703-6" ],
-                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
-                "language" : [ "eng" ],
-                "rights" : [ "COPYRIGHT 2021 Springer" ],
-                "snippet" : [ ".... By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+              "addata" : {
+                "format" : [ "journal" ],
+                "issn" : [ "0929-6212" ],
+                "jtitle" : [ "Wireless personal communications" ],
+                "genre" : [ "article" ],
+                "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
+                "pages" : [ "23-" ],
+                "eissn" : [ "1572-834X" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Springer" ],
+                "doi" : [ "10.1007/s11277-020-07703-6" ],
+                "au" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "atitle" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "date" : [ "2020-09-11" ],
+                "risdate" : [ "2020" ],
+                "volume" : [ "116" ],
+                "issue" : [ "1" ],
+                "spage" : [ "23" ]
               },
               "facets" : {
                 "creationdate" : [ "2020" ],
                 "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Information networks", "Monkeys", "Computer networks", "Engineering schools", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Wireless personal communications" ]
               }
@@ -416,7 +416,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 11:44:31&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -427,7 +427,7 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A648108178"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A648108178"
           }, {
             "pnx" : {
               "sort" : {
@@ -436,7 +436,8 @@ http_interactions:
                 "author" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2015_08_504" ],
+                "sourceid" : [ "elsevier_cross" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1016_j_procs_2015_08_504" ],
                 "sourcerecordid" : [ "S1877050915026393" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "recordtype" : [ "article" ],
@@ -444,82 +445,81 @@ http_interactions:
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06633203" ]
+                "score" : [ "0.06633455" ]
               },
-              "addata" : {
-                "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
-                "issn" : [ "1877-0509" ],
-                "oa" : [ "free_for_read" ],
-                "jtitle" : [ "Procedia computer science" ],
-                "genre" : [ "article" ],
-                "au" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "atitle" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
-                "date" : [ "2015" ],
-                "risdate" : [ "2015" ],
-                "volume" : [ "62" ],
-                "spage" : [ "442" ],
-                "epage" : [ "449" ],
-                "pages" : [ "442-449" ],
-                "eissn" : [ "1877-0509" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.procs.2015.08.504" ],
-                "format" : [ "journal" ]
+              "search" : {
+                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
+                "creationdate" : [ "2015" ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
+                "sourceid" : [ "AAFTH" ],
+                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
+                "issn" : [ "1877-0509", "1877-0509" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Elsevier B.V" ],
+                "startdate" : [ "2015" ],
+                "enddate" : [ "2015" ],
+                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ]
+              },
+              "display" : {
+                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
+                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
+                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
+                "publisher" : [ "Elsevier B.V" ],
+                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
+                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2015.08.504" ],
+                "rights" : [ "2015 The Authors" ],
+                "snippet" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
                 "openurl" : [ "$$Topenurl_article" ],
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
-              "search" : {
-                "creationdate" : [ "2015" ],
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
-                "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "issn" : [ "1877-0509", "1877-0509" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2015" ],
-                "enddate" : [ "2015" ],
-                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
-                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
-              },
-              "display" : {
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
-                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2015.08.504" ],
-                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2015 The Authors" ],
-                "snippet" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+              "addata" : {
+                "format" : [ "journal" ],
+                "issn" : [ "1877-0509" ],
+                "jtitle" : [ "Procedia computer science" ],
+                "genre" : [ "article" ],
+                "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
+                "epage" : [ "449" ],
+                "pages" : [ "442-449" ],
+                "eissn" : [ "1877-0509" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Elsevier B.V" ],
+                "doi" : [ "10.1016/j.procs.2015.08.504" ],
+                "au" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "atitle" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "date" : [ "2015" ],
+                "risdate" : [ "2015" ],
+                "volume" : [ "62" ],
+                "spage" : [ "442" ],
+                "oa" : [ "free_for_read" ]
               },
               "facets" : {
                 "creationdate" : [ "2015" ],
                 "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Engineering optimization problems", "fission-fusion social structure", "Nature Inspired Algorithms", "Swarm intelligence", "Spider Monkey Optimization Algorithm" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "ScienceDirect Open Access Titles", "Elsevier:ScienceDirect:Open Access", "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Procedia computer science" ]
               }
@@ -539,7 +539,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 11:44:31&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -550,7 +550,7 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procs_2015_08_504"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1016_j_procs_2015_08_504"
           }, {
             "pnx" : {
               "sort" : {
@@ -559,7 +559,8 @@ http_interactions:
                 "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A491502847" ],
+                "sourceid" : [ "gale_wiley" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A491502847" ],
                 "sourcerecordid" : [ "A491502847" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "recordtype" : [ "article" ],
@@ -567,22 +568,56 @@ http_interactions:
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
-                "sourceid" : [ "gale_wiley" ],
                 "galeid" : [ "A491502847" ],
-                "score" : [ "0.06524757" ]
+                "score" : [ "0.06524965" ]
+              },
+              "search" : {
+                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
+                "creationdate" : [ "2017" ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
+                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
+                "issn" : [ "0824-7935", "1467-8640" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "startdate" : [ "201705" ],
+                "enddate" : [ "201705" ],
+                "scope" : [ "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
+                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
+                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
+                "publisher" : [ "Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
+                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
+                "rights" : [ "2016 Wiley Periodicals, Inc.", "COPYRIGHT 2017 Blackwell Publishers Ltd." ],
+                "snippet" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
+                "format" : [ "journal" ],
                 "issn" : [ "0824-7935" ],
                 "jtitle" : [ "Computational intelligence" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "date" : [ "2017-05" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "33" ],
-                "issue" : [ "2" ],
-                "spage" : [ "210" ],
+                "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
                 "epage" : [ "240" ],
                 "pages" : [ "210-240" ],
                 "eissn" : [ "1467-8640" ],
@@ -590,59 +625,24 @@ http_interactions:
                 "pub" : [ "Wiley Subscription Services, Inc" ],
                 "doi" : [ "10.1111/coin.12081" ],
                 "tpages" : [ "31" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2017" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "BSHEE" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "issn" : [ "0824-7935", "1467-8640" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201705" ],
-                "enddate" : [ "201705" ],
-                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
-                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
-              },
-              "display" : {
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "publisher" : [ "Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
-                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2016 Wiley Periodicals, Inc.", "COPYRIGHT 2017 Blackwell Publishers Ltd." ],
-                "snippet" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "date" : [ "2017-05" ],
+                "risdate" : [ "2017" ],
+                "volume" : [ "33" ],
+                "issue" : [ "2" ],
+                "spage" : [ "210" ]
               },
               "facets" : {
                 "creationdate" : [ "2017" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization", "Lennard–Jones problem", "Usage", "Monkeys", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Computational intelligence" ]
               }
@@ -662,7 +662,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:18:51&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 11:44:31&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -673,17 +673,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A491502847"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A491502847"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "939",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "36",
-            "PC_SEARCH_TIME_TOTAL" : "976",
+            "PC_SEARCH_CALL_TIME" : "394",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "65",
+            "PC_SEARCH_TIME_TOTAL" : "459",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 977,
-            "COMBINED_SEARCH_TIME" : 982,
+            "BUILD_COMBINED_RESULTS_MAP" : 460,
+            "COMBINED_SEARCH_TIME" : 465,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ {
             "name" : "jtitle",
@@ -754,6 +754,9 @@ http_interactions:
               "value" : "Computer Science",
               "count" : "15"
             }, {
+              "value" : "Optimierungsalgorithmus",
+              "count" : "15"
+            }, {
               "value" : "Optimization Algorithms",
               "count" : "14"
             }, {
@@ -761,9 +764,6 @@ http_interactions:
               "count" : "14"
             }, {
               "value" : "Engineering, Electrical & Electronic",
-              "count" : "13"
-            }, {
-              "value" : "Optimierungsalgorithmus",
               "count" : "13"
             }, {
               "value" : "Analysis",
@@ -911,12 +911,12 @@ http_interactions:
               "count" : "12"
             }, {
               "value" : "2020",
-              "count" : "20"
+              "count" : "19"
             }, {
               "value" : "2021",
               "count" : "15"
             } ]
           } ]
         }
-  recorded_at: Mon, 17 May 2021 15:18:51 GMT
+  recorded_at: Wed, 19 May 2021 15:44:32 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/monkeys_primo_articles.yml
+++ b/test/vcr_cassettes/monkeys_primo_articles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,monkeys&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,monkeys&scope=FAKE_PRIMO_ARTICLE_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549964'
+      - '549967'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 20:06:52 GMT
+      - Wed, 19 May 2021 14:29:39 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,8 +46,8 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 754746,
-            "total" : 754746,
+            "totalResultsPC" : 754947,
+            "total" : 754947,
             "first" : 1,
             "last" : 5
           },
@@ -59,83 +59,83 @@ http_interactions:
           "docs" : [ {
             "pnx" : {
               "sort" : {
-                "title" : [ "Monkeys" ],
                 "creationdate" : [ "20120418" ],
+                "title" : [ "Monkeys" ],
                 "author" : [ "Liu, Ken" ]
               },
               "control" : {
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "recordid" : [ "cdi_crossref_primary_10_1038_484410a" ],
+                "sourceid" : [ "crossref" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1038_484410a" ],
                 "sourcerecordid" : [ "10_1038_484410a" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-11782-215b52dfce158458f5dc4d2f5c42ec852dff2b5941e5ec4bc08d67d449b552403" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNotjk1rwkAQQAdRNGrpz-hpdWYzkx2PRdoqRLzoOST7AVZbS_bkvxepp3d48HgAr4QLwlKXrMyE7QAKYlcZrtQNoUC0alDLagLTnL8RUchxAePd9fccb3kOo9Recnx5cgbHz4_DemPq_dd2_V4bIqfWWJJObEg-kiiLJgmeg03i2UavD5VsJyumKNFz51FD5QLzqhOxjOUM3v67vr_m3MfU_PWnn7a_NYTN4795_pd3tqI0vQ" ],
-                "sourceid" : [ "crossref" ],
-                "score" : [ "0.018675037" ]
+                "sourcetype" : [ "Aggregation Database" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
+                "score" : [ "0.018671729" ]
+              },
+              "search" : {
+                "creationdate" : [ "2012" ],
+                "title" : [ "Monkeys", "Nature (London)" ],
+                "recordid" : [ "eNotjk1rwkAQQAdRNGrpz-hpdWYzkx2PRdoqRLzoOST7AVZbS_bkvxepp3d48HgAr4QLwlKXrMyE7QAKYlcZrtQNoUC0alDLagLTnL8RUchxAePd9fccb3kOo9Recnx5cgbHz4_DemPq_dd2_V4bIqfWWJJObEg-kiiLJgmeg03i2UavD5VsJyumKNFz51FD5QLzqhOxjOUM3v67vr_m3MfU_PWnn7a_NYTN4795_pd3tqI0vQ" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Liu, Ken" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Liu, Ken" ],
+                "issn" : [ "0028-0836", "1476-4687" ],
+                "fulltext" : [ "true" ],
+                "startdate" : [ "20120418" ],
+                "enddate" : [ "20120418" ],
+                "scope" : [ "AAYXX", "CITATION" ]
+              },
+              "display" : {
+                "title" : [ "Monkeys" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Liu, Ken" ],
+                "source" : [ "Academic Search Complete", "Medline Complete", "Alma/SFX Local Collection", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "Nature Journal Archive", "Nature Journals Online", "Agricultural & Environmental Science Collection", "Environmental Science Collection" ],
+                "ispartof" : [ "Nature (London), 2012-04-18, Vol.484 (7394), p.410-410" ],
+                "identifier" : [ "ISSN: 0028-0836", "EISSN: 1476-4687", "DOI: 10.1038/484410a" ],
+                "snippet" : [ "...Ted and Kathy stared at the chaotic scene through the bars of the cage. A large, male macaque monkey about two feet tall screeched and lifted the typewriter..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
+                "format" : [ "journal" ],
                 "issn" : [ "0028-0836" ],
                 "jtitle" : [ "Nature (London)" ],
                 "genre" : [ "article" ],
+                "epage" : [ "410" ],
+                "pages" : [ "410-410" ],
+                "eissn" : [ "1476-4687" ],
+                "ristype" : [ "JOUR" ],
+                "doi" : [ "10.1038/484410a" ],
                 "au" : [ "Liu, Ken" ],
                 "atitle" : [ "Monkeys" ],
                 "date" : [ "2012-04-18" ],
                 "risdate" : [ "2012" ],
                 "volume" : [ "484" ],
                 "issue" : [ "7394" ],
-                "spage" : [ "410" ],
-                "epage" : [ "410" ],
-                "pages" : [ "410-410" ],
-                "eissn" : [ "1476-4687" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1038/484410a" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Liu, Ken" ],
-                "recordid" : [ "eNotjk1rwkAQQAdRNGrpz-hpdWYzkx2PRdoqRLzoOST7AVZbS_bkvxepp3d48HgAr4QLwlKXrMyE7QAKYlcZrtQNoUC0alDLagLTnL8RUchxAePd9fccb3kOo9Recnx5cgbHz4_DemPq_dd2_V4bIqfWWJJObEg-kiiLJgmeg03i2UavD5VsJyumKNFz51FD5QLzqhOxjOUM3v67vr_m3MfU_PWnn7a_NYTN4795_pd3tqI0vQ" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Monkeys", "Nature (London)" ],
-                "creationdate" : [ "2012" ],
-                "scope" : [ "AAYXX", "CITATION" ],
-                "creatorcontrib" : [ "Liu, Ken" ],
-                "issn" : [ "0028-0836", "1476-4687" ],
-                "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20120418" ],
-                "enddate" : [ "20120418" ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Medline Complete", "Alma/SFX Local Collection", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "Nature Journal Archive", "Nature Journals Online", "Agricultural & Environmental Science Collection", "Environmental Science Collection" ],
-                "creator" : [ "Liu, Ken" ],
-                "ispartof" : [ "Nature (London), 2012-04-18, Vol.484 (7394), p.410-410" ],
-                "identifier" : [ "ISSN: 0028-0836", "EISSN: 1476-4687", "DOI: 10.1038/484410a" ],
-                "language" : [ "eng" ],
-                "snippet" : [ "...Ted and Kathy stared at the chaotic scene through the bars of the cage. A large, male macaque monkey about two feet tall screeched and lifted the typewriter..." ],
-                "title" : [ "Monkeys" ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "spage" : [ "410" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2012" ],
                 "creatorcontrib" : [ "Liu, Ken" ],
-                "rsrctype" : [ "articles" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-11782-215b52dfce158458f5dc4d2f5c42ec852dff2b5941e5ec4bc08d67d449b552403" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-11782-215b52dfce158458f5dc4d2f5c42ec852dff2b5941e5ec4bc08d67d449b552403" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Nature (London)" ]
               }
@@ -155,7 +155,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 16:06:53&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Monkeys&rft.jtitle=Nature+%28London%29&rft.au=Liu%2C+Ken&rft.date=2012-04-18&rft.volume=484&rft.issue=7394&rft.spage=410&rft.epage=410&rft.pages=410-410&rft.issn=0028-0836&rft.eissn=1476-4687&rft_id=info:doi/10.1038%2F484410a&rft_dat=<crossref>10_1038_484410a</crossref>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Monkeys&rft.jtitle=Nature+%28London%29&rft.au=Liu%2C+Ken&rft.date=2012-04-18&rft.volume=484&rft.issue=7394&rft.spage=410&rft.epage=410&rft.pages=410-410&rft.issn=0028-0836&rft.eissn=1476-4687&rft_id=info:doi/10.1038%2F484410a&rft_dat=<crossref>10_1038_484410a</crossref>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -166,42 +166,79 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1038_484410a"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1038_484410a"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
                 "creationdate" : [ "201107" ],
+                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
                 "author" : [ "Beran, Michael J ; Smith, J. David" ]
               },
               "control" : {
+                "sourceid" : [ "gale_pubme" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_pubmedcentral_primary_oai_pubmedcentral_nih_gov_3095768" ],
+                "sourcerecordid" : [ "A256414754" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-1691t-755d341723f843a89e42dc0402e9ef754773e44639110d83b16497fb4295ccd73" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNqFkU-P0zAQxS0EYsvCV4BcEOwhYfwncXJZqapYWGkRF7hwsVxn0rqb2MVOVuq3x1G7XTghHyzN_N7TzDxC3lEoKNDq064wfuPsaL0rGFBaACtS_RlZ0FryXNa8fk4WABRyYFJekFcx7gBAMFm_JBeMirLhki3Ir1vX-TDo2SmLiPfWbbL1IQtbjFPMBu_u8RCzj9-0SS8bpl6Po77KtGszo_eT2Vr3RK1wnUR6j32vr16TF53uI745_Zfk583nH6uv-d33L7er5V1Oq4aOuSzLlgsqGe9qwXXdoGCtAQEMG-xkKaTkKETFG0qhrfmaVqKR3VqwpjSmlfySXB9999N6wNagG4Pu1T7YQYeD8tqqfzvObtXGPygOTSmrOhl8OBkE_3vCOKrBRjPv4NBPUdWV5IxW0CSyOJIb3aOy6XTJcD5Mi4M13mFnU33JykpQkUZPAnkUmOBjDNidx6Kg5iTVTp2TVHOSCphK9aR8-_dWZ91jdAl4fwJ0NLrvgnbGxidOMJCshsQtjxymDB4sBhWNRWewtQHNqFpv_zvMH0D3wFI" ],
                 "sourcetype" : [ "Open Access Repository" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "pqid" : [ "867321609" ],
                 "galeid" : [ "A256414754" ],
-                "recordid" : [ "cdi_pubmedcentral_primary_oai_pubmedcentral_nih_gov_3095768" ],
-                "sourcerecordid" : [ "A256414754" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-1691t-755d341723f843a89e42dc0402e9ef754773e44639110d83b16497fb4295ccd73" ],
+                "score" : [ "0.016648645" ]
+              },
+              "search" : {
+                "description" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ],
+                "creationdate" : [ "2011" ],
+                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)", "Cognition" ],
+                "recordid" : [ "eNqFkU-P0zAQxS0EYsvCV4BcEOwhYfwncXJZqapYWGkRF7hwsVxn0rqb2MVOVuq3x1G7XTghHyzN_N7TzDxC3lEoKNDq064wfuPsaL0rGFBaACtS_RlZ0FryXNa8fk4WABRyYFJekFcx7gBAMFm_JBeMirLhki3Ir1vX-TDo2SmLiPfWbbL1IQtbjFPMBu_u8RCzj9-0SS8bpl6Po77KtGszo_eT2Vr3RK1wnUR6j32vr16TF53uI745_Zfk583nH6uv-d33L7er5V1Oq4aOuSzLlgsqGe9qwXXdoGCtAQEMG-xkKaTkKETFG0qhrfmaVqKR3VqwpjSmlfySXB9999N6wNagG4Pu1T7YQYeD8tqqfzvObtXGPygOTSmrOhl8OBkE_3vCOKrBRjPv4NBPUdWV5IxW0CSyOJIb3aOy6XTJcD5Mi4M13mFnU33JykpQkUZPAnkUmOBjDNidx6Kg5iTVTp2TVHOSCphK9aR8-_dWZ91jdAl4fwJ0NLrvgnbGxidOMJCshsQtjxymDB4sBhWNRWewtQHNqFpv_zvMH0D3wFI" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqFkU-P0zAQxS0EYsvCV4BcEOwhYfwncXJZqapYWGkRF7hwsVxn0rqb2MVOVuq3x1G7XTghHyzN_N7TzDxC3lEoKNDq064wfuPsaL0rGFBaACtS_RlZ0FryXNa8fk4WABRyYFJekFcx7gBAMFm_JBeMirLhki3Ir1vX-TDo2SmLiPfWbbL1IQtbjFPMBu_u8RCzj9-0SS8bpl6Po77KtGszo_eT2Vr3RK1wnUR6j32vr16TF53uI745_Zfk583nH6uv-d33L7er5V1Oq4aOuSzLlgsqGe9qwXXdoGCtAQEMG-xkKaTkKETFG0qhrfmaVqKR3VqwpjSmlfySXB9999N6wNagG4Pu1T7YQYeD8tqqfzvObtXGPygOTSmrOhl8OBkE_3vCOKrBRjPv4NBPUdWV5IxW0CSyOJIb3aOy6XTJcD5Mi4M13mFnU33JykpQkUZPAnkUmOBjDNidx6Kg5iTVTp2TVHOSCphK9aR8-_dWZ91jdAl4fwJ0NLrvgnbGxidOMJCshsQtjxymDB4sBhWNRWewtQHNqFpv_zvMH0D3wFI" ],
-                "sourceid" : [ "gale_pubme" ],
-                "score" : [ "0.016651459" ]
+                "creatorcontrib" : [ "Beran, Michael J", "Smith, J. David" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Beran, Michael J", "Smith, J. David" ],
+                "subject" : [ "Comparative cognition ; Monkeys ; Information seeking ; Primate cognition ; Metacognition ; Fundamental and applied biological sciences. Psychology ; Biological and medical sciences ; Cognition. Intelligence ; Miscellaneous ; Psychology. Psychoanalysis. Psychiatry ; Psychology. Psychophysiology ; Learning ; Psychomotor Performance ; Animals ; Discrimination (Psychology) ; Female ; Information Seeking Behavior ; Male ; Cognition ; Macaca mulatta - psychology ; Photic Stimulation ; Cebus - psychology ; Pigeons ; Index Medicus ; primate cognition ; monkeys ; comparative cognition ; metacognition ; information seeking" ],
+                "issn" : [ "0010-0277", "1873-7838" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Cognition" ],
+                "general" : [ "Elsevier B.V", "Elsevier" ],
+                "startdate" : [ "201107" ],
+                "enddate" : [ "201107" ],
+                "scope" : [ "IQODW", "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "BSHEE", "7X8", "5PM" ]
+              },
+              "display" : {
+                "description" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ],
+                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Beran, Michael J ; Smith, J. David" ],
+                "subject" : [ "Comparative cognition ; Monkeys ; Information seeking ; Primate cognition ; Metacognition ; Fundamental and applied biological sciences. Psychology ; Biological and medical sciences ; Cognition. Intelligence ; Miscellaneous ; Psychology. Psychoanalysis. Psychiatry ; Psychology. Psychophysiology ; Learning ; Psychomotor Performance ; Animals ; Discrimination (Psychology) ; Female ; Information Seeking Behavior ; Male ; Cognition ; Macaca mulatta - psychology ; Photic Stimulation ; Cebus - psychology ; Pigeons ; Index Medicus ; primate cognition ; monkeys ; comparative cognition ; metacognition ; information seeking" ],
+                "source" : [ "ScienceDirect Pi2 Collection", "Elsevier:ScienceDirect:Social Sciences Subject Collection:2018", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "ScienceDirect Social & Behavioral Sciences College Edition Backfile", "Alma/SFX Local Collection", "Life Sciences Japan [FCJLS]", "Elsevier:ScienceDirect:Neuroscience Subject Collection:2017", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]", "ScienceDirect Health & Life Sciences College Edition Backfile" ],
+                "publisher" : [ "Amsterdam: Elsevier B.V" ],
+                "ispartof" : [ "Cognition, 2011-07, Vol.120 (1), p.90-105" ],
+                "identifier" : [ "ISSN: 0010-0277", "EISSN: 1873-7838", "DOI: 10.1016/j.cognition.2011.02.016", "PMID: 21459372", "CODEN: CGTNAU" ],
+                "rights" : [ "2011 Elsevier B.V.", "2015 INIST-CNRS", "Copyright © 2011 Elsevier B.V. All rights reserved.", "COPYRIGHT 2011 Elsevier B.V.", "2011 Elsevier B.V. All rights reserved. 2011" ],
+                "snippet" : [ ".... We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al..." ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=24207280$$DView record in Pascal Francis" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ],
+                "format" : [ "journal" ],
                 "issn" : [ "0010-0277" ],
-                "addtitle" : [ "Cognition" ],
-                "oa" : [ "free_for_read" ],
                 "jtitle" : [ "Cognition" ],
                 "genre" : [ "article" ],
-                "au" : [ "Beran, Michael J", "Smith, J. David" ],
-                "atitle" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
-                "date" : [ "2011-07" ],
-                "risdate" : [ "2011" ],
-                "volume" : [ "120" ],
-                "issue" : [ "1" ],
-                "spage" : [ "90" ],
+                "addtitle" : [ "Cognition" ],
+                "abstract" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ],
                 "epage" : [ "105" ],
                 "pages" : [ "90-105" ],
                 "eissn" : [ "1873-7838" ],
@@ -210,62 +247,25 @@ http_interactions:
                 "cop" : [ "Amsterdam" ],
                 "pub" : [ "Elsevier B.V" ],
                 "doi" : [ "10.1016/j.cognition.2011.02.016" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "backlink" : [ "$$Uhttp://pascal-francis.inist.fr/vibad/index.php?action=getRecordDetail&idt=24207280$$DView record in Pascal Francis" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Beran, Michael J", "Smith, J. David" ],
-                "subject" : [ "Comparative cognition ; Monkeys ; Information seeking ; Primate cognition ; Metacognition ; Fundamental and applied biological sciences. Psychology ; Biological and medical sciences ; Cognition. Intelligence ; Miscellaneous ; Psychology. Psychoanalysis. Psychiatry ; Psychology. Psychophysiology ; Learning ; Psychomotor Performance ; Animals ; Discrimination (Psychology) ; Female ; Information Seeking Behavior ; Male ; Cognition ; Macaca mulatta - psychology ; Photic Stimulation ; Cebus - psychology ; Pigeons ; Index Medicus ; primate cognition ; monkeys ; comparative cognition ; metacognition ; information seeking" ],
-                "recordid" : [ "eNqFkU-P0zAQxS0EYsvCV4BcEOwhYfwncXJZqapYWGkRF7hwsVxn0rqb2MVOVuq3x1G7XTghHyzN_N7TzDxC3lEoKNDq064wfuPsaL0rGFBaACtS_RlZ0FryXNa8fk4WABRyYFJekFcx7gBAMFm_JBeMirLhki3Ir1vX-TDo2SmLiPfWbbL1IQtbjFPMBu_u8RCzj9-0SS8bpl6Po77KtGszo_eT2Vr3RK1wnUR6j32vr16TF53uI745_Zfk583nH6uv-d33L7er5V1Oq4aOuSzLlgsqGe9qwXXdoGCtAQEMG-xkKaTkKETFG0qhrfmaVqKR3VqwpjSmlfySXB9999N6wNagG4Pu1T7YQYeD8tqqfzvObtXGPygOTSmrOhl8OBkE_3vCOKrBRjPv4NBPUdWV5IxW0CSyOJIb3aOy6XTJcD5Mi4M13mFnU33JykpQkUZPAnkUmOBjDNidx6Kg5iTVTp2TVHOSCphK9aR8-_dWZ91jdAl4fwJ0NLrvgnbGxidOMJCshsQtjxymDB4sBhWNRWewtQHNqFpv_zvMH0D3wFI" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)", "Cognition" ],
-                "creationdate" : [ "2011" ],
-                "scope" : [ "IQODW", "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "BSHEE", "7X8", "5PM" ],
-                "creatorcontrib" : [ "Beran, Michael J", "Smith, J. David" ],
-                "issn" : [ "0010-0277", "1873-7838" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Cognition" ],
-                "general" : [ "Elsevier B.V", "Elsevier" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201107" ],
-                "enddate" : [ "201107" ],
-                "description" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "Elsevier:ScienceDirect:Social Sciences Subject Collection:2018", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "ScienceDirect Social & Behavioral Sciences College Edition Backfile", "Alma/SFX Local Collection", "Life Sciences Japan [FCJLS]", "Elsevier:ScienceDirect:Neuroscience Subject Collection:2017", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]", "ScienceDirect Health & Life Sciences College Edition Backfile" ],
-                "creator" : [ "Beran, Michael J ; Smith, J. David" ],
-                "publisher" : [ "Amsterdam: Elsevier B.V" ],
-                "ispartof" : [ "Cognition, 2011-07, Vol.120 (1), p.90-105" ],
-                "identifier" : [ "ISSN: 0010-0277", "EISSN: 1873-7838", "DOI: 10.1016/j.cognition.2011.02.016", "PMID: 21459372", "CODEN: CGTNAU" ],
-                "subject" : [ "Comparative cognition ; Monkeys ; Information seeking ; Primate cognition ; Metacognition ; Fundamental and applied biological sciences. Psychology ; Biological and medical sciences ; Cognition. Intelligence ; Miscellaneous ; Psychology. Psychoanalysis. Psychiatry ; Psychology. Psychophysiology ; Learning ; Psychomotor Performance ; Animals ; Discrimination (Psychology) ; Female ; Information Seeking Behavior ; Male ; Cognition ; Macaca mulatta - psychology ; Photic Stimulation ; Cebus - psychology ; Pigeons ; Index Medicus ; primate cognition ; monkeys ; comparative cognition ; metacognition ; information seeking" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2011 Elsevier B.V.", "2015 INIST-CNRS", "Copyright © 2011 Elsevier B.V. All rights reserved.", "COPYRIGHT 2011 Elsevier B.V.", "2011 Elsevier B.V. All rights reserved. 2011" ],
-                "snippet" : [ ".... We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al..." ],
-                "title" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "Animal metacognition is an active, growing research area, and one part of metacognition is flexible information-seeking behavior. In Roberts et al. (2009), pigeons failed an intuitive information-seeking task. They basically refused, despite multiple fostering experiments, to view a sample image before attempting to find its match. Roberts et al. concluded that pigeons’ lack of an information-seeking capacity reflected their broader lack of metacognition. We report a striking species contrast to pigeons. Eight rhesus macaques and seven capuchin monkeys passed the Roberts et al. test of information seeking—often in their first testing session. Members of both primate species appreciated immediately the lack of information signaled by an occluded sample, and the need for an information-seeking response to manage the situation. In subsequent testing, macaques demonstrated flexible/varied forms of information management. Capuchins did not. The research findings bear on the phylogenetic distribution of metacognition across the vertebrates, and on the underlying psychological requirements for metacognitive and information-seeking performances." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Beran, Michael J", "Smith, J. David" ],
+                "atitle" : [ "Information seeking by rhesus monkeys (Macaca mulatta) and capuchin monkeys (Cebus apella)" ],
+                "date" : [ "2011-07" ],
+                "risdate" : [ "2011" ],
+                "volume" : [ "120" ],
+                "issue" : [ "1" ],
+                "spage" : [ "90" ],
+                "oa" : [ "free_for_read" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2011" ],
                 "creatorcontrib" : [ "Beran, Michael J", "Smith, J. David" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Comparative cognition", "Monkeys", "Information seeking", "Primate cognition", "Metacognition", "Fundamental and applied biological sciences. Psychology", "Biological and medical sciences", "Cognition. Intelligence", "Miscellaneous", "Psychology. Psychoanalysis. Psychiatry", "Psychology. Psychophysiology", "Learning", "Psychomotor Performance", "Animals", "Discrimination (Psychology)", "Female", "Information Seeking Behavior", "Male", "Cognition", "Macaca mulatta - psychology", "Photic Stimulation", "Cebus - psychology", "Pigeons", "Index Medicus", "primate cognition", "monkeys", "comparative cognition", "metacognition", "information seeking" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "Pascal-Francis", "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "Academic OneFile (A&I only)", "MEDLINE - Academic", "PubMed Central (Full Participant titles)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1691t-755d341723f843a89e42dc0402e9ef754773e44639110d83b16497fb4295ccd73" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-1691t-755d341723f843a89e42dc0402e9ef754773e44639110d83b16497fb4295ccd73" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Cognition" ]
               }
@@ -285,7 +285,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 16:06:53&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_pubme&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Information+seeking+by+rhesus+monkeys+%28Macaca+mulatta%29+and+capuchin+monkeys+%28Cebus+apella%29&rft.jtitle=Cognition&rft.au=Beran%2C+Michael+J&rft.date=2011-07&rft.volume=120&rft.issue=1&rft.spage=90&rft.epage=105&rft.pages=90-105&rft.issn=0010-0277&rft.eissn=1873-7838&rft.coden=CGTNAU&rft_id=info:doi/10.1016%2Fj.cognition.2011.02.016&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_pubme>867321609</gale_pubme>&svc_dat=viewit&rft_galeid=A256414754"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_pubme&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Information+seeking+by+rhesus+monkeys+%28Macaca+mulatta%29+and+capuchin+monkeys+%28Cebus+apella%29&rft.jtitle=Cognition&rft.au=Beran%2C+Michael+J&rft.date=2011-07&rft.volume=120&rft.issue=1&rft.spage=90&rft.epage=105&rft.pages=90-105&rft.issn=0010-0277&rft.eissn=1873-7838&rft.coden=CGTNAU&rft_id=info:doi/10.1016%2Fj.cognition.2011.02.016&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_pubme>867321609</gale_pubme>&svc_dat=viewit&rft_galeid=A256414754"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -296,40 +296,79 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_pubmedcentral_primary_oai_pubmedcentral_nih_gov_3095768"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_pubmedcentral_primary_oai_pubmedcentral_nih_gov_3095768"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
                 "creationdate" : [ "201908" ],
+                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
                 "author" : [ "Beran, Michael J ; French, Kristin ; Smith, Travis R ; Parrish, Audrey E" ]
               },
               "control" : {
+                "sourceid" : [ "proquest_pubme" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_pubmedcentral_primary_oai_pubmedcentral_nih_gov_6684444" ],
+                "sourcerecordid" : [ "2196249846" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-a385t-c1e1f0f5a61b8d6a40ab407f2493d993fa6387e2b11b678df4609bc7c7964f4a3" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNp9kV1rFDEUhoNY7Fq98RcEvLHi2GSSzceNIEvVwq4F216HM5mkm3U-0mSmsP_elC0tvfHk4nDIc15e3oPQB0q-UsLkmR17UopK-QotqGa6qomSr9GCSLasJGHiGL3NeVcYQbl8g44ZUVrUjC3Q3Tr0YXItPr8PrRusw6PHv-e-cam6ilDmDcQYhlscBvxn6_Kc8WYc_rp9xp82YMvD_dzBNMEphqHFK4iz3Rb4ibqCCLuyBtF1HZy-Q0ceuuzeP_YTdPPj_Hr1q1pf_rxYfV9XwNRyqix11BO_BEEb1QrgBBpOpK-5Zq3WzINgSrq6obQRUrWeC6IbK63UgnsO7AR9O-jGuelda90wJehMTKGHtDcjBPPyZwhbczveGyEUL1UEPj4KpPFudnkyu3FOQ_Fs6lrRkqRi_6doCZlrxUWhPh8om8ack_NPPigxD0c0z0cs8JcDXIIzMe8tpCnYzmU7p1TMPrCGMmaYKT7YP_iynTM" ],
                 "sourcetype" : [ "Open Access Repository" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "pqid" : [ "2196249846" ],
-                "recordid" : [ "cdi_pubmedcentral_primary_oai_pubmedcentral_nih_gov_6684444" ],
-                "sourcerecordid" : [ "2281147834" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-a385t-c1e1f0f5a61b8d6a40ab407f2493d993fa6387e2b11b678df4609bc7c7964f4a3" ],
+                "score" : [ "0.016332163" ]
+              },
+              "search" : {
+                "description" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ],
+                "creationdate" : [ "2019" ],
+                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)", "Journal of comparative psychology (1983)" ],
+                "sourceid" : [ "7RZ" ],
+                "recordid" : [ "eNp9kV1rFDEUhoNY7Fq98RcEvLHi2GSSzceNIEvVwq4F216HM5mkm3U-0mSmsP_elC0tvfHk4nDIc15e3oPQB0q-UsLkmR17UopK-QotqGa6qomSr9GCSLasJGHiGL3NeVcYQbl8g44ZUVrUjC3Q3Tr0YXItPr8PrRusw6PHv-e-cam6ilDmDcQYhlscBvxn6_Kc8WYc_rp9xp82YMvD_dzBNMEphqHFK4iz3Rb4ibqCCLuyBtF1HZy-Q0ceuuzeP_YTdPPj_Hr1q1pf_rxYfV9XwNRyqix11BO_BEEb1QrgBBpOpK-5Zq3WzINgSrq6obQRUrWeC6IbK63UgnsO7AR9O-jGuelda90wJehMTKGHtDcjBPPyZwhbczveGyEUL1UEPj4KpPFudnkyu3FOQ_Fs6lrRkqRi_6doCZlrxUWhPh8om8ack_NPPigxD0c0z0cs8JcDXIIzMe8tpCnYzmU7p1TMPrCGMmaYKT7YP_iynTM" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp9kV1rFDEUhoNY7Fq98RcEvLHi2GSSzceNIEvVwq4F216HM5mkm3U-0mSmsP_elC0tvfHk4nDIc15e3oPQB0q-UsLkmR17UopK-QotqGa6qomSr9GCSLasJGHiGL3NeVcYQbl8g44ZUVrUjC3Q3Tr0YXItPr8PrRusw6PHv-e-cam6ilDmDcQYhlscBvxn6_Kc8WYc_rp9xp82YMvD_dzBNMEphqHFK4iz3Rb4ibqCCLuyBtF1HZy-Q0ceuuzeP_YTdPPj_Hr1q1pf_rxYfV9XwNRyqix11BO_BEEb1QrgBBpOpK-5Zq3WzINgSrq6obQRUrWeC6IbK63UgnsO7AR9O-jGuelda90wJehMTKGHtDcjBPPyZwhbczveGyEUL1UEPj4KpPFudnkyu3FOQ_Fs6lrRkqRi_6doCZlrxUWhPh8om8ack_NPPigxD0c0z0cs8JcDXIIzMe8tpCnYzmU7p1TMPrCGMmaYKT7YP_iynTM" ],
-                "sourceid" : [ "proquest_pubme" ],
-                "score" : [ "0.016333867" ]
+                "creatorcontrib" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-2504-0338" ],
+                "creator" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
+                "contributor" : [ "Fragaszy, Dorothy M" ],
+                "subject" : [ "Clinical trials ; Numerical analysis ; Monkeys & apes ; Research methodology ; Numbers ; monkeys ; mental number line ; space ; SNARC effect" ],
+                "issn" : [ "0735-7036", "1939-2087" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "American Psychological Association" ],
+                "startdate" : [ "201908" ],
+                "enddate" : [ "201908" ],
+                "scope" : [ "AAYXX", "CITATION", "7RZ", "5PM" ]
+              },
+              "display" : {
+                "description" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ],
+                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Beran, Michael J ; French, Kristin ; Smith, Travis R ; Parrish, Audrey E" ],
+                "contributor" : [ "Fragaszy, Dorothy M" ],
+                "subject" : [ "Clinical trials ; Numerical analysis ; Monkeys & apes ; Research methodology ; Numbers ; monkeys ; mental number line ; space ; SNARC effect" ],
+                "source" : [ "Alma/SFX Local Collection", "PsycARTICLES" ],
+                "publisher" : [ "Washington: American Psychological Association" ],
+                "ispartof" : [ "Journal of comparative psychology (1983), 2019-08, Vol.133 (3), p.281-293" ],
+                "identifier" : [ "ISSN: 0735-7036", "EISSN: 1939-2087", "DOI: 10.1037/com0000177", "PMID: 30896233" ],
+                "rights" : [ "2019 American Psychological Association", "2019, American Psychological Association. American Psychological Association", "Copyright American Psychological Association Aug 2019" ],
+                "snippet" : [ ".... We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ],
+                "format" : [ "journal" ],
                 "orcidid" : [ "https://orcid.org/0000-0002-2504-0338" ],
                 "issn" : [ "0735-7036" ],
                 "jtitle" : [ "Journal of comparative psychology (1983)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
-                "atitle" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
-                "date" : [ "2019-08" ],
-                "risdate" : [ "2019" ],
-                "volume" : [ "133" ],
-                "issue" : [ "3" ],
-                "spage" : [ "281" ],
+                "abstract" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ],
                 "epage" : [ "293" ],
                 "pages" : [ "281-293" ],
                 "eissn" : [ "1939-2087" ],
@@ -337,63 +376,24 @@ http_interactions:
                 "cop" : [ "Washington" ],
                 "pub" : [ "American Psychological Association" ],
                 "doi" : [ "10.1037/com0000177" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
-                "contributor" : [ "Fragaszy, Dorothy M" ],
-                "subject" : [ "Clinical trials ; Numerical analysis ; Monkeys & apes ; Research methodology ; Numbers ; monkeys ; mental number line ; space ; SNARC effect" ],
-                "recordid" : [ "eNp9kV1rFDEUhoNY7Fq98RcEvLHi2GSSzceNIEvVwq4F216HM5mkm3U-0mSmsP_elC0tvfHk4nDIc15e3oPQB0q-UsLkmR17UopK-QotqGa6qomSr9GCSLasJGHiGL3NeVcYQbl8g44ZUVrUjC3Q3Tr0YXItPr8PrRusw6PHv-e-cam6ilDmDcQYhlscBvxn6_Kc8WYc_rp9xp82YMvD_dzBNMEphqHFK4iz3Rb4ibqCCLuyBtF1HZy-Q0ceuuzeP_YTdPPj_Hr1q1pf_rxYfV9XwNRyqix11BO_BEEb1QrgBBpOpK-5Zq3WzINgSrq6obQRUrWeC6IbK63UgnsO7AR9O-jGuelda90wJehMTKGHtDcjBPPyZwhbczveGyEUL1UEPj4KpPFudnkyu3FOQ_Fs6lrRkqRi_6doCZlrxUWhPh8om8ack_NPPigxD0c0z0cs8JcDXIIzMe8tpCnYzmU7p1TMPrCGMmaYKT7YP_iynTM" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)", "Journal of comparative psychology (1983)" ],
-                "creationdate" : [ "2019" ],
-                "sourceid" : [ "7RZ" ],
-                "scope" : [ "AAYXX", "CITATION", "7RZ", "5PM" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-2504-0338" ],
-                "creatorcontrib" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
-                "issn" : [ "0735-7036", "1939-2087" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "American Psychological Association" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201908" ],
-                "enddate" : [ "201908" ],
-                "description" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "Alma/SFX Local Collection", "PsycARTICLES" ],
-                "creator" : [ "Beran, Michael J ; French, Kristin ; Smith, Travis R ; Parrish, Audrey E" ],
-                "contributor" : [ "Fragaszy, Dorothy M" ],
-                "publisher" : [ "Washington: American Psychological Association" ],
-                "ispartof" : [ "Journal of comparative psychology (1983), 2019-08, Vol.133 (3), p.281-293" ],
-                "identifier" : [ "ISSN: 0735-7036", "EISSN: 1939-2087", "DOI: 10.1037/com0000177", "PMID: 30896233" ],
-                "subject" : [ "Clinical trials ; Numerical analysis ; Monkeys & apes ; Research methodology ; Numbers ; monkeys ; mental number line ; space ; SNARC effect" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2019 American Psychological Association", "2019, American Psychological Association. American Psychological Association", "Copyright American Psychological Association Aug 2019" ],
-                "snippet" : [ ".... We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome..." ],
-                "title" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
-                "description" : [ "Humans exhibit evidence of a mental number line that suggests a left-to-right, or sometimes right-to-left, representation of smaller to larger numbers. The Spatial Numerical Association of Response Codes (SNARC) effect is one example of this mental number line and has been investigated extensively in humans. Less research has been done with animals, and results have been inconclusive. Rugani, Vallortigara, Priftis, and Regolin (2015) found that young chicks showed a bias to respond to small quantities presented to their left and large quantities presented to their right when forced to move toward those stimuli to gain food reward. We replicated this design with rhesus macaques and capuchin monkeys using a computerized task, but we did not find this outcome. We also trained monkeys to choose between 2 arrays of dots, and then assessed biases in terms of choice location and response latency on trials with a numerical difference and on trials with equal numbers of items in both sets. There was no evidence of SNARC-like effects in equal trials, although when arrays differed in number, 12 of 19 monkeys showed differential performance depending on whether the smaller array was at the left or at the right onscreen. These results indicate that SNARC-like effects may not emerge in all contexts and may not be phylogenetically widespread. More effort is needed to broaden the number of species assessed and match other methods that are used with human participants so that we can better define the presence and extent of such effects." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
+                "atitle" : [ "Limited Evidence of Number-Space Mapping in Rhesus Monkeys (Macaca mulatta) and Capuchin Monkeys (Sapajus apella)" ],
+                "date" : [ "2019-08" ],
+                "risdate" : [ "2019" ],
+                "volume" : [ "133" ],
+                "issue" : [ "3" ],
+                "spage" : [ "281" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2019" ],
                 "creatorcontrib" : [ "Beran, Michael J", "French, Kristin", "Smith, Travis R", "Parrish, Audrey E" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Clinical trials", "Numerical analysis", "Monkeys & apes", "Research methodology", "Numbers", "monkeys", "mental number line", "space", "SNARC effect" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "CrossRef", "PsycARTICLES", "PubMed Central (Full Participant titles)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-a385t-c1e1f0f5a61b8d6a40ab407f2493d993fa6387e2b11b678df4609bc7c7964f4a3" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-a385t-c1e1f0f5a61b8d6a40ab407f2493d993fa6387e2b11b678df4609bc7c7964f4a3" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Journal of comparative psychology (1983)" ]
               }
@@ -413,7 +413,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 16:06:53&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_pubme&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Limited+Evidence+of+Number-Space+Mapping+in+Rhesus+Monkeys+%28Macaca+mulatta%29+and+Capuchin+Monkeys+%28Sapajus+apella%29&rft.jtitle=Journal+of+comparative+psychology+%281983%29&rft.au=Beran%2C+Michael+J&rft.date=2019-08&rft.volume=133&rft.issue=3&rft.spage=281&rft.epage=293&rft.pages=281-293&rft.issn=0735-7036&rft.eissn=1939-2087&rft_id=info:doi/10.1037%2Fcom0000177&rft.pub=American+Psychological+Association&rft.place=Washington&rft_dat=<proquest_pubme>2196249846</proquest_pubme>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_pubme&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Limited+Evidence+of+Number-Space+Mapping+in+Rhesus+Monkeys+%28Macaca+mulatta%29+and+Capuchin+Monkeys+%28Sapajus+apella%29&rft.jtitle=Journal+of+comparative+psychology+%281983%29&rft.au=Beran%2C+Michael+J&rft.date=2019-08&rft.volume=133&rft.issue=3&rft.spage=281&rft.epage=293&rft.pages=281-293&rft.issn=0735-7036&rft.eissn=1939-2087&rft_id=info:doi/10.1037%2Fcom0000177&rft.pub=American+Psychological+Association&rft.place=Washington&rft_dat=<proquest_pubme>2196249846</proquest_pubme>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -424,41 +424,77 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_pubmedcentral_primary_oai_pubmedcentral_nih_gov_6684444"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_pubmedcentral_primary_oai_pubmedcentral_nih_gov_6684444"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
                 "creationdate" : [ "20071201" ],
+                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
                 "author" : [ "Weiss, Daniel J ; Wark, Jason D ; Rosenbaum, David A" ]
               },
               "control" : {
+                "sourceid" : [ "gale_proqu" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_68541774" ],
+                "sourcerecordid" : [ "A171616869" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-1503t-a6dcd2ae3d1efe94f68d47feb40552427a4297cc839f86be3749a501acb70c573" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNqNUdGO1CAUJUbjjqufoOHJaGIrFAqtb5txXDdZo8mMz4Shl7F1CrNAk92_l7GT2de9PACXc0645yCEKSlprs9DSbmQRVs1pKwIkSWpSCXK-2docX54jhakrUUhWyku0KsYB5JLMvESXdCGMMopW6Dhh3d_4QGvAT7h0_nXXrvz5av_gjd_AK9cV6yTToCXfrQ-JLyyFkzCvcudlLwrNv6AN3rUoXcRf1jr3dS7KWIPXX-Y4sfX6IXV-whvTvsl-v1ttVl-L25_Xt8sr24LWhOWCi0601UaWEfBQsutaDouLWw5qeuKV1LzqpXGNKy1jdgCk7zVNaHabCUxtWSX6P2sewj-boKY1NhHA_s8FfgpKtHUnErJM7CcgTu9B9U761PQJq8Oxt54B7bP_SsqqaCiEW0mNDPBBB9jAKsOoc_zPihK1DEYNaij_-rovzoGo_4Ho-4z9d3pU9N2hO6ReEoiA-oZEPUO1OCn4LJJTxF-O_OGmHw463JCBJeEs3_rHaIG" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "pqid" : [ "68541774" ],
                 "galeid" : [ "A171616869" ],
-                "recordid" : [ "cdi_proquest_miscellaneous_68541774" ],
-                "sourcerecordid" : [ "A171616869" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-1503t-a6dcd2ae3d1efe94f68d47feb40552427a4297cc839f86be3749a501acb70c573" ],
+                "score" : [ "0.016320815" ]
+              },
+              "search" : {
+                "description" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ],
+                "creationdate" : [ "2007" ],
+                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)", "Psychological science" ],
+                "recordid" : [ "eNqNUdGO1CAUJUbjjqufoOHJaGIrFAqtb5txXDdZo8mMz4Shl7F1CrNAk92_l7GT2de9PACXc0645yCEKSlprs9DSbmQRVs1pKwIkSWpSCXK-2docX54jhakrUUhWyku0KsYB5JLMvESXdCGMMopW6Dhh3d_4QGvAT7h0_nXXrvz5av_gjd_AK9cV6yTToCXfrQ-JLyyFkzCvcudlLwrNv6AN3rUoXcRf1jr3dS7KWIPXX-Y4sfX6IXV-whvTvsl-v1ttVl-L25_Xt8sr24LWhOWCi0601UaWEfBQsutaDouLWw5qeuKV1LzqpXGNKy1jdgCk7zVNaHabCUxtWSX6P2sewj-boKY1NhHA_s8FfgpKtHUnErJM7CcgTu9B9U761PQJq8Oxt54B7bP_SsqqaCiEW0mNDPBBB9jAKsOoc_zPihK1DEYNaij_-rovzoGo_4Ho-4z9d3pU9N2hO6ReEoiA-oZEPUO1OCn4LJJTxF-O_OGmHw463JCBJeEs3_rHaIG" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNqNUdGO1CAUJUbjjqufoOHJaGIrFAqtb5txXDdZo8mMz4Shl7F1CrNAk92_l7GT2de9PACXc0645yCEKSlprs9DSbmQRVs1pKwIkSWpSCXK-2docX54jhakrUUhWyku0KsYB5JLMvESXdCGMMopW6Dhh3d_4QGvAT7h0_nXXrvz5av_gjd_AK9cV6yTToCXfrQ-JLyyFkzCvcudlLwrNv6AN3rUoXcRf1jr3dS7KWIPXX-Y4sfX6IXV-whvTvsl-v1ttVl-L25_Xt8sr24LWhOWCi0601UaWEfBQsutaDouLWw5qeuKV1LzqpXGNKy1jdgCk7zVNaHabCUxtWSX6P2sewj-boKY1NhHA_s8FfgpKtHUnErJM7CcgTu9B9U761PQJq8Oxt54B7bP_SsqqaCiEW0mNDPBBB9jAKsOoc_zPihK1DEYNaij_-rovzoGo_4Ho-4z9d3pU9N2hO6ReEoiA-oZEPUO1OCn4LJJTxF-O_OGmHw463JCBJeEs3_rHaIG" ],
-                "sourceid" : [ "gale_proqu" ],
-                "score" : [ "0.016323581" ]
+                "creatorcontrib" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
+                "subject" : [ "Marshmallows ; Hands ; Trials ; Animals ; Terraces ; Primates ; Problem solving ; Monkeys ; Research Articles ; Comparative psychology ; Posture ; Behavior, Animal ; Psychomotor Performance ; Female ; Male ; Cognition ; Saguinus ; Hand Strength ; Index Medicus" ],
+                "issn" : [ "0956-7976", "1467-9280" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Psychol Sci" ],
+                "general" : [ "Blackwell Publishing", "SAGE Publications", "Wiley Subscription Services, Inc" ],
+                "startdate" : [ "20071201" ],
+                "enddate" : [ "20071201" ],
+                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "BSHEE", "7X8" ]
+              },
+              "display" : {
+                "description" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ],
+                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Weiss, Daniel J ; Wark, Jason D ; Rosenbaum, David A" ],
+                "subject" : [ "Marshmallows ; Hands ; Trials ; Animals ; Terraces ; Primates ; Problem solving ; Monkeys ; Research Articles ; Comparative psychology ; Posture ; Behavior, Animal ; Psychomotor Performance ; Female ; Male ; Cognition ; Saguinus ; Hand Strength ; Index Medicus" ],
+                "source" : [ "Academic Search Complete", "Business Source Complete", "SAGE Complete A-Z List (1999-Present)", "Medline Complete", "JSTOR Life Sciences", "Alma/SFX Local Collection", "SAGE Complete A-Z List" ],
+                "publisher" : [ "Los Angeles, CA: Blackwell Publishing" ],
+                "ispartof" : [ "Psychological science, 2007-12-01, Vol.18 (12), p.1063-1068" ],
+                "identifier" : [ "ISSN: 0956-7976", "EISSN: 1467-9280", "DOI: 10.1111/j.1467-9280.2007.02026.x", "PMID: 18031413" ],
+                "rights" : [ "Copyright 2007 Association for Psychological Science", "2007 Association for Psychological Science", "COPYRIGHT 2007 Blackwell Publishers Ltd." ],
+                "snippet" : [ "... investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ],
+                "format" : [ "journal" ],
                 "issn" : [ "0956-7976" ],
-                "addtitle" : [ "Psychol Sci" ],
                 "jtitle" : [ "Psychological science" ],
                 "genre" : [ "article" ],
-                "au" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
-                "atitle" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
-                "date" : [ "2007-12-01" ],
-                "risdate" : [ "2007" ],
-                "volume" : [ "18" ],
-                "issue" : [ "12" ],
-                "spage" : [ "1063" ],
+                "addtitle" : [ "Psychol Sci" ],
+                "abstract" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ],
                 "epage" : [ "1068" ],
                 "pages" : [ "1063-1068" ],
                 "eissn" : [ "1467-9280" ],
@@ -466,60 +502,24 @@ http_interactions:
                 "cop" : [ "Los Angeles, CA" ],
                 "pub" : [ "Blackwell Publishing" ],
                 "doi" : [ "10.1111/j.1467-9280.2007.02026.x" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
-                "subject" : [ "Marshmallows ; Hands ; Trials ; Animals ; Terraces ; Primates ; Problem solving ; Monkeys ; Research Articles ; Comparative psychology ; Posture ; Behavior, Animal ; Psychomotor Performance ; Female ; Male ; Cognition ; Saguinus ; Hand Strength ; Index Medicus" ],
-                "recordid" : [ "eNqNUdGO1CAUJUbjjqufoOHJaGIrFAqtb5txXDdZo8mMz4Shl7F1CrNAk92_l7GT2de9PACXc0645yCEKSlprs9DSbmQRVs1pKwIkSWpSCXK-2docX54jhakrUUhWyku0KsYB5JLMvESXdCGMMopW6Dhh3d_4QGvAT7h0_nXXrvz5av_gjd_AK9cV6yTToCXfrQ-JLyyFkzCvcudlLwrNv6AN3rUoXcRf1jr3dS7KWIPXX-Y4sfX6IXV-whvTvsl-v1ttVl-L25_Xt8sr24LWhOWCi0601UaWEfBQsutaDouLWw5qeuKV1LzqpXGNKy1jdgCk7zVNaHabCUxtWSX6P2sewj-boKY1NhHA_s8FfgpKtHUnErJM7CcgTu9B9U761PQJq8Oxt54B7bP_SsqqaCiEW0mNDPBBB9jAKsOoc_zPihK1DEYNaij_-rovzoGo_4Ho-4z9d3pU9N2hO6ReEoiA-oZEPUO1OCn4LJJTxF-O_OGmHw463JCBJeEs3_rHaIG" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)", "Psychological science" ],
-                "creationdate" : [ "2007" ],
-                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "BSHEE", "7X8" ],
-                "creatorcontrib" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
-                "issn" : [ "0956-7976", "1467-9280" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Psychol Sci" ],
-                "general" : [ "Blackwell Publishing", "SAGE Publications", "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20071201" ],
-                "enddate" : [ "20071201" ],
-                "description" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Business Source Complete", "SAGE Complete A-Z List (1999-Present)", "Medline Complete", "JSTOR Life Sciences", "Alma/SFX Local Collection", "SAGE Complete A-Z List" ],
-                "creator" : [ "Weiss, Daniel J ; Wark, Jason D ; Rosenbaum, David A" ],
-                "publisher" : [ "Los Angeles, CA: Blackwell Publishing" ],
-                "ispartof" : [ "Psychological science, 2007-12-01, Vol.18 (12), p.1063-1068" ],
-                "identifier" : [ "ISSN: 0956-7976", "EISSN: 1467-9280", "DOI: 10.1111/j.1467-9280.2007.02026.x", "PMID: 18031413" ],
-                "subject" : [ "Marshmallows ; Hands ; Trials ; Animals ; Terraces ; Primates ; Problem solving ; Monkeys ; Research Articles ; Comparative psychology ; Posture ; Behavior, Animal ; Psychomotor Performance ; Female ; Male ; Cognition ; Saguinus ; Hand Strength ; Index Medicus" ],
-                "language" : [ "eng" ],
-                "rights" : [ "Copyright 2007 Association for Psychological Science", "2007 Association for Psychological Science", "COPYRIGHT 2007 Blackwell Publishers Ltd." ],
-                "snippet" : [ "... investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect..." ],
-                "title" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
-                "description" : [ "The way human adults grasp objects is typically influenced by their knowledge of what they'intend to do with the objects. This influence is reflected in the end-state comfort effect: Actors adopt initially uncomfortable postures to accommodate later task demands. Although many experiments have demonstrated this effect, to the best of our knowledge its phylogenetic roots have not been investigated. In two experiments, we tested whether 9 cotton-top tamarin monkeys would show the end-state comfort effect. We did so by presenting the monkeys with a small cup containing a marshmallow. The cup was suspended in different orientations. The monkeys inhibited their natural grasping tendencies and adopted unusual grasping postures to accommodate subsequent task requirements, thus demonstrating the end-state comfort effect. This outcome provides evidence for more sophisticated motor planning than has previously been ascribed to this and related species." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
+                "atitle" : [ "Monkey See, Monkey Plan, Monkey Do: The End-State Comfort Effect in Cotton-Top Tamarins (Saguinus oedipus)" ],
+                "date" : [ "2007-12-01" ],
+                "risdate" : [ "2007" ],
+                "volume" : [ "18" ],
+                "issue" : [ "12" ],
+                "spage" : [ "1063" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2007" ],
                 "creatorcontrib" : [ "Weiss, Daniel J", "Wark, Jason D", "Rosenbaum, David A" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Marshmallows", "Hands", "Trials", "Animals", "Terraces", "Primates", "Problem solving", "Monkeys", "Research Articles", "Comparative psychology", "Posture", "Behavior, Animal", "Psychomotor Performance", "Female", "Male", "Cognition", "Saguinus", "Hand Strength", "Index Medicus" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "Academic OneFile (A&I only)", "MEDLINE - Academic" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1503t-a6dcd2ae3d1efe94f68d47feb40552427a4297cc839f86be3749a501acb70c573" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-1503t-a6dcd2ae3d1efe94f68d47feb40552427a4297cc839f86be3749a501acb70c573" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Psychological science" ]
               }
@@ -539,7 +539,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 16:06:53&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Monkey+See%2C+Monkey+Plan%2C+Monkey+Do%3A+The+End-State+Comfort+Effect+in+Cotton-Top+Tamarins+%28Saguinus+oedipus%29&rft.jtitle=Psychological+science&rft.au=Weiss%2C+Daniel+J&rft.date=2007-12-01&rft.volume=18&rft.issue=12&rft.spage=1063&rft.epage=1068&rft.pages=1063-1068&rft.issn=0956-7976&rft.eissn=1467-9280&rft_id=info:doi/10.1111%2Fj.1467-9280.2007.02026.x&rft.pub=Blackwell+Publishing&rft.place=Los+Angeles%2C+CA&rft_dat=<gale_proqu>68541774</gale_proqu>&svc_dat=viewit&rft_galeid=A171616869"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Monkey+See%2C+Monkey+Plan%2C+Monkey+Do%3A+The+End-State+Comfort+Effect+in+Cotton-Top+Tamarins+%28Saguinus+oedipus%29&rft.jtitle=Psychological+science&rft.au=Weiss%2C+Daniel+J&rft.date=2007-12-01&rft.volume=18&rft.issue=12&rft.spage=1063&rft.epage=1068&rft.pages=1063-1068&rft.issn=0956-7976&rft.eissn=1467-9280&rft_id=info:doi/10.1111%2Fj.1467-9280.2007.02026.x&rft.pub=Blackwell+Publishing&rft.place=Los+Angeles%2C+CA&rft_dat=<gale_proqu>68541774</gale_proqu>&svc_dat=viewit&rft_galeid=A171616869"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -550,41 +550,80 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_68541774"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_68541774"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers" ],
                 "creationdate" : [ "200911" ],
+                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers" ],
                 "author" : [ "Amici, Federica ; Aureli, Filippo ; Visalberghi, Elisabetta ; Call, Josep" ]
               },
               "control" : {
+                "sourceid" : [ "gale_proqu" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_614508006" ],
+                "sourcerecordid" : [ "A213956916" ],
+                "originalsourceid" : [ "FETCH-LOGICAL-1490t-a06afdd905c7d6c4888fccd4efcba78b256a174cd6f6fb4cefd699213cadb3653" ],
+                "recordtype" : [ "article" ],
+                "addsrcrecordid" : [ "eNp90VFrFDEQAOBFFDyr4E8IgtCCWyeb3WTzeD1sK1R8UJ_DbDKpqXubNdlFzl9vylkEEcnDQPhmhpmpqpcczjkI9RYBuAKlH1UbroWuG-jV42oDSnS1AiGfVs9yvgMAyVu1qfDTHBwl9iFO3-iQ2el2oZEyu6XofYqHcMZwcmyH82q_humP29GwZoYzjSOescs4jvEHu8KfxLYpriXlAlMKlPLz6onHMdOL3_Gk-nL57vPuur75ePV-t72peathqREkeuc0dFY5adu-7721riVvB1T90HQSuWqtk176obXkndS64cKiG4TsxEn16lh3TvH7Snkxd3FNU2lpyqgd9GXk_6GGQ1uIhoLOj-gWRzJh8nFJaMtztA82TuRD-d-W3rqTmt9XPT0m2BRzTuTNnMIe08FwMPdXMQ9XKfTNkeKMZs4Hi2kJtmzcrinRtBgb94Y3wrRGyL7w1__mf7lfiHiaVQ" ],
                 "sourcetype" : [ "Aggregation Database" ],
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "pqid" : [ "210400690" ],
                 "galeid" : [ "A213956916" ],
-                "recordid" : [ "cdi_proquest_journals_614508006" ],
-                "sourcerecordid" : [ "A213956916" ],
-                "originalsourceid" : [ "FETCH-LOGICAL-1490t-a06afdd905c7d6c4888fccd4efcba78b256a174cd6f6fb4cefd699213cadb3653" ],
+                "score" : [ "0.016275702" ]
+              },
+              "search" : {
+                "description" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ],
+                "creationdate" : [ "2009" ],
+                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers: Evidence for Perspective Taking?", "Journal of comparative psychology (1983)" ],
+                "sourceid" : [ "7RZ" ],
+                "recordid" : [ "eNp90VFrFDEQAOBFFDyr4E8IgtCCWyeb3WTzeD1sK1R8UJ_DbDKpqXubNdlFzl9vylkEEcnDQPhmhpmpqpcczjkI9RYBuAKlH1UbroWuG-jV42oDSnS1AiGfVs9yvgMAyVu1qfDTHBwl9iFO3-iQ2el2oZEyu6XofYqHcMZwcmyH82q_humP29GwZoYzjSOescs4jvEHu8KfxLYpriXlAlMKlPLz6onHMdOL3_Gk-nL57vPuur75ePV-t72peathqREkeuc0dFY5adu-7721riVvB1T90HQSuWqtk176obXkndS64cKiG4TsxEn16lh3TvH7Snkxd3FNU2lpyqgd9GXk_6GGQ1uIhoLOj-gWRzJh8nFJaMtztA82TuRD-d-W3rqTmt9XPT0m2BRzTuTNnMIe08FwMPdXMQ9XKfTNkeKMZs4Hi2kJtmzcrinRtBgb94Y3wrRGyL7w1__mf7lfiHiaVQ" ],
                 "recordtype" : [ "article" ],
-                "addsrcrecordid" : [ "eNp90VFrFDEQAOBFFDyr4E8IgtCCWyeb3WTzeD1sK1R8UJ_DbDKpqXubNdlFzl9vylkEEcnDQPhmhpmpqpcczjkI9RYBuAKlH1UbroWuG-jV42oDSnS1AiGfVs9yvgMAyVu1qfDTHBwl9iFO3-iQ2el2oZEyu6XofYqHcMZwcmyH82q_humP29GwZoYzjSOescs4jvEHu8KfxLYpriXlAlMKlPLz6onHMdOL3_Gk-nL57vPuur75ePV-t72peathqREkeuc0dFY5adu-7721riVvB1T90HQSuWqtk176obXkndS64cKiG4TsxEn16lh3TvH7Snkxd3FNU2lpyqgd9GXk_6GGQ1uIhoLOj-gWRzJh8nFJaMtztA82TuRD-d-W3rqTmt9XPT0m2BRzTuTNnMIe08FwMPdXMQ9XKfTNkeKMZs4Hi2kJtmzcrinRtBgb94Y3wrRGyL7w1__mf7lfiHiaVQ" ],
-                "sourceid" : [ "gale_proqu" ],
-                "score" : [ "0.016278299" ]
+                "creatorcontrib" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0003-3539-1067", "https://orcid.org/0000-0002-0671-013X", "https://orcid.org/0000-0001-7407-5468" ],
+                "creator" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
+                "contributor" : [ "Burghardt, Gordon M" ],
+                "subject" : [ "Spider monkeys ; Cognition ; Research ; Behavior ; Gaze ; Comparative analysis ; Animal behavior ; Monkeys & apes ; Animal cognition" ],
+                "issn" : [ "0735-7036", "1939-2087" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "American Psychological Association", "American Psychological Association, Inc" ],
+                "startdate" : [ "200911" ],
+                "enddate" : [ "200911" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE", "7RZ" ]
+              },
+              "display" : {
+                "description" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ],
+                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers: Evidence for Perspective Taking?" ],
+                "type" : [ "article" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Amici, Federica ; Aureli, Filippo ; Visalberghi, Elisabetta ; Call, Josep" ],
+                "contributor" : [ "Burghardt, Gordon M" ],
+                "subject" : [ "Spider monkeys ; Cognition ; Research ; Behavior ; Gaze ; Comparative analysis ; Animal behavior ; Monkeys & apes ; Animal cognition" ],
+                "source" : [ "Alma/SFX Local Collection", "PsycARTICLES" ],
+                "publisher" : [ "Washington: American Psychological Association" ],
+                "ispartof" : [ "Journal of comparative psychology (1983), 2009-11, Vol.123 (4), p.368-374" ],
+                "identifier" : [ "ISSN: 0735-7036", "EISSN: 1939-2087", "DOI: 10.1037/a0017079" ],
+                "rights" : [ "2009 American Psychological Association", "COPYRIGHT 2009 American Psychological Association, Inc.", "2009, American Psychological Association" ],
+                "snippet" : [ ".... The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella...", ".... The authors investigated the ability of spider monkeys (Ateles geoffroyi) and capuchin monkeys (Cebus apella...", ".... The authors investigated the ability of spider monkeys ( Ateles geoffroyi) and capuchin monkeys ( Cebus apella..." ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "addata" : {
-                "abstract" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ],
+                "format" : [ "journal" ],
                 "orcidid" : [ "https://orcid.org/0000-0003-3539-1067", "https://orcid.org/0000-0002-0671-013X", "https://orcid.org/0000-0001-7407-5468" ],
                 "issn" : [ "0735-7036" ],
                 "jtitle" : [ "Journal of comparative psychology (1983)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
-                "atitle" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers" ],
-                "date" : [ "2009-11" ],
-                "risdate" : [ "2009" ],
-                "volume" : [ "123" ],
-                "issue" : [ "4" ],
-                "spage" : [ "368" ],
+                "abstract" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ],
                 "epage" : [ "374" ],
                 "pages" : [ "368-374" ],
                 "eissn" : [ "1939-2087" ],
@@ -592,63 +631,24 @@ http_interactions:
                 "cop" : [ "Washington" ],
                 "pub" : [ "American Psychological Association" ],
                 "doi" : [ "10.1037/a0017079" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
-                "contributor" : [ "Burghardt, Gordon M" ],
-                "subject" : [ "Spider monkeys ; Cognition ; Research ; Behavior ; Gaze ; Comparative analysis ; Animal behavior ; Monkeys & apes ; Animal cognition" ],
-                "recordid" : [ "eNp90VFrFDEQAOBFFDyr4E8IgtCCWyeb3WTzeD1sK1R8UJ_DbDKpqXubNdlFzl9vylkEEcnDQPhmhpmpqpcczjkI9RYBuAKlH1UbroWuG-jV42oDSnS1AiGfVs9yvgMAyVu1qfDTHBwl9iFO3-iQ2el2oZEyu6XofYqHcMZwcmyH82q_humP29GwZoYzjSOescs4jvEHu8KfxLYpriXlAlMKlPLz6onHMdOL3_Gk-nL57vPuur75ePV-t72peathqREkeuc0dFY5adu-7721riVvB1T90HQSuWqtk176obXkndS64cKiG4TsxEn16lh3TvH7Snkxd3FNU2lpyqgd9GXk_6GGQ1uIhoLOj-gWRzJh8nFJaMtztA82TuRD-d-W3rqTmt9XPT0m2BRzTuTNnMIe08FwMPdXMQ9XKfTNkeKMZs4Hi2kJtmzcrinRtBgb94Y3wrRGyL7w1__mf7lfiHiaVQ" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers: Evidence for Perspective Taking?", "Journal of comparative psychology (1983)" ],
-                "creationdate" : [ "2009" ],
-                "sourceid" : [ "7RZ" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE", "7RZ" ],
-                "orcidid" : [ "https://orcid.org/0000-0003-3539-1067", "https://orcid.org/0000-0002-0671-013X", "https://orcid.org/0000-0001-7407-5468" ],
-                "creatorcontrib" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
-                "issn" : [ "0735-7036", "1939-2087" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "American Psychological Association", "American Psychological Association, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "200911" ],
-                "enddate" : [ "200911" ],
-                "description" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "Alma/SFX Local Collection", "PsycARTICLES" ],
-                "creator" : [ "Amici, Federica ; Aureli, Filippo ; Visalberghi, Elisabetta ; Call, Josep" ],
-                "contributor" : [ "Burghardt, Gordon M" ],
-                "publisher" : [ "Washington: American Psychological Association" ],
-                "ispartof" : [ "Journal of comparative psychology (1983), 2009-11, Vol.123 (4), p.368-374" ],
-                "identifier" : [ "ISSN: 0735-7036", "EISSN: 1939-2087", "DOI: 10.1037/a0017079" ],
-                "subject" : [ "Spider monkeys ; Cognition ; Research ; Behavior ; Gaze ; Comparative analysis ; Animal behavior ; Monkeys & apes ; Animal cognition" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2009 American Psychological Association", "COPYRIGHT 2009 American Psychological Association, Inc.", "2009, American Psychological Association" ],
-                "snippet" : [ ".... The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella...", ".... The authors investigated the ability of spider monkeys (Ateles geoffroyi) and capuchin monkeys (Cebus apella...", ".... The authors investigated the ability of spider monkeys ( Ateles geoffroyi) and capuchin monkeys ( Cebus apella..." ],
-                "title" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers: Evidence for Perspective Taking?" ],
-                "description" : [ "Gaze following is an adaptive skill that might have been selected in social species, such as many nonhuman primates, to obtain information about food location, predators, and social interactions. The authors investigated the ability of spider monkeys (\nAteles geoffroyi\n) and capuchin monkeys (\nCebus apella\n) to follow the gaze of a human around barriers and the presence of \"looking back\" behavior. In the 1st experiment, a human looked to a target location inside the testing room, whereas in the 2nd experiment, the human looked behind an opaque barrier placed outside the testing room. The authors compared the frequency of looking at the target location with the corresponding baseline looking frequencies. Both species (a) showed evidence of spontaneous gaze following in the 1st experiment and (b) engaged in gaze following behind the barrier in the 2nd experiment. In contrast, neither species performed \"looking back\" responses. The authors conclude that both monkey species showed some indication of perspective-taking abilities, although the absence of \"looking back\" behavior suggests a potential difference from the abilities shown by the great apes." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
+                "atitle" : [ "Spider Monkeys (Ateles geoffroyi) and Capuchin Monkeys (Cebus apella) Follow Gaze Around Barriers" ],
+                "date" : [ "2009-11" ],
+                "risdate" : [ "2009" ],
+                "volume" : [ "123" ],
+                "issue" : [ "4" ],
+                "spage" : [ "368" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2009" ],
                 "creatorcontrib" : [ "Amici, Federica", "Aureli, Filippo", "Visalberghi, Elisabetta", "Call, Josep" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Spider monkeys", "Cognition", "Research", "Behavior", "Gaze", "Comparative analysis", "Animal behavior", "Monkeys & apes", "Animal cognition" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
+                "language" : [ "eng" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)", "PsycARTICLES" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1490t-a06afdd905c7d6c4888fccd4efcba78b256a174cd6f6fb4cefd699213cadb3653" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-1490t-a06afdd905c7d6c4888fccd4efcba78b256a174cd6f6fb4cefd699213cadb3653" ],
                 "frbrtype" : [ "5" ],
                 "jtitle" : [ "Journal of comparative psychology (1983)" ]
               }
@@ -668,7 +668,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 16:06:53&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+Monkeys+%28Ateles+geoffroyi%29+and+Capuchin+Monkeys+%28Cebus+apella%29+Follow+Gaze+Around+Barriers&rft.jtitle=Journal+of+comparative+psychology+%281983%29&rft.au=Amici%2C+Federica&rft.date=2009-11&rft.volume=123&rft.issue=4&rft.spage=368&rft.epage=374&rft.pages=368-374&rft.issn=0735-7036&rft.eissn=1939-2087&rft_id=info:doi/10.1037%2Fa0017079&rft.pub=American+Psychological+Association&rft.place=Washington&rft_dat=<gale_proqu>210400690</gale_proqu>&svc_dat=viewit&rft_galeid=A213956916"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:29:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+Monkeys+%28Ateles+geoffroyi%29+and+Capuchin+Monkeys+%28Cebus+apella%29+Follow+Gaze+Around+Barriers&rft.jtitle=Journal+of+comparative+psychology+%281983%29&rft.au=Amici%2C+Federica&rft.date=2009-11&rft.volume=123&rft.issue=4&rft.spage=368&rft.epage=374&rft.pages=368-374&rft.issn=0735-7036&rft.eissn=1939-2087&rft_id=info:doi/10.1037%2Fa0017079&rft.pub=American+Psychological+Association&rft.place=Washington&rft_dat=<gale_proqu>210400690</gale_proqu>&svc_dat=viewit&rft_galeid=A213956916"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -679,17 +679,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_journals_614508006"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_614508006"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "709",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "39",
-            "PC_SEARCH_TIME_TOTAL" : "748",
+            "PC_SEARCH_CALL_TIME" : "845",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "47",
+            "PC_SEARCH_TIME_TOTAL" : "892",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 749,
-            "COMBINED_SEARCH_TIME" : 755,
+            "BUILD_COMBINED_RESULTS_MAP" : 894,
+            "COMBINED_SEARCH_TIME" : 900,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ {
             "name" : "jtitle",
@@ -698,22 +698,22 @@ http_interactions:
               "count" : "12488"
             }, {
               "value" : "The New York Times",
-              "count" : "11857"
+              "count" : "11860"
             }, {
               "value" : "Plos One",
-              "count" : "11771"
+              "count" : "11777"
             }, {
               "value" : "The Washington Post",
-              "count" : "11596"
+              "count" : "11601"
             }, {
               "value" : "The Los Angeles Times",
-              "count" : "10246"
+              "count" : "10248"
             }, {
               "value" : "Journal Of Comparative Neurology",
               "count" : "9270"
             }, {
               "value" : "Chicago Tribune",
-              "count" : "8862"
+              "count" : "8863"
             }, {
               "value" : "Variety",
               "count" : "8547"
@@ -728,10 +728,10 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "743708"
+              "count" : "743899"
             }, {
               "value" : "jpn",
-              "count" : "16069"
+              "count" : "16079"
             }, {
               "value" : "chi",
               "count" : "2008"
@@ -743,10 +743,10 @@ http_interactions:
               "count" : "838"
             }, {
               "value" : "fre",
-              "count" : "770"
+              "count" : "769"
             }, {
               "value" : "ger",
-              "count" : "704"
+              "count" : "702"
             }, {
               "value" : "rus",
               "count" : "346"
@@ -761,19 +761,19 @@ http_interactions:
               "count" : "100"
             }, {
               "value" : "dut",
-              "count" : "62"
+              "count" : "63"
             }, {
               "value" : "afr",
               "count" : "56"
             }, {
               "value" : "swe",
-              "count" : "50"
+              "count" : "51"
             }, {
               "value" : "kor",
               "count" : "48"
             }, {
               "value" : "ita",
-              "count" : "43"
+              "count" : "44"
             }, {
               "value" : "cze",
               "count" : "32"
@@ -791,91 +791,91 @@ http_interactions:
             "name" : "topic",
             "values" : [ {
               "value" : "Science & Technology",
-              "count" : "254914"
+              "count" : "254990"
             }, {
               "value" : "Life Sciences & Biomedicine",
-              "count" : "224081"
+              "count" : "224148"
             }, {
               "value" : "Animals",
-              "count" : "196447"
+              "count" : "196469"
             }, {
               "value" : "Humans",
-              "count" : "148045"
+              "count" : "148033"
             }, {
               "value" : "Male",
-              "count" : "105162"
+              "count" : "105155"
             }, {
               "value" : "Female",
-              "count" : "88288"
+              "count" : "88281"
             }, {
               "value" : "Neurosciences",
-              "count" : "84950"
+              "count" : "84979"
             }, {
               "value" : "Biological And Medical Sciences",
-              "count" : "82128"
+              "count" : "82141"
             }, {
               "value" : "Neurosciences & Neurology",
-              "count" : "80614"
+              "count" : "80636"
             }, {
               "value" : "Research",
-              "count" : "51979"
+              "count" : "51988"
             }, {
               "value" : "Fundamental And Applied Biological Sciences. Psychology",
-              "count" : "48006"
+              "count" : "48010"
             }, {
               "value" : "Medical Sciences",
-              "count" : "38931"
+              "count" : "38940"
             }, {
               "value" : "Adult",
-              "count" : "38600"
+              "count" : "38601"
             }, {
               "value" : "Rats",
-              "count" : "34983"
+              "count" : "34980"
             }, {
               "value" : "Analysis",
-              "count" : "34387"
+              "count" : "34393"
             }, {
               "value" : "Mice",
-              "count" : "29981"
+              "count" : "29977"
             }, {
               "value" : "Social Sciences",
-              "count" : "29369"
+              "count" : "29428"
             }, {
               "value" : "Science & Technology - Other Topics",
-              "count" : "25710"
+              "count" : "25717"
             }, {
               "value" : "Research Article",
-              "count" : "25170"
+              "count" : "25183"
             }, {
               "value" : "Multidisciplinary Sciences",
-              "count" : "24958"
+              "count" : "24967"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "articles",
-              "count" : "565620"
+              "count" : "565786"
             }, {
               "value" : "newspaper_articles",
-              "count" : "104273"
+              "count" : "104291"
             }, {
               "value" : "reviews",
-              "count" : "27058"
+              "count" : "27068"
             }, {
               "value" : "journals",
-              "count" : "23039"
+              "count" : "23038"
             }, {
               "value" : "book_chapters",
-              "count" : "22789"
+              "count" : "22817"
             }, {
               "value" : "reference_entrys",
-              "count" : "6291"
+              "count" : "6292"
             }, {
               "value" : "conference_proceedings",
-              "count" : "2395"
+              "count" : "2397"
             }, {
               "value" : "books",
-              "count" : "1626"
+              "count" : "1628"
             }, {
               "value" : "web_resources",
               "count" : "743"
@@ -884,7 +884,7 @@ http_interactions:
               "count" : "631"
             }, {
               "value" : "text_resources",
-              "count" : "251"
+              "count" : "226"
             }, {
               "value" : "datasets",
               "count" : "11"
@@ -902,88 +902,88 @@ http_interactions:
             "name" : "domain",
             "values" : [ {
               "value" : "ProQuest Historical Newspapers",
-              "count" : "754746"
+              "count" : "754947"
             }, {
               "value" : "Academic Search Complete",
-              "count" : "192377"
+              "count" : "192906"
             }, {
               "value" : "Medline Complete",
-              "count" : "164520"
+              "count" : "164562"
             }, {
               "value" : "Single Journals",
-              "count" : "164118"
+              "count" : "163661"
             }, {
               "value" : "Factiva",
-              "count" : "163185"
+              "count" : "163218"
             }, {
               "value" : "PubMed Central",
-              "count" : "113300"
+              "count" : "113386"
             }, {
               "value" : "Nexis Uni",
-              "count" : "113223"
+              "count" : "113255"
             }, {
               "value" : "Global Newsstream",
-              "count" : "104096"
+              "count" : "104117"
             }, {
               "value" : "Wiley Online Library All Journals",
-              "count" : "94310"
+              "count" : "94334"
             }, {
               "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
-              "count" : "87721"
+              "count" : "88105"
             }, {
               "value" : "Wiley Online Library Full Collection 2016",
-              "count" : "81134"
+              "count" : "81152"
             }, {
               "value" : "Wiley Online Library Journals + OA Offset 2015-2017",
-              "count" : "80931"
+              "count" : "80950"
             }, {
               "value" : "PressReader",
-              "count" : "80129"
+              "count" : "80138"
             }, {
               "value" : "ABI/INFORM Collection",
-              "count" : "73353"
+              "count" : "73366"
             }, {
               "value" : "Wiley Online Library All Backfiles",
-              "count" : "69515"
+              "count" : "69116"
             }, {
               "value" : "Publicly Available Content Database",
-              "count" : "63675"
+              "count" : "63732"
             }, {
               "value" : "SpringerLink Contemporary (1997 - Present)",
-              "count" : "63516"
+              "count" : "63530"
             }, {
               "value" : "ScienceDirect Journals (Transactional Access)",
-              "count" : "57350"
+              "count" : "57353"
             }, {
               "value" : "ScienceDirect Journals (5 years ago - present)",
-              "count" : "54663"
+              "count" : "54665"
             }, {
               "value" : "Business Source Complete",
-              "count" : "51261"
+              "count" : "51271"
             } ]
           }, {
             "name" : "tlevel",
             "values" : [ {
               "value" : "open_access",
-              "count" : "184631"
+              "count" : "184766"
             }, {
               "value" : "peer_reviewed",
-              "count" : "367104"
+              "count" : "367560"
             }, {
               "value" : "online_resources",
-              "count" : "754746"
+              "count" : "754947"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "07 days back",
-              "count" : "113"
+              "count" : "105"
             }, {
               "value" : "30 days back",
-              "count" : "1413"
+              "count" : "1514"
             }, {
               "value" : "90 days back",
-              "count" : "12629"
+              "count" : "12586"
             } ]
           }, {
             "name" : "creationdate",
@@ -995,22 +995,22 @@ http_interactions:
               "count" : "346"
             }, {
               "value" : "1900",
-              "count" : "6289"
+              "count" : "6288"
             }, {
               "value" : "1910",
               "count" : "2049"
             }, {
               "value" : "1920",
-              "count" : "2048"
+              "count" : "2049"
             }, {
               "value" : "1930",
               "count" : "3217"
             }, {
               "value" : "1940",
-              "count" : "4066"
+              "count" : "4065"
             }, {
               "value" : "1950",
-              "count" : "3348"
+              "count" : "3347"
             }, {
               "value" : "1951",
               "count" : "403"
@@ -1022,28 +1022,28 @@ http_interactions:
               "count" : "511"
             }, {
               "value" : "1954",
-              "count" : "471"
+              "count" : "470"
             }, {
               "value" : "1955",
-              "count" : "598"
+              "count" : "597"
             }, {
               "value" : "1956",
-              "count" : "605"
+              "count" : "606"
             }, {
               "value" : "1957",
               "count" : "691"
             }, {
               "value" : "1958",
-              "count" : "712"
+              "count" : "713"
             }, {
               "value" : "1959",
               "count" : "832"
             }, {
               "value" : "1960",
-              "count" : "860"
+              "count" : "861"
             }, {
               "value" : "1961",
-              "count" : "887"
+              "count" : "885"
             }, {
               "value" : "1962",
               "count" : "952"
@@ -1052,180 +1052,180 @@ http_interactions:
               "count" : "1164"
             }, {
               "value" : "1964",
-              "count" : "1210"
+              "count" : "1211"
             }, {
               "value" : "1965",
-              "count" : "1376"
+              "count" : "1377"
             }, {
               "value" : "1966",
               "count" : "1382"
             }, {
               "value" : "1967",
-              "count" : "1447"
+              "count" : "1445"
             }, {
               "value" : "1968",
               "count" : "1739"
             }, {
               "value" : "1969",
-              "count" : "3030"
+              "count" : "3028"
             }, {
               "value" : "1970",
-              "count" : "1846"
+              "count" : "1844"
             }, {
               "value" : "1971",
-              "count" : "2024"
+              "count" : "2026"
             }, {
               "value" : "1972",
-              "count" : "2061"
+              "count" : "2065"
             }, {
               "value" : "1973",
-              "count" : "2352"
+              "count" : "2351"
             }, {
               "value" : "1974",
               "count" : "2289"
             }, {
               "value" : "1975",
-              "count" : "2471"
+              "count" : "2472"
             }, {
               "value" : "1976",
-              "count" : "2541"
+              "count" : "2543"
             }, {
               "value" : "1977",
-              "count" : "2951"
+              "count" : "2955"
             }, {
               "value" : "1978",
-              "count" : "2905"
+              "count" : "2906"
             }, {
               "value" : "1979",
-              "count" : "2920"
+              "count" : "2919"
             }, {
               "value" : "1980",
-              "count" : "3236"
+              "count" : "3232"
             }, {
               "value" : "1981",
               "count" : "3637"
             }, {
               "value" : "1982",
-              "count" : "3568"
+              "count" : "3570"
             }, {
               "value" : "1983",
-              "count" : "3784"
+              "count" : "3783"
             }, {
               "value" : "1984",
-              "count" : "4169"
+              "count" : "4168"
             }, {
               "value" : "1985",
-              "count" : "5021"
+              "count" : "5019"
             }, {
               "value" : "1986",
               "count" : "5134"
             }, {
               "value" : "1987",
-              "count" : "5815"
+              "count" : "5817"
             }, {
               "value" : "1988",
-              "count" : "6263"
+              "count" : "6267"
             }, {
               "value" : "1989",
-              "count" : "6471"
+              "count" : "6470"
             }, {
               "value" : "1990",
-              "count" : "6918"
+              "count" : "6921"
             }, {
               "value" : "1991",
-              "count" : "7700"
+              "count" : "7698"
             }, {
               "value" : "1992",
-              "count" : "8580"
+              "count" : "8585"
             }, {
               "value" : "1993",
-              "count" : "8586"
+              "count" : "8589"
             }, {
               "value" : "1994",
-              "count" : "8976"
+              "count" : "8980"
             }, {
               "value" : "1995",
               "count" : "9175"
             }, {
               "value" : "1996",
-              "count" : "11374"
+              "count" : "11372"
             }, {
               "value" : "1997",
-              "count" : "13620"
+              "count" : "13619"
             }, {
               "value" : "1998",
-              "count" : "15355"
+              "count" : "15359"
             }, {
               "value" : "1999",
-              "count" : "16508"
+              "count" : "16501"
             }, {
               "value" : "2000",
-              "count" : "18252"
+              "count" : "18255"
             }, {
               "value" : "2001",
               "count" : "19006"
             }, {
               "value" : "2002",
-              "count" : "19507"
+              "count" : "19505"
             }, {
               "value" : "2003",
-              "count" : "21519"
+              "count" : "21522"
             }, {
               "value" : "2004",
-              "count" : "23967"
+              "count" : "23963"
             }, {
               "value" : "2005",
-              "count" : "25808"
+              "count" : "25813"
             }, {
               "value" : "2006",
-              "count" : "27507"
+              "count" : "27499"
             }, {
               "value" : "2007",
-              "count" : "27640"
+              "count" : "27637"
             }, {
               "value" : "2008",
               "count" : "27440"
             }, {
               "value" : "2009",
-              "count" : "26384"
+              "count" : "26382"
             }, {
               "value" : "2010",
-              "count" : "27020"
+              "count" : "27023"
             }, {
               "value" : "2011",
-              "count" : "28921"
+              "count" : "28913"
             }, {
               "value" : "2012",
-              "count" : "31285"
+              "count" : "31289"
             }, {
               "value" : "2013",
-              "count" : "32189"
+              "count" : "32192"
             }, {
               "value" : "2014",
-              "count" : "33523"
+              "count" : "33528"
             }, {
               "value" : "2015",
-              "count" : "31004"
+              "count" : "31012"
             }, {
               "value" : "2016",
-              "count" : "30589"
+              "count" : "30593"
             }, {
               "value" : "2017",
-              "count" : "29332"
+              "count" : "29340"
             }, {
               "value" : "2018",
               "count" : "26561"
             }, {
               "value" : "2019",
-              "count" : "23528"
+              "count" : "23529"
             }, {
               "value" : "2020",
-              "count" : "20334"
+              "count" : "20349"
             }, {
               "value" : "2021",
-              "count" : "6956"
+              "count" : "7130"
             } ]
           } ]
         }
-  recorded_at: Mon, 17 May 2021 20:06:53 GMT
+  recorded_at: Wed, 19 May 2021 14:29:39 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/no_results_primo.yml
+++ b/test/vcr_cassettes/no_results_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcornandorangejuice&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcornandorangejuice&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -23,7 +23,7 @@ http_interactions:
       P3p:
       - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
       X-Exl-Api-Remaining:
-      - '549997'
+      - '549958'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -35,7 +35,7 @@ http_interactions:
       Content-Length:
       - '521'
       Date:
-      - Mon, 17 May 2021 15:06:03 GMT
+      - Wed, 19 May 2021 15:44:29 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -52,16 +52,16 @@ http_interactions:
           "highlights" : { },
           "docs" : [ ],
           "timelog" : {
-            "CALL_SOLR_GET_IDS_LIST" : "887",
+            "CALL_SOLR_GET_IDS_LIST" : "623",
             "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "0",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "892",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "635",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 894,
-            "COMBINED_SEARCH_TIME" : 897,
+            "BUILD_COMBINED_RESULTS_MAP" : 637,
+            "COMBINED_SEARCH_TIME" : 639,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 1
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:03 GMT
+  recorded_at: Wed, 19 May 2021 15:44:29 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/physical_book_primo.yml
+++ b/test/vcr_cassettes/physical_book_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,Ch%CA%BBoms%C5%ADk%CA%BBi%20kk%C5%ADt%20%C5%8Fmn%C5%ADn%20toj%C5%8Fn&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549994'
+      - '549969'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -35,9 +35,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Content-Length:
-      - '7953'
+      - '8055'
       Date:
-      - Mon, 17 May 2021 15:06:26 GMT
+      - Wed, 19 May 2021 14:29:29 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -69,6 +69,8 @@ http_interactions:
                 "format" : [ "363 p. : ill. ; 23 cm." ],
                 "identifier" : [ "$$CISBN$$V8976820444;$$COCLC$$V(OCoLC)61400624" ],
                 "creationdate" : [ "1998" ],
+                "lds07" : [ "61400624 8976820444" ],
+                "lds09" : [ "Sŏul-si : Gŭrinbi,    1998   ko" ],
                 "lds04" : [ "Off Campus Collection copy from Noam Chomsky collection, with inscription." ],
                 "creator" : [ "Barsky, Robert F.$$QBarsky, Robert F." ],
                 "publisher" : [ "Sŏul-si : Gŭrinbi", "서울시 : 그린비" ],
@@ -90,7 +92,7 @@ http_interactions:
                 "originalsourceid" : [ "001349272-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "0.020869972" ]
+                "score" : [ "0.021057345" ]
               },
               "addata" : {
                 "aulast" : [ "Barsky" ],
@@ -232,24 +234,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "280",
-            "CALL_SOLR_GET_IDS_LIST" : "2693",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "396",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "147",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "39",
-            "RETRIVE_FROM_DB_RECORDS" : "74",
-            "RETRIVE_FROM_DB_RELATIONS" : "17",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "197",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "199",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "125",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "3511",
-            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 0,
-            "COMBINED_SEARCH_TIME" : 3,
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "12",
+            "CALL_SOLR_GET_IDS_LIST" : "3745",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "510",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "1",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "6",
+            "RETRIVE_FROM_DB_RELATIONS" : "1",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "483",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "27",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "40",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "4320",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 1,
+            "BUILD_COMBINED_RESULTS_MAP" : 4382,
+            "COMBINED_SEARCH_TIME" : 4386,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:26 GMT
+  recorded_at: Wed, 19 May 2021 14:29:30 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo.yml
+++ b/test/vcr_cassettes/popcorn_primo.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcorn&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549996'
+      - '549963'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:06 GMT
+      - Wed, 19 May 2021 14:51:10 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -86,7 +86,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "2.950539E-4" ]
+                "score" : [ "2.957334E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -229,42 +229,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721306761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724606761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721306761" ],
+                "mms" : [ "9933019724606761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019721306761" ],
-                "recordid" : [ "alma9933019721306761" ],
+                "sourcerecordid" : [ "9933019724606761" ],
+                "recordid" : [ "alma9933019724606761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573078" ],
+                "originalsourceid" : [ "991000000000573049" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573078" ],
+                "oclcid" : [ "(ckb)1000000000573049" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Thailand" ]
+                "jtitle" : [ "Popcorn Industry Profile: Australia" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9003628398970808267" ]
+                "frbrgroupid" : [ "9059165500462499698" ]
               }
             },
             "delivery" : {
@@ -310,42 +310,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723406761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724306761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723406761" ],
+                "mms" : [ "9933019724306761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019723406761" ],
-                "recordid" : [ "alma9933019723406761" ],
+                "sourcerecordid" : [ "9933019724306761" ],
+                "recordid" : [ "alma9933019724306761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573061" ],
+                "originalsourceid" : [ "991000000000573052" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573061" ],
+                "oclcid" : [ "(ckb)1000000000573052" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Greece" ]
+                "jtitle" : [ "Popcorn Industry Profile: Brazil" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9037562016405007885" ]
+                "frbrgroupid" : [ "9083335249684128851" ]
               }
             },
             "delivery" : {
@@ -391,42 +391,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722106761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724806761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722106761" ],
+                "mms" : [ "9933019724806761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019722106761" ],
-                "recordid" : [ "alma9933019722106761" ],
+                "sourcerecordid" : [ "9933019724806761" ],
+                "recordid" : [ "alma9933019724806761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573073" ],
+                "originalsourceid" : [ "991000000000573047" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573073" ],
+                "oclcid" : [ "(ckb)1000000000573047" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: South Korea" ]
+                "jtitle" : [ "Popcorn Industry Profile: Argentina" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9004595849084473098" ]
+                "frbrgroupid" : [ "9001959784471604878" ]
               }
             },
             "delivery" : {
@@ -472,42 +472,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724206761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724506761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724206761" ],
+                "mms" : [ "9933019724506761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019724206761" ],
-                "recordid" : [ "alma9933019724206761" ],
+                "sourcerecordid" : [ "9933019724506761" ],
+                "recordid" : [ "alma9933019724506761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573053" ],
+                "originalsourceid" : [ "991000000000573050" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.586844E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573053" ],
+                "oclcid" : [ "(ckb)1000000000573050" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Chile" ]
+                "jtitle" : [ "Popcorn Industry Profile: Austria" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9007649350935717203" ]
+                "frbrgroupid" : [ "9060146011692305880" ]
               }
             },
             "delivery" : {
@@ -552,24 +552,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "513",
-            "CALL_SOLR_GET_IDS_LIST" : "1051",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "977",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "169",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "84",
-            "RETRIVE_FROM_DB_RECORDS" : "232",
-            "RETRIVE_FROM_DB_RELATIONS" : "24",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "499",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "478",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "334",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "2890",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "24",
+            "CALL_SOLR_GET_IDS_LIST" : "239",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "532",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "2",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "3",
+            "RETRIVE_FROM_DB_RECORDS" : "14",
+            "RETRIVE_FROM_DB_RELATIONS" : "2",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "469",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "63",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "167",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "975",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 2912,
-            "COMBINED_SEARCH_TIME" : 2916,
+            "BUILD_COMBINED_RESULTS_MAP" : 1007,
+            "COMBINED_SEARCH_TIME" : 1017,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 7
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:07 GMT
+  recorded_at: Wed, 19 May 2021 14:51:10 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo_articles.yml
+++ b/test/vcr_cassettes/popcorn_primo_articles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcorn&scope=FAKE_PRIMO_ARTICLE_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549996'
+      - '549965'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:14 GMT
+      - Wed, 19 May 2021 14:51:06 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -46,8 +46,8 @@ http_interactions:
         {
           "info" : {
             "totalResultsLocal" : -1,
-            "totalResultsPC" : 132266,
-            "total" : 132266,
+            "totalResultsPC" : 132284,
+            "total" : 132284,
             "first" : 1,
             "last" : 5
           },
@@ -63,7 +63,7 @@ http_interactions:
                 "title" : [ "Popcorn" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1088_2058_7058_29_11_46" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1088_2058_7058_29_11_46" ],
                 "sourcerecordid" : [ "10_1088_2058_7058_29_11_46" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "recordtype" : [ "article" ],
@@ -72,24 +72,7 @@ http_interactions:
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "crossref" ],
-                "score" : [ "0.021811698" ]
-              },
-              "addata" : {
-                "issn" : [ "0953-8585" ],
-                "jtitle" : [ "Physics world" ],
-                "genre" : [ "article" ],
-                "atitle" : [ "Popcorn" ],
-                "date" : [ "2016-11" ],
-                "risdate" : [ "2016" ],
-                "volume" : [ "29" ],
-                "issue" : [ "11" ],
-                "spage" : [ "42" ],
-                "epage" : [ "42" ],
-                "pages" : [ "42-42" ],
-                "eissn" : [ "2058-7058" ],
-                "ristype" : [ "JOUR" ],
-                "doi" : [ "10.1088/2058-7058/29/11/46" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.021807468" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -101,36 +84,53 @@ http_interactions:
                 "title" : [ "Popcorn", "Physics world" ],
                 "recordid" : [ "eNo9j81KBDEQhBtR1nHdF_Ad4nQn6U7nKIt_sKAHPYchkwFl11kSL769DoqXKqjDx1cAV4TXhKq9RVYTfqK3sSfqvZxA9z-eQoeRnVFWPoeL1t4RSbxyB6vn-Zjn-nEJZ9Owb2Xz12t4vbt92T6Y3dP94_ZmZzJZ_TSlsIvis1cfWGVS8RKDCzigyOjzmG3h6GWiUDIGDa44EiQXtBCN7NZgf7m5zq3VMqVjfTsM9SsRpuVKWqzTYp1sTETJi_sGjyA4gg" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION" ],
+                "rsrctype" : [ "article" ],
                 "issn" : [ "0953-8585", "2058-7058" ],
                 "fulltext" : [ "true" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "201611" ],
-                "enddate" : [ "201611" ]
+                "enddate" : [ "201611" ],
+                "scope" : [ "AAYXX", "CITATION" ]
               },
               "display" : {
                 "title" : [ "Popcorn" ],
-                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
-                "type" : [ "article" ],
-                "source" : [ "Alma/SFX Local Collection" ],
-                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
                 "language" : [ "eng" ],
+                "source" : [ "Alma/SFX Local Collection" ],
+                "ispartof" : [ "Physics world, 2016-11, Vol.29 (11), p.42-42" ],
+                "identifier" : [ "ISSN: 0953-8585", "EISSN: 2058-7058", "DOI: 10.1088/2058-7058/29/11/46" ],
+                "type" : [ "article" ],
                 "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "jtitle" : [ "Physics world" ],
+                "genre" : [ "article" ],
+                "issn" : [ "0953-8585" ],
+                "spage" : [ "42" ],
+                "epage" : [ "42" ],
+                "pages" : [ "42-42" ],
+                "eissn" : [ "2058-7058" ],
+                "ristype" : [ "JOUR" ],
+                "doi" : [ "10.1088/2058-7058/29/11/46" ],
+                "atitle" : [ "Popcorn" ],
+                "date" : [ "2016-11" ],
+                "risdate" : [ "2016" ],
+                "volume" : [ "29" ],
+                "issue" : [ "11" ]
+              },
               "facets" : {
                 "creationdate" : [ "2016" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c128t-ee53964c4847586f864697370a066d4cdc2e5946f17ec07873e31601378e11d53" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Physics world" ]
+                "jtitle" : [ "Physics world" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -148,7 +148,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -159,16 +159,16 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1088_2058_7058_29_11_46"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1088_2058_7058_29_11_46"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
                 "creationdate" : [ "201211" ],
-                "title" : [ "Baryonic popcorn" ],
-                "author" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ]
+                "title" : [ "Baryonic popcorn" ]
               },
               "control" : {
-                "recordid" : [ "cdi_crossref_primary_10_1007_JHEP11_2012_047" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1007_JHEP11_2012_047" ],
                 "sourcerecordid" : [ "2398248625" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "recordtype" : [ "article" ],
@@ -178,21 +178,58 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2398248625" ],
-                "score" : [ "0.020141866" ]
+                "score" : [ "0.020139625" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "creationdate" : [ "2012" ],
+                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
+                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
+                "recordtype" : [ "article" ],
+                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
+                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "issn" : [ "1029-8479", "1029-8479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "J. High Energ. Phys" ],
+                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
+                "startdate" : [ "201211" ],
+                "enddate" : [ "201211" ],
+                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ]
+              },
+              "display" : {
+                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
+                "title" : [ "Baryonic popcorn" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
+                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
+                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
+                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
+                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
+                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
+                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
-                "issn" : [ "1029-8479" ],
-                "oa" : [ "free_for_read" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "The journal of high energy physics" ],
                 "genre" : [ "article" ],
-                "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "atitle" : [ "Baryonic popcorn" ],
-                "stitle" : [ "J. High Energ. Phys" ],
-                "date" : [ "2012-11" ],
-                "risdate" : [ "2012" ],
-                "volume" : [ "2012" ],
-                "issue" : [ "11" ],
+                "issn" : [ "1029-8479" ],
+                "abstract" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ],
                 "spage" : [ "1" ],
                 "epage" : [ "85" ],
                 "pages" : [ "1-85" ],
@@ -201,64 +238,27 @@ http_interactions:
                 "cop" : [ "Berlin/Heidelberg" ],
                 "pub" : [ "Springer-Verlag" ],
                 "doi" : [ "10.1007/JHEP11(2012)047" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2012" ],
-                "title" : [ "Baryonic popcorn", "The journal of high energy physics" ],
-                "creator" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "recordid" : [ "eNpNj01LAzEQhoMoWKvgzavgRQ9rZ_KxSY5aqlUKetBzyG4SadHNmrQH_72pW9TTvAzPfDyEnCFcI4CcPM5nz4iXFJBeAZd7ZIRAdaW41Pv_8iE5ynkFgAI1jMjprU1fsVu2533s25i6Y3IQ7Hv2J7s6Jq93s5fpvFo83T9MbxYVcs7XlazBQcOFU1hbcCo0teROtN4p67h0FkKjqFISlSj9EJyvIQhpNWtt4zQbk4thb5_i58bntVnFTerKSUOZVpSrmopCTQaqTTHn5IPp0_KjvGwQzFbbDNpmq22K9t9ELmT35tPvxA-CDBnsIhoBEtk3fBNW7g" ],
-                "recordtype" : [ "article" ],
-                "sourceid" : [ "ARAPS", "P62", "PIMPY" ],
-                "scope" : [ "AAYXX", "CITATION", "8FE", "8FG", "ABUWG", "ARAPS", "AZQEC", "BENPR", "BGLVJ", "DWQXO", "HCIFZ", "P5Z", "P62", "PIMPY", "PQEST", "PQQKQ", "PQUKI" ],
-                "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "issn" : [ "1029-8479", "1029-8479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "J. High Energ. Phys" ],
-                "general" : [ "Springer-Verlag", "Springer Nature B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201211" ],
-                "enddate" : [ "201211" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
-              },
-              "display" : {
-                "title" : [ "Baryonic popcorn" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer-Verlag" ],
-                "ispartof" : [ "The journal of high energy physics, 2012-11, Vol.2012 (11), p.1-85" ],
-                "type" : [ "article" ],
-                "source" : [ "Publicly Available Content Database", "ProQuest Advanced Technologies & Aerospace Collection", "Advanced Technologies & Aerospace Collection", "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Kaplunovsky, Vadim ; Melnikov, Dmitry ; Sonnenschein, Jacob" ],
-                "identifier" : [ "ISSN: 1029-8479", "EISSN: 1029-8479", "DOI: 10.1007/JHEP11(2012)047" ],
-                "subject" : [ "Solitons Monopoles and Instantons ; AdS-CFT Correspondence ; Quantum Physics ; Quantum Field Theories, String Theory ; Classical and Quantum Gravitation, Relativity Theory ; Physics ; Phase Diagram of QCD ; Elementary Particles, Quantum Field Theory ; Flavor (particle physics) ; Lattices ; Chains ; Phase transitions ; Density ; Instantons ; Baryons ; Multilayers ; Gauge theory ; Ferromagnetism ; Configurations ; Nuclear matter ; Crystal structure ; Branes ; Solid phases" ],
-                "language" : [ "eng" ],
-                "rights" : [ "SISSA, Trieste, Italy 2012", "SISSA, Trieste, Italy 2012." ],
-                "snippet" : [ ".... We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "In the large N\nc\nlimit cold dense nuclear matter must be in a lattice phase. This applies also to holographic models of hadron physics. In a class of such models, like the generalized Sakai-Sugimoto model, baryons take the form of instantons of the effective flavor gauge theory that resides on probe flavor branes. In this paper we study the phase structure of baryonic crystals by analyzing discrete periodic configurations of such instantons. We find that instanton configurations exhibit a series of “popcorn” transitions upon increasing the density. Through these transitions normal (3D) lattices expand into the transverse dimension, eventually becoming a higher dimensional (4D) multi-layer lattice at large densities.We consider 3D lattices of zero size instantons as well as 1D periodic chains of finite size instantons, which serve as toy models of the full holographic systems. In particular, for the finite-size case we determine solutions of the corresponding ADHM equations for both a straight chain and for a 2D zigzag configuration where instantons pop up into the holographic dimension. At low density the system takes the form of an “abelian anti- ferromagnetic” straight periodic chain. Above a critical density there is a second order phase transition into a zigzag structure. An even higher density yields a rich phase space characterized by the formation of multi-layer zigzag structures. The finite size of the lattices in the transverse dimension is a signal of an emerging Fermi sea of quarks. We thus propose that the popcorn transitions indicate the onset of the “quarkyonic” phase of the cold dense nuclear matter." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
+                "atitle" : [ "Baryonic popcorn" ],
+                "stitle" : [ "J. High Energ. Phys" ],
+                "date" : [ "2012-11" ],
+                "risdate" : [ "2012" ],
+                "volume" : [ "2012" ],
+                "issue" : [ "11" ],
+                "oa" : [ "free_for_read" ]
               },
               "facets" : {
                 "creationdate" : [ "2012" ],
                 "creatorcontrib" : [ "Kaplunovsky, Vadim", "Melnikov, Dmitry", "Sonnenschein, Jacob" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Solitons Monopoles and Instantons", "AdS-CFT Correspondence", "Quantum Physics", "Quantum Field Theories, String Theory", "Classical and Quantum Gravitation, Relativity Theory", "Physics", "Phase Diagram of QCD", "Elementary Particles, Quantum Field Theory", "Flavor (particle physics)", "Lattices", "Chains", "Phase transitions", "Density", "Instantons", "Baryons", "Multilayers", "Gauge theory", "Ferromagnetism", "Configurations", "Nuclear matter", "Crystal structure", "Branes", "Solid phases" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "ProQuest SciTech Collection", "ProQuest Technology Collection", "ProQuest Central (Alumni Edition)", "Advanced Technologies & Aerospace Collection", "ProQuest Central Essentials", "ProQuest Central", "Technology Collection", "ProQuest Central Korea", "SciTech Premium Collection", "Advanced Technologies & Aerospace Database", "ProQuest Advanced Technologies & Aerospace Collection", "Publicly Available Content Database", "ProQuest One Academic Eastern Edition", "ProQuest One Academic", "ProQuest One Academic UKI Edition" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-1444t-760d0b45d816a0d8fb674d5ced8ad47da0fb828871854d5ffde60f57a93cabd93" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "The journal of high energy physics" ]
+                "jtitle" : [ "The journal of high energy physics" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -276,7 +276,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Baryonic+popcorn&rft.jtitle=The+journal+of+high+energy+physics&rft.au=Kaplunovsky%2C+Vadim&rft.date=2012-11&rft.volume=2012&rft.issue=11&rft.spage=1&rft.epage=85&rft.pages=1-85&rft.issn=1029-8479&rft.eissn=1029-8479&rft_id=info:doi/10.1007%2FJHEP11%282012%29047&rft.pub=Springer-Verlag&rft.place=Berlin%2FHeidelberg&rft.stitle=J.+High+Energ.+Phys&rft_dat=<proquest_cross>2398248625</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -287,17 +287,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1007_JHEP11_2012_047"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1007_JHEP11_2012_047"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
                 "creationdate" : [ "20200717" ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "author" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ]
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ]
               },
               "control" : {
-                "recordid" : [ "cdi_proquest_miscellaneous_2407314819" ],
-                "sourcerecordid" : [ "2424628284" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_2407314819" ],
+                "sourcerecordid" : [ "2407314819" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
@@ -306,21 +306,59 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "proquest_cross" ],
                 "pqid" : [ "2424628284" ],
-                "score" : [ "0.019118225" ]
+                "score" : [ "0.019115865" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "creationdate" : [ "2020" ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
+                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
+                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "issn" : [ "1439-4235", "1439-7641" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Chemphyschem" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "startdate" : [ "20200717" ],
+                "enddate" : [ "20200717" ],
+                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ]
+              },
+              "display" : {
+                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
+                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
+                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
+                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
+                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
+                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
+                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
+                "format" : [ "journal" ],
+                "jtitle" : [ "Chemphyschem" ],
+                "genre" : [ "article" ],
                 "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
                 "issn" : [ "1439-4235" ],
                 "addtitle" : [ "Chemphyschem" ],
-                "jtitle" : [ "Chemphyschem" ],
-                "genre" : [ "article" ],
-                "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "date" : [ "2020-07-17" ],
-                "risdate" : [ "2020" ],
-                "volume" : [ "21" ],
-                "issue" : [ "14" ],
+                "abstract" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ],
                 "spage" : [ "1531" ],
                 "epage" : [ "1540" ],
                 "pages" : [ "1531-1540" ],
@@ -329,64 +367,26 @@ http_interactions:
                 "cop" : [ "Germany" ],
                 "pub" : [ "Wiley Subscription Services, Inc" ],
                 "doi" : [ "10.1002/cphc.202000116" ],
-                "tpages" : [ "10" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "openurl" : [ "$$Topenurl_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creationdate" : [ "2020" ],
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices", "Chemphyschem" ],
-                "creator" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "recordid" : [ "eNqF0ctqGzEUBmARWpo07TbLIugmhdiRji4zs0yHODYEnEW6HmTNcT1hLLmSpsG7PkKfMU8SuXZS6KZoodunH8FPyBlnY84YXNrNyo6BAWOMc31ETrgU1ajQkr85rCUIdUzex_iQTckK_o4cC5CqVApOyOPc0bRCOvFhbVLnHfXLPwd3fmN9cHTSm58-GJcoXIinX7-_Dsk4bLNEel5PRT3PYyq-0M7RK4vJ9C2uti1mWnuXTOc6953OXMIQE_a9CXRmMX4gb5emj_jxMJ-Sb5Pr-3o6up3fzOqr25EVFfBRIUEVvFqiNkaXRrVaVq1hzFQawearwiormcq7okRYCFuoChYGNOKi1EqckvN97ib4HwPG1Ky7aHf_cOiH2IBkheCy5FWmn_-hD34ILv8uK5AaSihlVuO9ssHHGHDZbEK3NmHbcNbsKml2lTSvleQHnw6xw2KN7St_6SCDag8eux63_4lr6rtp_Tf8GU8Hl3g" ],
-                "recordtype" : [ "article" ],
-                "scope" : [ "CGR", "CUY", "CVF", "ECM", "EIF", "NPM", "AAYXX", "CITATION", "K9.", "7X8" ],
-                "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "orcidid" : [ "https://orcid.org/0000-0002-7233-7206" ],
-                "issn" : [ "1439-4235", "1439-7641" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Chemphyschem" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20200717" ],
-                "enddate" : [ "20200717" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
-              },
-              "display" : {
-                "title" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
-                "publisher" : [ "Germany: Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Chemphyschem, 2020-07-17, Vol.21 (14), p.1531-1540" ],
-                "type" : [ "article" ],
-                "source" : [ "Wiley-Blackwell PALCI Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Orbis-Cascade Wiley-Blackwell Shared Titles 2011", "Alma/SFX Local Collection", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "creator" : [ "Kleimeier, N. Fabian ; Turner, Andrew M ; Fortenberry, Ryan C ; Kaiser, Ralf I" ],
-                "identifier" : [ "ISSN: 1439-4235", "EISSN: 1439-7641", "DOI: 10.1002/cphc.202000116", "PMID: 32458552" ],
-                "subject" : [ "non-equilibrium processes ; interstellar synthesis ; IR spectroscopy ; mass spectroscopy ; complex organic molecules ; Acetaldehyde - chemistry ; Cold Temperature ; Flavoring Agents - chemical synthesis ; Ultraviolet Rays ; Models, Chemical ; Free Radicals - chemistry ; Deuterium - chemistry ; Diacetyl - chemical synthesis ; Acetaldehyde - radiation effects ; Extraterrestrial Environment - chemistry ; Deep space ; Molecular structure ; Molecular clouds ; Galactic cosmic rays ; Substitution reactions ; Amino acids ; Ice ; Aldehydes ; Cosmic rays ; Acetaldehyde ; Complexity ; Organic chemistry ; Ionizing radiation ; Meteorites ; Star formation ; Photoionization ; Interstellar chemistry ; Astrochemistry ; Chemical synthesis ; Interstellar matter ; Index Medicus" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2020 Wiley‐VCH Verlag GmbH & Co. KGaA, Weinheim", "2020 Wiley-VCH Verlag GmbH & Co. KGaA, Weinheim." ],
-                "snippet" : [ "...) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K...", "...\n) - a butter and popcorn flavorant - synthesized within acetaldehyde-based interstellar analog ices exposed to ionizing radiation at 5 K..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "Acetaldehyde (CH3CHO) is ubiquitous throughout the interstellar medium and has been observed in cold molecular clouds, star forming regions, and in meteorites such as Murchison. As the simplest methyl‐bearing aldehyde, acetaldehyde constitutes a critical precursor to prebiotic molecules such as the sugar deoxyribose and amino acids via the Strecker synthesis. In this study, we reveal the first laboratory detection of 2,3‐butanedione (diacetyl, CH3COCOCH3) – a butter and popcorn flavorant – synthesized within acetaldehyde‐based interstellar analog ices exposed to ionizing radiation at 5 K. Detailed isotopic substitution experiments combined with tunable vacuum ultraviolet (VUV) photoionization of the subliming molecules demonstrate that 2,3‐butanedione is formed predominantly via the barrier‐less radical–radical reaction of two acetyl radicals (CH3ĊO). These processes are of fundamental importance for a detailed understanding of how complex organic molecules (COMs) are synthesized in deep space thus constraining the molecular structures and complexity of molecules forming in extraterrestrial ices containing acetaldehyde through a vigorous galactic cosmic ray driven non‐equilibrium chemistry.\nInterstellar popcorn: Exploiting photoionization reflectron time‐of‐flight mass spectrometry, we demonstrate that the popcorn and butter flavorant 2,3‐butanedione (diacetyl) represents the main reaction product of acetaldehyde ices exposed to ionizing radiation." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
+                "atitle" : [ "On the Formation of the Popcorn Flavorant 2,3‐Butanedione (CH3COCOCH3) in Acetaldehyde‐Containing Interstellar Ices" ],
+                "date" : [ "2020-07-17" ],
+                "risdate" : [ "2020" ],
+                "volume" : [ "21" ],
+                "issue" : [ "14" ],
+                "tpages" : [ "10" ]
               },
               "facets" : {
                 "creationdate" : [ "2020" ],
                 "creatorcontrib" : [ "Kleimeier, N. Fabian", "Turner, Andrew M", "Fortenberry, Ryan C", "Kaiser, Ralf I" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "non-equilibrium processes", "interstellar synthesis", "IR spectroscopy", "mass spectroscopy", "complex organic molecules", "Acetaldehyde - chemistry", "Cold Temperature", "Flavoring Agents - chemical synthesis", "Ultraviolet Rays", "Models, Chemical", "Free Radicals - chemistry", "Deuterium - chemistry", "Diacetyl - chemical synthesis", "Acetaldehyde - radiation effects", "Extraterrestrial Environment - chemistry", "Deep space", "Molecular structure", "Molecular clouds", "Galactic cosmic rays", "Substitution reactions", "Amino acids", "Ice", "Aldehydes", "Cosmic rays", "Acetaldehyde", "Complexity", "Organic chemistry", "Ionizing radiation", "Meteorites", "Star formation", "Photoionization", "Interstellar chemistry", "Astrochemistry", "Chemical synthesis", "Interstellar matter", "Index Medicus" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "Medline", "MEDLINE", "MEDLINE (Ovid)", "MEDLINE", "MEDLINE", "PubMed", "CrossRef", "ProQuest Health & Medical Complete (Alumni)", "MEDLINE - Academic" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c3921-7425719fe6aa68a5d649da00a96e2c5717c5c4056e278e2b3c7592ba26eeb8653" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Chemphyschem" ]
+                "jtitle" : [ "Chemphyschem" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -404,7 +404,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-proquest_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=On+the+Formation+of+the+Popcorn+Flavorant+2%2C3%E2%80%90Butanedione+%28CH3COCOCH3%29+in+Acetaldehyde%E2%80%90Containing+Interstellar+Ices&rft.jtitle=Chemphyschem&rft.au=Kleimeier%2C+N.+Fabian&rft.date=2020-07-17&rft.volume=21&rft.issue=14&rft.spage=1531&rft.epage=1540&rft.pages=1531-1540&rft.issn=1439-4235&rft.eissn=1439-7641&rft_id=info:doi/10.1002%2Fcphc.202000116&rft.pub=Wiley+Subscription+Services%2C+Inc&rft.place=Germany&rft_dat=<proquest_cross>2424628284</proquest_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -415,16 +415,16 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_miscellaneous_2407314819"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_miscellaneous_2407314819"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
                 "creationdate" : [ "20180105" ],
-                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "author" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ]
+                "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A521493458" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A521493458" ],
                 "sourcerecordid" : [ "A521493458" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "recordtype" : [ "article" ],
@@ -434,29 +434,7 @@ http_interactions:
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
                 "galeid" : [ "A521493458" ],
-                "score" : [ "0.018662874" ]
-              },
-              "addata" : {
-                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
-                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
-                "issn" : [ "1614-6832" ],
-                "jtitle" : [ "Advanced energy materials" ],
-                "genre" : [ "article" ],
-                "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
-                "date" : [ "2018-01-05" ],
-                "risdate" : [ "2018" ],
-                "volume" : [ "8" ],
-                "issue" : [ "1" ],
-                "spage" : [ "1701110" ],
-                "epage" : [ "n/a" ],
-                "pages" : [ "1701110-n/a" ],
-                "eissn" : [ "1614-6840" ],
-                "ristype" : [ "JOUR" ],
-                "pub" : [ "Wiley Subscription Services, Inc" ],
-                "doi" : [ "10.1002/aenm.201701110" ],
-                "tpages" : [ "8" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.018661754" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -464,54 +442,76 @@ http_interactions:
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "creationdate" : [ "2018" ],
                 "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries", "Advanced energy materials" ],
-                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
                 "recordid" : [ "eNqFkLtOw0AQRS0EEijQUu8POOz4vXQhIhApQMSjtmZfYZG9a-3aQnQU_AF_yJdgBEpKZooZzdxzixtFp0CnQGlyhsq204RCSQGA7kVHUEAWF1VG97d7mhxGJyG80LEyBjRNj6KPteuE85YsbeiMV5KsnXdDIDcovBOqaYYGPZmj586ek3vszCgZtDZ2QxbIvRHYG2eJ9q4l90YoglaSZR_IrOuav28gxpKV6Z_N0H69fz4MjR48ucC-V96ocBwdaGyCOvmbk-hpcfk4v45Xd1fL-WwVQw4ZjUugUuRCphXjqNJc5pxxpoVKMl4KLXNMMpBagmZCKJ1y1IKxgqMoqrLkkE6i6a_vBhtVG6td71GMLVVrhLNKm_E-yxPIWJrl1Q4YswjBK1133rTo32qg9U_u9U_u9Tb3EWC_wOvo9PaPup5d3t7s2G8KmIsa" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "rsrctype" : [ "article" ],
                 "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "creator" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
                 "issn" : [ "1614-6832", "1614-6840" ],
                 "fulltext" : [ "true" ],
                 "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "20180105" ],
                 "enddate" : [ "20180105" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
               },
               "display" : {
+                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
                 "title" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
+                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
+                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
                 "publisher" : [ "Wiley Subscription Services, Inc" ],
                 "ispartof" : [ "Advanced energy materials, 2018-01-05, Vol.8 (1), p.1701110-n/a" ],
-                "type" : [ "article" ],
-                "source" : [ "Wiley-Blackwell Journals \"Not In Any Collection\" 2014 - China", "Wiley Online Library Journals \"Not In Any Collection\" 2016", "Wiley-Blackwell 2013 Journals \"Not In Any Collection\"", "Wiley-Blackwell Journals 2010-2013 Free Opt Ins - China", "Wiley-Blackwell Journals \"Not In Any Collection\" 2011", "Wiley Online Library All Journals" ],
-                "creator" : [ "Zhong, Yu ; Xia, Xinhui ; Deng, Shengjue ; Zhan, Jiye ; Fang, Ruyi ; Xia, Yang ; Wang, Xiuli ; Zhang, Qiang ; Tu, Jiangping" ],
                 "identifier" : [ "ISSN: 1614-6832", "EISSN: 1614-6840", "DOI: 10.1002/aenm.201701110" ],
-                "subject" : [ "biomass‐derived porous carbons ; lithium–sulfur batteries ; cathodes ; nanostructures ; metal–carbon composites ; Sulfur compounds ; Electrical conductivity ; Electrochemistry ; Porosity ; Batteries ; Sulfur ; Electric properties" ],
-                "language" : [ "eng" ],
                 "rights" : [ "2017 WILEY‐VCH Verlag GmbH & Co. KGaA, Weinheim", "COPYRIGHT 2018 Wiley Subscription Services, Inc." ],
                 "snippet" : [ ".... Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ]
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "jtitle" : [ "Advanced energy materials" ],
+                "genre" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0002-3929-1541" ],
+                "issn" : [ "1614-6832" ],
+                "abstract" : [ "The advancement of electrochemical energy storage is closely bound up with the breakthrough of controllable fabrication of energy materials. Inspired by a popcorn fabrication from corn raw, herein a unique porous macrocellular carbon composed of cross‐linked nano/microsheets by a powerful puffing of rice precursor is described. The rice is directly puffed with a volume enlargement of ≈20 times when it is instantaneously released from a sealed environment with a high pressure of 1.0 MPa at 200 °C. Interestingly, when metal (e.g., Ni) nanoparticles are embedded in the puffed rice derived carbon (PRC), high‐quality PRC/metal composites are achieved with attractive properties of a high electrical conductivity of ≈7.2 × 104 S m−1, a large porosity of 85.1%, and a surface area of 1492.2 m2 g−1. The PRC/Ni are employed as a host in lithium–sulfur batteries. The designed PRC/Ni/S electrode exhibits a high reversible capacity of 1257.2 mA h g−1 at 0.2 C, a prolonged cycle life (821 mA h g−1 after 500 cycles), and enhanced rate capability, much better than other counterparts (PRC/S and rGO/S). The excellent properties are attributed to the advantages of PRC/Ni network with a high electrical conductivity, strong adsorption/blocking ability for polysulfides, and interconnected porous framework.\nA unique porous microcellular carbon composed of cross‐linked nano/microsheets created by a powerful puffing of a rice precursor is described. Because of the advantages of the puffed‐rice‐derived carbon/Ni network with a high electrical conductivity and strong adsorption/blocking ability for polysulfides, the microcellular carbon‐based electrode exhibits high sulfur utilization, long cycling life, and high rate performance in a working lithium–sulfur battery." ],
+                "spage" : [ "1701110" ],
+                "epage" : [ "n/a" ],
+                "pages" : [ "1701110-n/a" ],
+                "eissn" : [ "1614-6840" ],
+                "ristype" : [ "JOUR" ],
+                "pub" : [ "Wiley Subscription Services, Inc" ],
+                "doi" : [ "10.1002/aenm.201701110" ],
+                "au" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
+                "atitle" : [ "Popcorn Inspired Porous Macrocellular Carbon: Rapid Puffing Fabrication from Rice and Its Applications in Lithium–Sulfur Batteries" ],
+                "date" : [ "2018-01-05" ],
+                "risdate" : [ "2018" ],
+                "volume" : [ "8" ],
+                "issue" : [ "1" ],
+                "tpages" : [ "8" ]
+              },
               "facets" : {
                 "creationdate" : [ "2018" ],
                 "creatorcontrib" : [ "Zhong, Yu", "Xia, Xinhui", "Deng, Shengjue", "Zhan, Jiye", "Fang, Ruyi", "Xia, Yang", "Wang, Xiuli", "Zhang, Qiang", "Tu, Jiangping" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "biomass‐derived porous carbons", "lithium–sulfur batteries", "cathodes", "nanostructures", "metal–carbon composites", "Sulfur compounds", "Electrical conductivity", "Electrochemistry", "Porosity", "Batteries", "Sulfur", "Electric properties" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-15140-710dc5cd389bae35d5b9b9fce24b7cfd5a241dfd1f9ccef3bafc996bac6877b13" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Advanced energy materials" ]
+                "jtitle" : [ "Advanced energy materials" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -529,7 +529,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn+Inspired+Porous+Macrocellular+Carbon%3A+Rapid+Puffing+Fabrication+from+Rice+and+Its+Applications+in+Lithium%E2%80%93Sulfur+Batteries&rft.jtitle=Advanced+energy+materials&rft.au=Zhong%2C+Yu&rft.date=2018-01-05&rft.volume=8&rft.issue=1&rft.spage=1701110&rft.epage=n%2Fa&rft.pages=1701110-n%2Fa&rft.issn=1614-6832&rft.eissn=1614-6840&rft_id=info:doi/10.1002%2Faenm.201701110&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_cross>A521493458</gale_cross>&svc_dat=viewit&rft_galeid=A521493458"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -540,17 +540,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A521493458"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A521493458"
           }, {
             "pnx" : {
               "sort" : {
+                "author" : [ "Moreta, Cristina ; Tena, María Teresa" ],
                 "creationdate" : [ "20140815" ],
-                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "author" : [ "Moreta, Cristina ; Tena, María Teresa" ]
+                "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ]
               },
               "control" : {
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A375736650" ],
-                "sourcerecordid" : [ "A375736650" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A375736650" ],
+                "sourcerecordid" : [ "10_5465_19416520_2014_873178" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
@@ -558,28 +558,7 @@ http_interactions:
                 "sourceformat" : [ "XML" ],
                 "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
-                "galeid" : [ "A375736650" ],
-                "score" : [ "0.018273484" ]
-              },
-              "addata" : {
-                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
-                "issn" : [ "0021-9673" ],
-                "jtitle" : [ "Journal of Chromatography A" ],
-                "genre" : [ "article" ],
-                "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
-                "date" : [ "2014-08-15" ],
-                "risdate" : [ "2014" ],
-                "volume" : [ "1355" ],
-                "spage" : [ "211" ],
-                "epage" : [ "218" ],
-                "pages" : [ "211-218" ],
-                "coden" : [ "JOCRAM" ],
-                "ristype" : [ "JOUR" ],
-                "cop" : [ "Amsterdam" ],
-                "pub" : [ "Elsevier B.V" ],
-                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
-                "format" : [ "journal" ]
+                "score" : [ "0.01826014" ]
               },
               "links" : {
                 "openurlfulltext" : [ "$$Topenurlfull_article" ],
@@ -588,53 +567,73 @@ http_interactions:
                 "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
               },
               "search" : {
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
                 "creationdate" : [ "2014" ],
                 "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry", "Journal of Chromatography A" ],
-                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
                 "recordid" : [ "eNp9Uc1u3iAQ9KGVmqZ9gx649Ba7gP1h51IpSn-lSL20Z7SGxR9fMDhgV_Ut79Dn66VPUhxHOVYIsRpmhh22KN4wWjHKxLtTpY4xjFBxypqKioqy7llxRiln5aVo6xfFy5ROlLKWtvys-PMBZ4yj9TDb4EkwZMJo3BLiBqEm4G5XR0BZnYj1RIXoL8gUpq0g4PVT3cOQSI8mRHzAwWTjzA-31g-kX4kJaknZcXFzhBSWzEnBWf33_rezd4vVBH_lG7U1ckEeoT3MHIYI03F9ML5bQMdlCg7L2Y649WycHY4zGSElkiZUcxbhHNdXxXMDLuHrx_O8-PHp4_frL-XNt89fr69uStXUYi4bxTXlChQTtDeK0q6-NAeusOmgo3WnW6U57zianvUU21axA6uhY33eQtT1eVHtvgM4lNabsAXJS-NoVfBobMav6vbQ1kIcaBY0u0DFkFJEI6doR4irZFRuc5QnuUeX2xwlFTLPMcve7rIJkgJnInhl05OWdyKTKcu89zsPc-ifFqNMyqJXqG3MvyN1sP9_6B9CLL_L" ],
                 "recordtype" : [ "article" ],
-                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
                 "issn" : [ "0021-9673" ],
                 "fulltext" : [ "true" ],
                 "general" : [ "Elsevier B.V", "Elsevier" ],
-                "rsrctype" : [ "article" ],
                 "startdate" : [ "20140815" ],
                 "enddate" : [ "20140815" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+                "scope" : [ "IQODW", "AAYXX", "CITATION", "BSHEE" ]
               },
               "display" : {
+                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
                 "title" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
+                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
+                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
                 "publisher" : [ "Amsterdam: Elsevier B.V" ],
                 "ispartof" : [ "Journal of Chromatography A, 2014-08-15, Vol.1355, p.211-218" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Pi2 Collection", "ScienceDirect Physical Sciences College Edition Backfile", "Medium Multidisciplinary Collection [ECMMC]", "ScienceDirect Journals (Transactional Access)", "ScienceDirect Polish National Consort 2007", "ScienceDirect Journals (5 years ago - present)", "Alma/SFX Local Collection", "ScienceDirect Government Edition", "Small Multidisciplinary Collection [ECSMC]" ],
-                "creator" : [ "Moreta, Cristina ; Tena, María Teresa" ],
                 "identifier" : [ "ISSN: 0021-9673", "DOI: 10.1016/j.chroma.2014.06.018", "CODEN: JOCRAM" ],
-                "subject" : [ "Packaging ; Quadrupole-time of flight mass spectrometry ; Liquid chromatography ; Perfluorinated alkyl acids ; Focused ultrasound solid–liquid extraction ; Popcorn ; Fundamental and applied biological sciences. Psychology ; Food industries ; Biological and medical sciences ; Cereal and baking product industries ; Corn ; Ammonium perfluorooctanoate ; Mass spectrometry ; Analysis" ],
-                "language" : [ "eng" ],
                 "rights" : [ "2014 Elsevier B.V.", "2015 INIST-CNRS", "COPYRIGHT 2014 Elsevier B.V." ],
                 "snippet" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging...", "acents FUSLE and UHPLC-(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging..." ],
-                "lds50" : [ "peer_reviewed" ],
-                "description" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ]
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
               },
               "delivery" : {
                 "fulltext" : [ "fulltext" ],
                 "delcategory" : [ "Remote Search Resource" ]
               },
+              "addata" : {
+                "format" : [ "journal" ],
+                "jtitle" : [ "Journal of Chromatography A" ],
+                "genre" : [ "article" ],
+                "issn" : [ "0021-9673" ],
+                "abstract" : [ "•FUSLE and UHPLC–(QTOF)MS/MS of nine PFCAs and PFOS in corn, popcorn and packaging.•Complete extraction in one FUSLE cycle of only 10s.•Microwave popcorn bags and their content are analyzed before and after cooking.•PFAA levels from 3.50 to 750ng/g in packaging (mainly PFHxA). PFOA and PFOS not detected.•No PFAAs were found in corn and popcorn.\nAn analytical method is proposed to determine ten perfluorinated alkyl acids (PFAAs) [nine perfluorocarboxylic acids (PFCAs) and perfluorooctane sulfonate (PFOS)] in corn, popcorn and microwave popcorn packaging by focused ultrasound solid–liquid extraction (FUSLE) and ultra high performance liquid chromatography (UHPLC) coupled to quadrupole-time of flight mass spectrometry (QTOF-MS/MS). Selected PFAAs were extracted efficiently in only one 10-s cycle by FUSLE, a simple, safe and inexpensive technique. The developed method was validated for microwave popcorn bags matrix as well as corn and popcorn matrices in terms of linearity, matrix effect error, detection and quantification limits, repeatability and recovery values. The method showed good accuracy with recovery values around 100% except for the lowest chain length PFAAs, satisfactory reproducibility with RSDs under 16%, and sensitivity with limits of detection in the order of hundreds picograms per gram of sample (between 0.2 and 0.7ng/g). This method was also applied to the analysis of six microwave popcorn bags and the popcorn inside before and after cooking. PFCAs contents between 3.50ng/g and 750ng/g were found in bags, being PFHxA (perfluorohexanoic acid) the most abundant of them. However, no PFAAs were detected either corn or popcorn, therefore no migration was assumed." ],
+                "spage" : [ "211" ],
+                "epage" : [ "218" ],
+                "pages" : [ "211-218" ],
+                "coden" : [ "JOCRAM" ],
+                "ristype" : [ "JOUR" ],
+                "cop" : [ "Amsterdam" ],
+                "pub" : [ "Elsevier B.V" ],
+                "doi" : [ "10.1016/j.chroma.2014.06.018" ],
+                "au" : [ "Moreta, Cristina", "Tena, María Teresa" ],
+                "atitle" : [ "Determination of perfluorinated alkyl acids in corn, popcorn and popcorn bags before and after cooking by focused ultrasound solid–liquid extraction, liquid chromatography and quadrupole-time of flight mass spectrometry" ],
+                "date" : [ "2014-08-15" ],
+                "risdate" : [ "2014" ],
+                "volume" : [ "1355" ]
+              },
               "facets" : {
                 "creationdate" : [ "2014" ],
                 "creatorcontrib" : [ "Moreta, Cristina", "Tena, María Teresa" ],
-                "rsrctype" : [ "articles" ],
-                "language" : [ "eng" ],
                 "topic" : [ "Packaging", "Quadrupole-time of flight mass spectrometry", "Liquid chromatography", "Perfluorinated alkyl acids", "Focused ultrasound solid–liquid extraction", "Popcorn", "Fundamental and applied biological sciences. Psychology", "Food industries", "Biological and medical sciences", "Cereal and baking product industries", "Corn", "Ammonium perfluorooctanoate", "Mass spectrometry", "Analysis" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "Pascal-Francis", "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c436t-4c2d02cac160bfc00839f52ce48a8038d7cd2282efb1b0e77c1513a81ba816633" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Journal of Chromatography A" ]
+                "jtitle" : [ "Journal of Chromatography A" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -652,7 +651,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:06:14&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>A375736650</gale_cross>&svc_dat=viewit&rft_galeid=A375736650"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Determination+of+perfluorinated+alkyl+acids+in+corn%2C+popcorn+and+popcorn+bags+before+and+after+cooking+by+focused+ultrasound+solid%E2%80%93liquid+extraction%2C+liquid+chromatography+and+quadrupole-time+of+flight+mass+spectrometry&rft.jtitle=Journal+of+Chromatography+A&rft.au=Moreta%2C+Cristina&rft.date=2014-08-15&rft.volume=1355&rft.spage=211&rft.epage=218&rft.pages=211-218&rft.issn=0021-9673&rft.coden=JOCRAM&rft_id=info:doi/10.1016%2Fj.chroma.2014.06.018&rft.pub=Elsevier+B.V&rft.place=Amsterdam&rft_dat=<gale_cross>10_5465_19416520_2014_873178</gale_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -663,15 +662,15 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A375736650"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A375736650"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "663",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "39",
-            "PC_SEARCH_TIME_TOTAL" : "702",
-            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 0,
-            "COMBINED_SEARCH_TIME" : 4,
+            "PC_SEARCH_CALL_TIME" : "1242",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "50",
+            "PC_SEARCH_TIME_TOTAL" : "1292",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 1,
+            "BUILD_COMBINED_RESULTS_MAP" : 1294,
+            "COMBINED_SEARCH_TIME" : 1302,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 0
           },
@@ -679,10 +678,10 @@ http_interactions:
             "name" : "jtitle",
             "values" : [ {
               "value" : "The Washington Post",
-              "count" : "7878"
+              "count" : "7877"
             }, {
               "value" : "Chicago Tribune",
-              "count" : "7579"
+              "count" : "7580"
             }, {
               "value" : "The Los Angeles Times",
               "count" : "6322"
@@ -691,7 +690,7 @@ http_interactions:
               "count" : "5992"
             }, {
               "value" : "Toronto Star",
-              "count" : "3743"
+              "count" : "3744"
             }, {
               "value" : "Edmonton Journal",
               "count" : "2833"
@@ -703,7 +702,7 @@ http_interactions:
               "count" : "2612"
             }, {
               "value" : "The Wall Street Journal. Eastern Edition",
-              "count" : "2600"
+              "count" : "2604"
             }, {
               "value" : "National Post",
               "count" : "2598"
@@ -712,7 +711,7 @@ http_interactions:
             "name" : "lang",
             "values" : [ {
               "value" : "eng",
-              "count" : "131767"
+              "count" : "131784"
             }, {
               "value" : "por",
               "count" : "249"
@@ -721,7 +720,7 @@ http_interactions:
               "count" : "202"
             }, {
               "value" : "ger",
-              "count" : "141"
+              "count" : "142"
             }, {
               "value" : "chi",
               "count" : "88"
@@ -775,33 +774,36 @@ http_interactions:
             "name" : "topic",
             "values" : [ {
               "value" : "Motion Pictures",
-              "count" : "6843"
+              "count" : "6849"
             }, {
               "value" : "Science & Technology",
-              "count" : "5824"
+              "count" : "5815"
             }, {
               "value" : "Life Sciences & Biomedicine",
-              "count" : "4279"
+              "count" : "4272"
             }, {
               "value" : "Marketing",
-              "count" : "4190"
+              "count" : "4191"
             }, {
               "value" : "Restaurants",
               "count" : "4076"
             }, {
               "value" : "Food",
-              "count" : "2726"
+              "count" : "2727"
             }, {
               "value" : "Humans",
               "count" : "2418"
             }, {
               "value" : "Management",
-              "count" : "2124"
+              "count" : "2123"
             }, {
               "value" : "Analysis",
               "count" : "1800"
             }, {
               "value" : "Nutrition",
+              "count" : "1715"
+            }, {
+              "value" : "Theaters & Cinemas",
               "count" : "1711"
             }, {
               "value" : "Snack Foods",
@@ -810,35 +812,32 @@ http_interactions:
               "value" : "Methods",
               "count" : "1707"
             }, {
-              "value" : "Theaters & Cinemas",
-              "count" : "1707"
-            }, {
               "value" : "Motion Picture Industry",
-              "count" : "1698"
+              "count" : "1699"
             }, {
               "value" : "Diet",
-              "count" : "1643"
+              "count" : "1645"
             }, {
               "value" : "Research",
-              "count" : "1641"
+              "count" : "1636"
             }, {
               "value" : "Social Sciences",
-              "count" : "1581"
+              "count" : "1576"
             }, {
               "value" : "Theater",
-              "count" : "1508"
+              "count" : "1509"
             }, {
               "value" : "Health Aspects",
-              "count" : "1501"
+              "count" : "1500"
             } ]
           }, {
             "name" : "rtype",
             "values" : [ {
               "value" : "newspaper_articles",
-              "count" : "62942"
+              "count" : "62949"
             }, {
               "value" : "articles",
-              "count" : "58336"
+              "count" : "58347"
             }, {
               "value" : "reviews",
               "count" : "3968"
@@ -853,7 +852,7 @@ http_interactions:
               "count" : "632"
             }, {
               "value" : "web_resources",
-              "count" : "535"
+              "count" : "534"
             }, {
               "value" : "conference_proceedings",
               "count" : "328"
@@ -862,7 +861,7 @@ http_interactions:
               "count" : "213"
             }, {
               "value" : "books",
-              "count" : "135"
+              "count" : "136"
             }, {
               "value" : "text_resources",
               "count" : "9"
@@ -871,64 +870,64 @@ http_interactions:
             "name" : "domain",
             "values" : [ {
               "value" : "ProQuest Historical Newspapers",
-              "count" : "132266"
+              "count" : "132284"
             }, {
               "value" : "Global Newsstream",
-              "count" : "64456"
+              "count" : "64463"
             }, {
               "value" : "Factiva",
-              "count" : "60921"
+              "count" : "60931"
             }, {
               "value" : "Nexis Uni",
-              "count" : "54236"
+              "count" : "54247"
             }, {
               "value" : "PressReader",
               "count" : "43423"
             }, {
               "value" : "Single Journals",
-              "count" : "32986"
+              "count" : "32877"
             }, {
               "value" : "ABI/INFORM Collection",
-              "count" : "30745"
+              "count" : "30753"
             }, {
               "value" : "Academic Search Complete",
-              "count" : "19383"
+              "count" : "19414"
             }, {
               "value" : "Business Source Complete",
-              "count" : "17986"
+              "count" : "17988"
             }, {
               "value" : "Factiva (Selected Full Text)",
-              "count" : "7127"
+              "count" : "7126"
             }, {
               "value" : "Agricultural & Environmental Science Collection",
-              "count" : "6734"
+              "count" : "6741"
             }, {
               "value" : "Flipster",
-              "count" : "4769"
+              "count" : "4779"
             }, {
               "value" : "Ethnic NewsWatch",
-              "count" : "4266"
+              "count" : "4267"
             }, {
               "value" : "Advanced Technologies & Aerospace Collection",
               "count" : "3261"
             }, {
               "value" : "ProQuest Advanced Technologies & Aerospace Collection",
-              "count" : "3219"
+              "count" : "3220"
             }, {
               "value" : "Environmental Science Collection",
-              "count" : "2890"
+              "count" : "2892"
             }, {
               "value" : "Freely Accessible General Interest Journals",
-              "count" : "2717"
+              "count" : "2716"
             }, {
               "value" : "Freely Accessible Journals",
               "count" : "2658"
             }, {
               "value" : "Wall Street Journal Online",
-              "count" : "2603"
+              "count" : "2607"
             }, {
               "value" : "DOAJ Directory of Open Access Journals - Not for CDI Discovery",
-              "count" : "2574"
+              "count" : "2579"
             } ]
           }, {
             "name" : "tlevel",
@@ -937,22 +936,22 @@ http_interactions:
               "count" : "3866"
             }, {
               "value" : "peer_reviewed",
-              "count" : "10892"
+              "count" : "10898"
             }, {
               "value" : "online_resources",
-              "count" : "132266"
+              "count" : "132284"
             } ]
           }, {
             "name" : "newrecords",
             "values" : [ {
               "value" : "07 days back",
-              "count" : "24"
-            }, {
-              "value" : "30 days back",
-              "count" : "186"
+              "count" : "18"
             }, {
               "value" : "90 days back",
-              "count" : "2557"
+              "count" : "2531"
+            }, {
+              "value" : "30 days back",
+              "count" : "204"
             } ]
           }, {
             "name" : "creationdate",
@@ -1114,16 +1113,16 @@ http_interactions:
               "count" : "2894"
             }, {
               "value" : "1997",
-              "count" : "2844"
+              "count" : "2845"
             }, {
               "value" : "1998",
               "count" : "3596"
             }, {
               "value" : "1999",
-              "count" : "3846"
+              "count" : "3847"
             }, {
               "value" : "2000",
-              "count" : "4357"
+              "count" : "4358"
             }, {
               "value" : "2001",
               "count" : "4157"
@@ -1141,31 +1140,31 @@ http_interactions:
               "count" : "5328"
             }, {
               "value" : "2006",
-              "count" : "5017"
+              "count" : "5015"
             }, {
               "value" : "2007",
-              "count" : "5236"
+              "count" : "5234"
             }, {
               "value" : "2008",
               "count" : "5026"
             }, {
               "value" : "2009",
-              "count" : "4864"
+              "count" : "4865"
             }, {
               "value" : "2010",
-              "count" : "4793"
+              "count" : "4792"
             }, {
               "value" : "2011",
-              "count" : "4592"
+              "count" : "4591"
             }, {
               "value" : "2012",
-              "count" : "5089"
+              "count" : "5088"
             }, {
               "value" : "2013",
               "count" : "5227"
             }, {
               "value" : "2014",
-              "count" : "5031"
+              "count" : "5032"
             }, {
               "value" : "2015",
               "count" : "4667"
@@ -1174,21 +1173,21 @@ http_interactions:
               "count" : "4523"
             }, {
               "value" : "2017",
-              "count" : "4092"
+              "count" : "4091"
             }, {
               "value" : "2018",
-              "count" : "3810"
+              "count" : "3808"
             }, {
               "value" : "2019",
-              "count" : "3797"
+              "count" : "3799"
             }, {
               "value" : "2020",
-              "count" : "2978"
+              "count" : "2979"
             }, {
               "value" : "2021",
-              "count" : "933"
+              "count" : "952"
             } ]
           } ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:15 GMT
+  recorded_at: Wed, 19 May 2021 14:51:07 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/popcorn_primo_books.yml
+++ b/test/vcr_cassettes/popcorn_primo_books.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,popcorn&scope=alma&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,popcorn&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549995'
+      - '549966'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:06:25 GMT
+      - Wed, 19 May 2021 14:50:56 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -86,7 +86,7 @@ http_interactions:
                 "originalsourceid" : [ "002282366-MIT01" ],
                 "sourcesystem" : [ "ILS" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "2.9496138E-4" ]
+                "score" : [ "2.957334E-4" ]
               },
               "addata" : {
                 "aulast" : [ "Rudolph" ],
@@ -229,42 +229,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019721306761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724606761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019721306761" ],
+                "mms" : [ "9933019724606761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019721306761" ],
-                "recordid" : [ "alma9933019721306761" ],
+                "sourcerecordid" : [ "9933019724606761" ],
+                "recordid" : [ "alma9933019724606761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573078" ],
+                "originalsourceid" : [ "991000000000573049" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.5851083E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573078" ],
+                "oclcid" : [ "(ckb)1000000000573049" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Thailand" ]
+                "jtitle" : [ "Popcorn Industry Profile: Australia" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Thailand" ],
+                "title" : [ "Popcorn Industry Profile: Australia" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9003628398970808267" ]
+                "frbrgroupid" : [ "9059165500462499698" ]
               }
             },
             "delivery" : {
@@ -310,42 +310,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019723406761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724306761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019723406761" ],
+                "mms" : [ "9933019724306761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019723406761" ],
-                "recordid" : [ "alma9933019723406761" ],
+                "sourcerecordid" : [ "9933019724306761" ],
+                "recordid" : [ "alma9933019724306761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573061" ],
+                "originalsourceid" : [ "991000000000573052" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.5851083E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573061" ],
+                "oclcid" : [ "(ckb)1000000000573052" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Greece" ]
+                "jtitle" : [ "Popcorn Industry Profile: Brazil" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Greece" ],
+                "title" : [ "Popcorn Industry Profile: Brazil" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9037562016405007885" ]
+                "frbrgroupid" : [ "9083335249684128851" ]
               }
             },
             "delivery" : {
@@ -391,42 +391,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019722106761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724806761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019722106761" ],
+                "mms" : [ "9933019724806761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019722106761" ],
-                "recordid" : [ "alma9933019722106761" ],
+                "sourcerecordid" : [ "9933019724806761" ],
+                "recordid" : [ "alma9933019724806761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573073" ],
+                "originalsourceid" : [ "991000000000573047" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.5851083E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573073" ],
+                "oclcid" : [ "(ckb)1000000000573047" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: South Korea" ]
+                "jtitle" : [ "Popcorn Industry Profile: Argentina" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: South Korea" ],
+                "title" : [ "Popcorn Industry Profile: Argentina" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9004595849084473098" ]
+                "frbrgroupid" : [ "9001959784471604878" ]
               }
             },
             "delivery" : {
@@ -472,42 +472,42 @@ http_interactions:
           }, {
             "context" : "L",
             "adaptor" : "Local Search Engine",
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724206761",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/9933019724506761",
             "pnx" : {
               "display" : {
                 "source" : [ "Alma" ],
                 "type" : [ "journal" ],
                 "language" : [ "fre" ],
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "publisher" : [ "Datamonitor Plc" ],
-                "mms" : [ "9933019724206761" ],
+                "mms" : [ "9933019724506761" ],
                 "version" : [ "1" ]
               },
               "control" : {
-                "sourcerecordid" : [ "9933019724206761" ],
-                "recordid" : [ "alma9933019724206761" ],
+                "sourcerecordid" : [ "9933019724506761" ],
+                "recordid" : [ "alma9933019724506761" ],
                 "sourceid" : "alma",
-                "originalsourceid" : [ "991000000000573053" ],
+                "originalsourceid" : [ "991000000000573050" ],
                 "sourcesystem" : [ "SFX" ],
                 "sourceformat" : [ "MARC21" ],
-                "score" : [ "5.5851083E-4" ]
+                "score" : [ "5.616534E-4" ]
               },
               "addata" : {
                 "stitle" : [ "POPCORN INDUSTRY PROFILE" ],
                 "pub" : [ "Datamonitor Plc" ],
-                "oclcid" : [ "(ckb)1000000000573053" ],
+                "oclcid" : [ "(ckb)1000000000573050" ],
                 "format" : [ "journal" ],
                 "genre" : [ "journal" ],
                 "ristype" : [ "JOUR" ],
-                "jtitle" : [ "Popcorn Industry Profile: Chile" ]
+                "jtitle" : [ "Popcorn Industry Profile: Austria" ]
               },
               "sort" : {
-                "title" : [ "Popcorn Industry Profile: Chile" ],
+                "title" : [ "Popcorn Industry Profile: Austria" ],
                 "creationdate" : [ "0000" ]
               },
               "facets" : {
                 "frbrtype" : [ "6" ],
-                "frbrgroupid" : [ "9007649350935717203" ]
+                "frbrgroupid" : [ "9060146011692305880" ]
               }
             },
             "delivery" : {
@@ -552,24 +552,24 @@ http_interactions:
             }
           } ],
           "timelog" : {
-            "BUILD_RESULTS_RETRIVE_FROM_DB" : "66",
-            "CALL_SOLR_GET_IDS_LIST" : "500",
-            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "495",
-            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "1",
-            "RETRIVE_FROM_DB_COURSE_INFO" : "42",
-            "RETRIVE_FROM_DB_RECORDS" : "19",
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "39",
+            "CALL_SOLR_GET_IDS_LIST" : "779",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "276",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "20",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "11",
             "RETRIVE_FROM_DB_RELATIONS" : "2",
-            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "389",
-            "SET_AVAILABILTY_HOLDING_DEDUPS" : "106",
-            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "152",
-            "PRIMA_LOCAL_SEARCH_TOTAL" : "1227",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "166",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "110",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "166",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "1270",
             "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 1256,
-            "COMBINED_SEARCH_TIME" : 1258,
+            "BUILD_COMBINED_RESULTS_MAP" : 1298,
+            "COMBINED_SEARCH_TIME" : 1301,
             "PROCESS_COMBINED_RESULTS" : 0,
             "FEATURED_SEARCH_TIME" : 0
           },
           "facets" : [ ]
         }
-  recorded_at: Mon, 17 May 2021 15:06:26 GMT
+  recorded_at: Wed, 19 May 2021 14:50:57 GMT
 recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/primo_chapter.yml
+++ b/test/vcr_cassettes/primo_chapter.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://another_fake_server.example.com/primo/v1/search?apikey=FAKE_PRIMO_SEARCH_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=cdi&tab=bento&vid=FAKE_PRIMO_VID
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,%22spider%20monkey%20optimization%20algorithm%22&scope=FAKE_PRIMO_ARTICLE_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
     body:
       encoding: UTF-8
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       Vary:
       - accept-encoding
       X-Exl-Api-Remaining:
-      - '549989'
+      - '549964'
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Methods:
@@ -37,7 +37,7 @@ http_interactions:
       Transfer-Encoding:
       - chunked
       Date:
-      - Mon, 17 May 2021 15:07:39 GMT
+      - Wed, 19 May 2021 14:51:08 GMT
       Server:
       - CA-API-Gateway/9.0
     body:
@@ -59,33 +59,72 @@ http_interactions:
           "docs" : [ {
             "pnx" : {
               "sort" : {
-                "title" : [ "Spider Monkey Optimization Algorithm" ],
+                "author" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
                 "creationdate" : [ "20180607" ],
-                "author" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ]
+                "title" : [ "Spider Monkey Optimization Algorithm" ]
               },
               "control" : {
-                "sourcetype" : [ "Publisher" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "recordid" : [ "cdi_springer_books_10_1007_978_3_319_91341_4_4" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_springer_books_10_1007_978_3_319_91341_4_4" ],
                 "sourcerecordid" : [ "springer_books_10_1007_978_3_319_91341_4_4" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "recordtype" : [ "book_chapter" ],
                 "addsrcrecordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
+                "sourcetype" : [ "Publisher" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "springer" ],
                 "score" : [ "0.5" ]
               },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "creationdate" : [ "2018" ],
+                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
+                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
+                "recordtype" : [ "book_chapter" ],
+                "sourceid" : [ "" ],
+                "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "book_chapter" ],
+                "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
+                "isbn" : [ "3319913395", "9783319913391", "3319913417", "9783319913414" ],
+                "issn" : [ "1860-949X", "1860-9503" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Springer International Publishing" ],
+                "startdate" : [ "20180607" ],
+                "enddate" : [ "20180607" ],
+                "scope" : [ "" ]
+              },
+              "display" : {
+                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "title" : [ "Spider Monkey Optimization Algorithm" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
+                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
+                "source" : [ "Springer Book Series", "Springer Intelligent Technologies and Robotics eBooks 2019 English/International" ],
+                "publisher" : [ "Cham: Springer International Publishing" ],
+                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
+                "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
+                "relation" : [ "Studies in Computational Intelligence" ],
+                "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
+                "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "type" : [ "book_chapter" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
+              },
               "addata" : {
-                "abstract" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
+                "format" : [ "book" ],
+                "genre" : [ "bookitem" ],
                 "isbn" : [ "3319913395", "9783319913391" ],
                 "issn" : [ "1860-949X" ],
-                "genre" : [ "bookitem" ],
-                "au" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "btitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ],
-                "atitle" : [ "Spider Monkey Optimization Algorithm" ],
-                "seriestitle" : [ "Studies in Computational Intelligence" ],
-                "date" : [ "2018-06-07" ],
-                "risdate" : [ "2018" ],
+                "abstract" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
                 "spage" : [ "43" ],
                 "epage" : [ "59" ],
                 "pages" : [ "43-59" ],
@@ -95,63 +134,24 @@ http_interactions:
                 "cop" : [ "Cham" ],
                 "pub" : [ "Springer International Publishing" ],
                 "doi" : [ "10.1007/978-3-319-91341-4_4" ],
-                "format" : [ "book" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
-                "recordid" : [ "eNo9kLtOw0AURJeXRAj5AhoXtAv3-u6zjCICSEEpAIlu5bXXYZXEtrxu4Osx4VGNZkYaaQ5jVwg3CKBvrTacOKHlFkkgF04csQsag4PXx2yCRgG3EujkvyArT_8KYd_O2Syl6GEcVCZXNGHXz12sQp89tc02fGTrboj7-FkMsW2y-W7T9nF431-ys7rYpTD71Sl7Xd69LB74an3_uJiveEKymisAVUtVmlLmIG1QEimX2giFtTHBlyAqUwaSvsoFCY9a5J40QSiEL3NNU4Y_u6nrY7MJvfNtu00OwX0zcCMDR2585g6f3ciAvgAvS0jO" ],
-                "recordtype" : [ "book_chapter" ],
-                "title" : [ "Spider Monkey Optimization Algorithm", "Evolutionary and Swarm Intelligence Algorithms" ],
-                "creationdate" : [ "2018" ],
-                "sourceid" : [ "" ],
-                "scope" : [ "" ],
-                "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "isbn" : [ "3319913395", "9783319913391", "3319913417", "9783319913414" ],
-                "issn" : [ "1860-949X", "1860-9503" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Springer International Publishing" ],
-                "rsrctype" : [ "book_chapter" ],
-                "startdate" : [ "20180607" ],
-                "enddate" : [ "20180607" ],
-                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "book_chapter" ],
-                "source" : [ "Springer Book Series", "Springer Intelligent Technologies and Robotics eBooks 2019 English/International" ],
-                "creator" : [ "Sharma, Harish ; Hazrati, Garima ; Bansal, Jagdish Chand" ],
-                "publisher" : [ "Cham: Springer International Publishing" ],
-                "ispartof" : [ "Evolutionary and Swarm Intelligence Algorithms, 2018-06-07, p.43-59" ],
-                "identifier" : [ "ISSN: 1860-949X", "ISBN: 3319913395", "ISBN: 9783319913391", "EISSN: 1860-9503", "EISBN: 3319913417", "EISBN: 9783319913414", "DOI: 10.1007/978-3-319-91341-4_4" ],
-                "subject" : [ "Spider monkey optimization ; Swarm intelligence ; Numerical optimization ; Fission-fusion social structure" ],
-                "language" : [ "eng" ],
-                "relation" : [ "Studies in Computational Intelligence" ],
-                "rights" : [ "Springer International Publishing AG, part of Springer Nature 2019" ],
-                "snippet" : [ ".... This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ],
-                "title" : [ "Spider Monkey Optimization Algorithm" ],
-                "description" : [ "Foraging behavior of social creatures has always been a matter of study for the development of optimization algorithms. Spider Monkey Optimization (SMO) is a global optimization algorithm inspired by Fission-Fusion social (FFS) structure of spider monkeys during their foraging behavior. SMO exquisitely depicts two fundamental concepts of swarm intelligence: self-organization and division of labor. SMO has gained popularity in recent years as a swarm intelligence based algorithm and is being applied to many engineering optimization problems. This chapter presents the Spider Monkey Optimization algorithm in detail. A numerical example of SMO procedure has also been given for a better understanding of its working." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
+                "btitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ],
+                "atitle" : [ "Spider Monkey Optimization Algorithm" ],
+                "seriestitle" : [ "Studies in Computational Intelligence" ],
+                "date" : [ "2018-06-07" ],
+                "risdate" : [ "2018" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2018" ],
                 "creatorcontrib" : [ "Sharma, Harish", "Hazrati, Garima", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "book_chapters" ],
                 "topic" : [ "Spider monkey optimization", "Swarm intelligence", "Numerical optimization", "Fission-fusion social structure" ],
                 "prefilter" : [ "book_chapters" ],
+                "rsrctype" : [ "book_chapters" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-s1397-6006f56c8c52059e65132578461f88ebc04d8ce35bd2434b1742b3730ea4bc273" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ]
+                "jtitle" : [ "Evolutionary and Swarm Intelligence Algorithms" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -169,7 +169,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:08&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-springer&rft_val_fmt=info:ofi/fmt:kev:mtx:book&rft.genre=bookitem&rft.atitle=Spider+Monkey+Optimization+Algorithm&rft.btitle=Evolutionary+and+Swarm+Intelligence+Algorithms&rft.au=Sharma%2C+Harish&rft.date=2018-06-07&rft.spage=43&rft.epage=59&rft.pages=43-59&rft.issn=1860-949X&rft.eissn=1860-9503&rft.isbn=3319913395&rft_id=info:doi/10.1007%2F978-3-319-91341-4_4&rft.eisbn=3319913417&rft.pub=Springer+International+Publishing&rft.place=Cham&rft.series=Studies+in+Computational+Intelligence&rft_dat=<springer>springer_books_10_1007_978_3_319_91341_4_4</springer>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -180,41 +180,78 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_springer_books_10_1007_978_3_319_91341_4_4"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_springer_books_10_1007_978_3_319_91341_4_4"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
                 "creationdate" : [ "201712" ],
-                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ]
               },
               "control" : {
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "pqid" : [ "1954549491" ],
-                "galeid" : [ "A511146853" ],
-                "recordid" : [ "cdi_proquest_journals_1954549491" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_1954549491" ],
                 "sourcerecordid" : [ "A511146853" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
+                "sourcetype" : [ "Aggregation Database" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_proqu" ],
-                "score" : [ "0.09796392" ]
+                "pqid" : [ "1954549491" ],
+                "galeid" : [ "A511146853" ],
+                "score" : [ "0.09796783" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
+                "creationdate" : [ "2017" ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
+                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "article" ],
+                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
+                "issn" : [ "1432-7643", "1433-7479" ],
+                "fulltext" : [ "true" ],
+                "addtitle" : [ "Soft Comput" ],
+                "general" : [ "Springer Berlin Heidelberg", "Springer", "Springer Nature B.V" ],
+                "startdate" : [ "201712" ],
+                "enddate" : [ "201712" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
+                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
+                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
+                "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
+                "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
+                "rights" : [ "Springer-Verlag GmbH Germany 2017", "Springer-Verlag Berlin Heidelberg 2016", "COPYRIGHT 2017 Springer" ],
+                "snippet" : [ "...Soft Comput (2017) 21:6933–6962\nDOI 10.1007/s00500-016-2419-0\nFOUNDATIONS\nSpider monkey optimization algorithm for constrained\noptimization problems\nKavita..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
-                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
-                "issn" : [ "1432-7643" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "Soft computing (Berlin, Germany)" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "stitle" : [ "Soft Comput" ],
-                "date" : [ "2017-12" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "21" ],
-                "issue" : [ "23" ],
+                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
+                "issn" : [ "1432-7643" ],
+                "abstract" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ],
                 "spage" : [ "6933" ],
                 "epage" : [ "6962" ],
                 "pages" : [ "6933-6962" ],
@@ -223,63 +260,26 @@ http_interactions:
                 "cop" : [ "Berlin/Heidelberg" ],
                 "pub" : [ "Springer Berlin Heidelberg" ],
                 "doi" : [ "10.1007/s00500-016-2419-0" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
-                "recordid" : [ "eNp9kEtLxDAUhYsoOD5-gLuCS-mY2yRNuxwGnwy4UNchaZMxY9vUpLMYf71pK4oKkkXC5Tvn3JwoOgM0B4TYpUeIIpQgyJKUQJGgvWgGBOOEEVbsj-80YRnBh9GR9xuEUmAUz6L7x85UysWNbV_VLrZdbxrzLnpj21jUa-tM_9LE2rq4tK3vnTCtqn5inbOyVo0_iQ60qL06_byPo-frq6flbbJ6uLlbLlZJSSimicgzKSUDzDLJGEJQaZxnCqCiSuWY5BhAIJ0SDTgTeZWrQlIJRRgThonEx9H55BuC37bK93xjt64NkRwKSigpSAGBmk_UWtSKm1bbsHwZTqUaE_6itAnzBYVgm-UUBwFMgtJZ753SvHOmEW7HAfGhYz51zEPHfOiYo6C5mDQ-sO1auS9NOlADnQJP8ch_J_yhR3BQLFxvyrDX6N-FZv5NYL8TPgDsCJqd" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems", "Soft computing (Berlin, Germany)", "Soft Computing" ],
-                "creationdate" : [ "2017" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
-                "orcidid" : [ "https://orcid.org/0000-0003-3104-3233" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "issn" : [ "1432-7643", "1433-7479" ],
-                "fulltext" : [ "true" ],
-                "addtitle" : [ "Soft Comput" ],
-                "general" : [ "Springer Berlin Heidelberg", "Springer", "Springer Nature B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201712" ],
-                "enddate" : [ "201712" ],
-                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "publisher" : [ "Berlin/Heidelberg: Springer Berlin Heidelberg" ],
-                "ispartof" : [ "Soft computing (Berlin, Germany), 2017-12, Vol.21 (23), p.6933-6962" ],
-                "identifier" : [ "ISSN: 1432-7643", "EISSN: 1433-7479", "DOI: 10.1007/s00500-016-2419-0" ],
-                "subject" : [ "Engineering ; Deb’s technique ; CEC2006 ; Computational Intelligence ; Control, Robotics, Mechatronics ; Artificial Intelligence (incl. Robotics) ; Spider monkey optimization ; CEC2010 ; Mathematical Logic and Foundations ; Constrained optimization ; Monkeys ; Algorithms ; Mathematical optimization ; Analysis ; Bees ; Optimization algorithms ; Benchmarks ; Global optimization ; Swarm intelligence" ],
-                "language" : [ "eng" ],
-                "rights" : [ "Springer-Verlag GmbH Germany 2017", "Springer-Verlag Berlin Heidelberg 2016", "COPYRIGHT 2017 Springer" ],
-                "snippet" : [ "...Soft Comput (2017) 21:6933–6962\nDOI 10.1007/s00500-016-2419-0\nFOUNDATIONS\nSpider monkey optimization algorithm for constrained\noptimization problems\nKavita..." ],
-                "title" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
-                "description" : [ "In this paper, a modified version of spider monkey optimization (SMO) algorithm for solving constrained optimization problems has been proposed. To the best of author’s knowledge, this is the first attempt to develop a version of SMO which can solve constrained continuous optimization problems by using the Deb’s technique for handling constraints. The proposed algorithm is named constrained spider monkey optimization (CSMO) algorithm. The performance of CSMO is investigated on the well-defined constrained optimization problems of CEC2006 and CEC2010 benchmark sets. The results of the proposed algorithm are compared with constrained versions of particle swarm optimization, artificial bee colony and differential evolution. Outcome of the experiment and the discussion of results demonstrate that CSMO handles the global optimization task very well for constrained optimization problems and shows better performance in comparison with compared algorithms. Such an outcome will be an encouragement for the research community to further explore the potential of SMO in solving benchmarks as well as real-world problems, which are often constrained in nature." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "atitle" : [ "Spider monkey optimization algorithm for constrained optimization problems" ],
+                "stitle" : [ "Soft Comput" ],
+                "date" : [ "2017-12" ],
+                "risdate" : [ "2017" ],
+                "volume" : [ "21" ],
+                "issue" : [ "23" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2017" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Engineering", "Deb’s technique", "CEC2006", "Computational Intelligence", "Control, Robotics, Mechatronics", "Artificial Intelligence (incl. Robotics)", "Spider monkey optimization", "CEC2010", "Mathematical Logic and Foundations", "Constrained optimization", "Monkeys", "Algorithms", "Mathematical optimization", "Analysis", "Bees", "Optimization algorithms", "Benchmarks", "Global optimization", "Swarm intelligence" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c4535-a86bbb71376b77001df386e11d5ee8348311a0f24f136a8d8e9b5b193114734b3" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Soft computing (Berlin, Germany)", "Soft Computing" ]
+                "jtitle" : [ "Soft computing (Berlin, Germany)", "Soft Computing" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -297,7 +297,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:08&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_proqu&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Spider+monkey+optimization+algorithm+for+constrained+optimization+problems&rft.jtitle=Soft+computing+%28Berlin%2C+Germany%29&rft.au=Gupta%2C+Kavita&rft.date=2017-12&rft.volume=21&rft.issue=23&rft.spage=6933&rft.epage=6962&rft.pages=6933-6962&rft.issn=1432-7643&rft.eissn=1433-7479&rft_id=info:doi/10.1007%2Fs00500-016-2419-0&rft.pub=Springer+Berlin+Heidelberg&rft.place=Berlin%2FHeidelberg&rft.stitle=Soft+Comput&rft_dat=<gale_proqu>1954549491</gale_proqu>&svc_dat=viewit&rft_galeid=A511146853"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -308,99 +308,99 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_proquest_journals_1954549491"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_proquest_journals_1954549491"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "author" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
                 "creationdate" : [ "20200911" ],
-                "author" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ]
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ]
               },
               "control" : {
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "galeid" : [ "A648108178" ],
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A648108178" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A648108178" ],
                 "sourcerecordid" : [ "A648108178" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
+                "sourcetype" : [ "Aggregation Database" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_cross" ],
-                "score" : [ "0.06633203" ]
+                "galeid" : [ "A648108178" ],
+                "score" : [ "0.06633455" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
+                "creationdate" : [ "2020" ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
+                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
+                "issn" : [ "0929-6212", "1572-834X" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Springer" ],
+                "startdate" : [ "20200911" ],
+                "enddate" : [ "20200911" ],
+                "scope" : [ "AAYXX", "CITATION", "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
+                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
+                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
+                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
+                "publisher" : [ "Springer" ],
+                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
+                "identifier" : [ "ISSN: 0929-6212", "EISSN: 1572-834X", "DOI: 10.1007/s11277-020-07703-6" ],
+                "rights" : [ "COPYRIGHT 2021 Springer" ],
+                "snippet" : [ ".... By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
-                "issn" : [ "0929-6212" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "Wireless personal communications" ],
                 "genre" : [ "article" ],
-                "au" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "atitle" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
-                "date" : [ "2020-09-11" ],
-                "risdate" : [ "2020" ],
-                "volume" : [ "116" ],
-                "issue" : [ "1" ],
+                "issn" : [ "0929-6212" ],
+                "abstract" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ],
                 "spage" : [ "23" ],
                 "pages" : [ "23-" ],
                 "eissn" : [ "1572-834X" ],
                 "ristype" : [ "JOUR" ],
                 "pub" : [ "Springer" ],
                 "doi" : [ "10.1007/s11277-020-07703-6" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
-                "recordid" : [ "eNotkNtKAzEQhoMoWA8v4FVeIDrJ7ibZy3oWqr1Qwbtlmk3a2DapSUDq07u1MhcDw3w__B8hFxwuOYC6ypwLpRgIYKAUVEwekBFvlGC6qj8OyQha0TIpuDgmJzl_AgxYK0bkaxKxp9e4wmB8mFMf6Gt05RuTZbfW-WB7-mLLd0zLTN_z7uV143ub6HMMS7ul003xa_-DxcdAx6t5TL4s1tTFRMvC0qdQbAq20Ojo22LA8xk5crjK9vx_n5L3-7u3m0c2mT483YwnzAioBEOoeC2k7Ht0ra3aXlpUzWxmwbQOdO2E4yCVMbqpAVs-ayotERVy1EZDU52Sy33uHFe288HFktAM09u1NzEM5Yb7WNaag-ZKD4DYAybFnJN13Sb5NaZtx6HbWe72lrvBcvdnuZPVLxCzcQY" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things", "Wireless personal communications" ],
-                "creationdate" : [ "2020" ],
-                "scope" : [ "AAYXX", "CITATION", "BSHEE" ],
-                "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "issn" : [ "0929-6212", "1572-834X" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Springer" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "20200911" ],
-                "enddate" : [ "20200911" ],
-                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "SpringerLink Contemporary (1997 - Present)" ],
-                "creator" : [ "Mayilsamy, Jayaprakash ; Rangasamy, Devi Priya" ],
-                "publisher" : [ "Springer" ],
-                "ispartof" : [ "Wireless personal communications, 2020-09-11, Vol.116 (1), p.23" ],
-                "identifier" : [ "ISSN: 0929-6212", "EISSN: 1572-834X", "DOI: 10.1007/s11277-020-07703-6" ],
-                "subject" : [ "Information networks ; Monkeys ; Computer networks ; Engineering schools ; Algorithms ; Mathematical optimization" ],
-                "language" : [ "eng" ],
-                "rights" : [ "COPYRIGHT 2021 Springer" ],
-                "snippet" : [ ".... By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA..." ],
-                "title" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
-                "description" : [ "In the Internet of Things (IoT), the number of devices connected to the internet, and they can collect and exchange information at any time. IoT is helpful for the progress of a smart city and different applications. Software-Defined Network (SDN) offers programmability and flexibility in the IoT network. Nevertheless, the adoption of the number of gadgets will increase the transmission delay and this will lead the network to heavy loaded. To overcome this issue, an efficient load balancing technique has to be presented in the SDN network. By considering this solution as an aim, spider monkey optimization algorithm based load balancing (LB-SMOA) is presented in this paper. Using this technique, the controller with minimum load is selected and this selected controller balances the load of the heavily loaded controller. Simulation results show that the performance of the proposed LB-SMOA outperforms the existing load balancing techniques in terms of average response time, packet loss rate, and throughput." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
+                "atitle" : [ "Load Balancing in Software-Defined Networks Using Spider Monkey Optimization Algorithm for the Internet of Things" ],
+                "date" : [ "2020-09-11" ],
+                "risdate" : [ "2020" ],
+                "volume" : [ "116" ],
+                "issue" : [ "1" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2020" ],
                 "creatorcontrib" : [ "Mayilsamy, Jayaprakash", "Rangasamy, Devi Priya" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Information networks", "Monkeys", "Computer networks", "Engineering schools", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "CrossRef", "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-c2032-a0314266ddaf9e39d6ea75bbe0c9f084f2f1067cc8540a91b5386aa7a1a8c8053" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Wireless personal communications" ]
+                "jtitle" : [ "Wireless personal communications" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -418,7 +418,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:08&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Load+Balancing+in+Software-Defined+Networks+Using+Spider+Monkey+Optimization+Algorithm+for+the+Internet+of+Things&rft.jtitle=Wireless+personal+communications&rft.au=Mayilsamy%2C+Jayaprakash&rft.date=2020-09-11&rft.volume=116&rft.issue=1&rft.spage=23&rft.pages=23-&rft.issn=0929-6212&rft.eissn=1572-834X&rft_id=info:doi/10.1007%2Fs11277-020-07703-6&rft.pub=Springer&rft_dat=<gale_cross>A648108178</gale_cross>&svc_dat=viewit&rft_galeid=A648108178"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -429,37 +429,75 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A648108178"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A648108178"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "author" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
                 "creationdate" : [ "2015" ],
-                "author" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ]
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ]
               },
               "control" : {
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "recordid" : [ "cdi_crossref_primary_10_1016_j_procs_2015_08_504" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1016_j_procs_2015_08_504" ],
                 "sourcerecordid" : [ "S1877050915026393" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
+                "sourcetype" : [ "Aggregation Database" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "elsevier_cross" ],
-                "score" : [ "0.06633203" ]
+                "score" : [ "0.06633455" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
+                "creationdate" : [ "2015" ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
+                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
+                "recordtype" : [ "article" ],
+                "sourceid" : [ "AAFTH" ],
+                "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
+                "issn" : [ "1877-0509", "1877-0509" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Elsevier B.V" ],
+                "startdate" : [ "2015" ],
+                "enddate" : [ "2015" ],
+                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ]
+              },
+              "display" : {
+                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
+                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
+                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
+                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
+                "publisher" : [ "Elsevier B.V" ],
+                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
+                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2015.08.504" ],
+                "rights" : [ "2015 The Authors" ],
+                "snippet" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ],
+                "oa" : [ "free_for_read" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
-                "issn" : [ "1877-0509" ],
-                "oa" : [ "free_for_read" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "Procedia computer science" ],
                 "genre" : [ "article" ],
-                "au" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "atitle" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
-                "date" : [ "2015" ],
-                "risdate" : [ "2015" ],
-                "volume" : [ "62" ],
+                "issn" : [ "1877-0509" ],
+                "abstract" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ],
                 "spage" : [ "442" ],
                 "epage" : [ "449" ],
                 "pages" : [ "442-449" ],
@@ -467,63 +505,25 @@ http_interactions:
                 "ristype" : [ "JOUR" ],
                 "pub" : [ "Elsevier B.V" ],
                 "doi" : [ "10.1016/j.procs.2015.08.504" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
-                "recordid" : [ "eNp9kM9KAzEQh4MoWGqfwEteYNfJ_k0OHmpprVCpoD2HbDKrWbubJVmE-vRuWw-enMsM_OYbho-QWwYxA1bcNXHvnQ5xAiyPgcc5ZBdkwnhZRpCDuPwzX5NZCA2MlXIuWDkhy5UdOgyBPqiAhr64YAfrOrrrjRqQ2o6-9tagp8-u-8QD3faDbe23Oi3N9-_O2-GjvSFXtdoHnP32Kdmtlm-LdbTZPj4t5puIpSUrI8ONUgVwSOqiEjytK9RY5doYnaUZFxlkbExNLrgyWWl4lQgskprnvCpAJOmUpOe72rsQPNay97ZV_iAZyKMM2ciTDHmUIYHLUcZI3Z8pHF_7suhl0BY7jcZ61IM0zv7L_wACJmkX" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm", "Procedia computer science" ],
-                "creationdate" : [ "2015" ],
-                "sourceid" : [ "AAFTH" ],
-                "scope" : [ "6I.", "AAFTH", "AAYXX", "CITATION" ],
-                "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "issn" : [ "1877-0509", "1877-0509" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Elsevier B.V" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "2015" ],
-                "enddate" : [ "2015" ],
-                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "ScienceDirect Journals (Transactional Access)", "ScienceDirect Journals (5 years ago - present)", "Elsevier:ScienceDirect:Open Access" ],
-                "creator" : [ "Kumar, Sandeep ; Kumari, Rajani ; Sharma, Vivek Kumar" ],
-                "publisher" : [ "Elsevier B.V" ],
-                "ispartof" : [ "Procedia computer science, 2015, Vol.62, p.442-449" ],
-                "identifier" : [ "ISSN: 1877-0509", "EISSN: 1877-0509", "DOI: 10.1016/j.procs.2015.08.504" ],
-                "subject" : [ "Engineering optimization problems ; fission-fusion social structure ; Nature Inspired Algorithms ; Swarm intelligence ; Spider Monkey Optimization Algorithm" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2015 The Authors" ],
-                "snippet" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired..." ],
-                "title" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
-                "oa" : [ "free_for_read" ],
-                "description" : [ "Spider Monkey Optimization (SMO) technique is most recent member in the family of swarm optimization algorithms.SMO algorithm fall in class of Nature Inspired Algorithm (NIA). SMO algorithm is good in exploration and exploitation of local search space and it is well balanced algorithm most of the times. This paper presents a new strategy to update position of solution during local leader phase using fitness of individuals. The proposed algorithm is named as Fitness based Position Update in SMO (FPSMO) algorithm as it updates position of individuals based on their fitness. The anticipated strategy enhances the rate of convergence. The planned FPSMO approach tested over nineteen benchmark functions and for one real world problem so as to establish superiority of it over basic SMO algorithm." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
+                "atitle" : [ "Fitness Based Position Update in Spider Monkey Optimization Algorithm" ],
+                "date" : [ "2015" ],
+                "risdate" : [ "2015" ],
+                "volume" : [ "62" ],
+                "oa" : [ "free_for_read" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2015" ],
                 "creatorcontrib" : [ "Kumar, Sandeep", "Kumari, Rajani", "Sharma, Vivek Kumar" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "Engineering optimization problems", "fission-fusion social structure", "Nature Inspired Algorithms", "Swarm intelligence", "Spider Monkey Optimization Algorithm" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "ScienceDirect Open Access Titles", "Elsevier:ScienceDirect:Open Access", "CrossRef" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-13717-d8daa60802f6b983fbeceb5cddc434894041080d598ad47d8b29e62f858b60923" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Procedia computer science" ]
+                "jtitle" : [ "Procedia computer science" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -541,7 +541,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:08&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-elsevier_cross&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Fitness+Based+Position+Update+in+Spider+Monkey+Optimization+Algorithm&rft.jtitle=Procedia+computer+science&rft.au=Kumar%2C+Sandeep&rft.date=2015&rft.volume=62&rft.spage=442&rft.epage=449&rft.pages=442-449&rft.issn=1877-0509&rft.eissn=1877-0509&rft_id=info:doi/10.1016%2Fj.procs.2015.08.504&rft.pub=Elsevier+B.V&rft_dat=<elsevier_cross>S1877050915026393</elsevier_cross>&svc_dat=viewit"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -552,38 +552,74 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_crossref_primary_10_1016_j_procs_2015_08_504"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_crossref_primary_10_1016_j_procs_2015_08_504"
           }, {
             "pnx" : {
               "sort" : {
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
                 "creationdate" : [ "201705" ],
-                "author" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ]
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ]
               },
               "control" : {
-                "sourcetype" : [ "Aggregation Database" ],
-                "sourceformat" : [ "XML" ],
-                "sourcesystem" : [ "Other" ],
-                "galeid" : [ "A491502847" ],
-                "recordid" : [ "cdi_gale_infotracacademiconefile_A491502847" ],
+                "recordid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A491502847" ],
                 "sourcerecordid" : [ "A491502847" ],
                 "originalsourceid" : [ "FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "recordtype" : [ "article" ],
                 "addsrcrecordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
+                "sourcetype" : [ "Aggregation Database" ],
+                "sourceformat" : [ "XML" ],
+                "sourcesystem" : [ "Other" ],
                 "sourceid" : [ "gale_wiley" ],
-                "score" : [ "0.06524757" ]
+                "galeid" : [ "A491502847" ],
+                "score" : [ "0.06524965" ]
+              },
+              "links" : {
+                "openurlfulltext" : [ "$$Topenurlfull_article" ],
+                "openurl" : [ "$$Topenurl_article" ],
+                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
+              },
+              "search" : {
+                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
+                "creationdate" : [ "2017" ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
+                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
+                "recordtype" : [ "article" ],
+                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "rsrctype" : [ "article" ],
+                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
+                "issn" : [ "0824-7935", "1467-8640" ],
+                "fulltext" : [ "true" ],
+                "general" : [ "Wiley Subscription Services, Inc" ],
+                "startdate" : [ "201705" ],
+                "enddate" : [ "201705" ],
+                "scope" : [ "BSHEE" ]
+              },
+              "display" : {
+                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
+                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "language" : [ "eng" ],
+                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
+                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
+                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
+                "publisher" : [ "Wiley Subscription Services, Inc" ],
+                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
+                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
+                "rights" : [ "2016 Wiley Periodicals, Inc.", "COPYRIGHT 2017 Blackwell Publishers Ltd." ],
+                "snippet" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm..." ],
+                "type" : [ "article" ],
+                "lds50" : [ "peer_reviewed" ]
+              },
+              "delivery" : {
+                "fulltext" : [ "fulltext" ],
+                "delcategory" : [ "Remote Search Resource" ]
               },
               "addata" : {
-                "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
-                "issn" : [ "0824-7935" ],
+                "format" : [ "journal" ],
                 "jtitle" : [ "Computational intelligence" ],
                 "genre" : [ "article" ],
-                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "date" : [ "2017-05" ],
-                "risdate" : [ "2017" ],
-                "volume" : [ "33" ],
-                "issue" : [ "2" ],
+                "issn" : [ "0824-7935" ],
+                "abstract" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ],
                 "spage" : [ "210" ],
                 "epage" : [ "240" ],
                 "pages" : [ "210-240" ],
@@ -591,62 +627,26 @@ http_interactions:
                 "ristype" : [ "JOUR" ],
                 "pub" : [ "Wiley Subscription Services, Inc" ],
                 "doi" : [ "10.1111/coin.12081" ],
-                "tpages" : [ "31" ],
-                "format" : [ "journal" ]
-              },
-              "links" : {
-                "openurl" : [ "$$Topenurl_article" ],
-                "openurlfulltext" : [ "$$Topenurlfull_article" ],
-                "thumbnail" : [ "$$Usyndetics_thumb_exl" ]
-              },
-              "search" : {
-                "creator" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
-                "recordid" : [ "eNpVUMtOwzAQtBBIlMKFL_APpPiVxDlGFY9KhQqVniPbsVtDYkdOeIQf4LdxWy7sHna1uzOaHQCuMZrhGDfKWzfDBHF8AiaYZXnCM4ZOwQRxwpK8oOk5uOj7V4QQpoxPwM-i7YL_sG4Lh52GS69EA9daBLWDpbSNHUboDVx3ttYBPnr3pke46gbb2m8xWO9g2Wx9sMOuhZt-T_P8LuoQVwqWXaT-su3xzvgAN0551w9BWKfrfzSX4MyIptdXf3UKNne3L_OHZLm6X8zLZbKXy5NCcpXrOpNUZoaRDJtacJQWGEtJeKYZkVkhC6OwyVOTplJzY0hKhS4QQZTSKZgdebei0ZV1xkc1KmatWxvFaWPjvGQFThHhLI8AfAR8xsVYdSH-E8YKo2pveLU3vDoYXs1Xi6dDR38Bikl5KQ" ],
-                "recordtype" : [ "article" ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization", "Computational intelligence" ],
-                "creationdate" : [ "2017" ],
-                "scope" : [ "BSHEE" ],
-                "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "issn" : [ "0824-7935", "1467-8640" ],
-                "fulltext" : [ "true" ],
-                "general" : [ "Wiley Subscription Services, Inc" ],
-                "rsrctype" : [ "article" ],
-                "startdate" : [ "201705" ],
-                "enddate" : [ "201705" ],
-                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
-              },
-              "display" : {
-                "lds50" : [ "peer_reviewed" ],
-                "type" : [ "article" ],
-                "source" : [ "Academic Search Complete", "Business Source Complete", "Wiley Online Library Full Collection 2016", "Alma/SFX Local Collection", "Applied Science & Technology Source", "Wiley Online Library Journals + OA Offset 2015-2017", "Wiley Online Library All Journals" ],
-                "creator" : [ "Gupta, Kavita ; Deep, Kusum ; Bansal, Jagdish Chand" ],
-                "publisher" : [ "Wiley Subscription Services, Inc" ],
-                "ispartof" : [ "Computational intelligence, 2017-05, Vol.33 (2), p.210-240" ],
-                "identifier" : [ "ISSN: 0824-7935", "EISSN: 1467-8640", "DOI: 10.1111/coin.12081" ],
-                "subject" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization ; Lennard–Jones problem ; Usage ; Monkeys ; Algorithms ; Mathematical optimization" ],
-                "language" : [ "eng" ],
-                "rights" : [ "2016 Wiley Periodicals, Inc.", "COPYRIGHT 2017 Blackwell Publishers Ltd." ],
-                "snippet" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm..." ],
-                "title" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
-                "description" : [ "Spider monkey optimization (SMO) algorithm, which simulates the food searching behavior of a swarm of spider monkeys, is a new addition to the class of swarm intelligent techniques for solving unconstrained optimization problems. The purpose of this article is to study the performance of SMO after incorporating quadratic approximation (QA) operator in it. The proposed version is named as QA‐based spider monkey optimization (QASMO). An experimental study has been carried out to check the validity and applicability of QASMO. For validation purpose, the performance of QASMO is tested over a benchmark set of 46 scalable and nonscalable problems, and results are compared with the original SMO algorithm. In order to test the applicability of the proposed algorithm in solving real‐life optimization problems, one of the most challenging optimization problems, namely, Lennard–Jones (LJ) problem is considered. LJ clusters containing atoms from three to ten have been taken into consideration, and results are presented. To the best of our knowledge, this is the first attempt to apply SMO and its proposed variant on a real‐life problem. The results demonstrate that incorporation of QA in SMO has positive effects on its performance in terms of reliability, efficiency, and accuracy." ]
-              },
-              "delivery" : {
-                "fulltext" : [ "fulltext" ],
-                "delcategory" : [ "Remote Search Resource" ]
+                "au" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
+                "atitle" : [ "Improving the Local Search Ability of Spider Monkey Optimization Algorithm Using Quadratic Approximation for Unconstrained Optimization" ],
+                "date" : [ "2017-05" ],
+                "risdate" : [ "2017" ],
+                "volume" : [ "33" ],
+                "issue" : [ "2" ],
+                "tpages" : [ "31" ]
               },
               "facets" : {
-                "language" : [ "eng" ],
                 "creationdate" : [ "2017" ],
                 "creatorcontrib" : [ "Gupta, Kavita", "Deep, Kusum", "Bansal, Jagdish Chand" ],
-                "rsrctype" : [ "articles" ],
                 "topic" : [ "spider monkey optimization, quadratic approximation, swarm intelligent techniques, unconstrained optimization, global optimization", "Lennard–Jones problem", "Usage", "Monkeys", "Algorithms", "Mathematical optimization" ],
                 "prefilter" : [ "articles" ],
+                "rsrctype" : [ "articles" ],
                 "collection" : [ "Academic OneFile (A&I only)" ],
                 "toplevel" : [ "peer_reviewed", "online_resources" ],
-                "frbrgroupid" : [ "cdi_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
+                "frbrgroupid" : [ "FAKE_PRIMO_ARTICLE_SCOPE_FETCH-LOGICAL-13488-9b8c7ed6b3b6f4261fda805911bb286e42b69b9fc1f75f55be8ff253ae9020333" ],
                 "frbrtype" : [ "5" ],
-                "jtitle" : [ "Computational intelligence" ]
+                "jtitle" : [ "Computational intelligence" ],
+                "language" : [ "eng" ]
               }
             },
             "delivery" : {
@@ -664,7 +664,7 @@ http_interactions:
               "feDisplayOtherLocations" : false,
               "displayedAvailability" : "true",
               "holding" : [ ],
-              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-17 11:07:39&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
+              "almaOpenurl" : "https://na06.alma.exlibrisgroup.com/view/uresolver/01MIT_INST/openurl?ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:08&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-gale_wiley&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Improving+the+Local+Search+Ability+of+Spider+Monkey+Optimization+Algorithm+Using+Quadratic+Approximation+for+Unconstrained+Optimization&rft.jtitle=Computational+intelligence&rft.au=Gupta%2C+Kavita&rft.date=2017-05&rft.volume=33&rft.issue=2&rft.spage=210&rft.epage=240&rft.pages=210-240&rft.issn=0824-7935&rft.eissn=1467-8640&rft_id=info:doi/10.1111%2Fcoin.12081&rft.pub=Wiley+Subscription+Services%2C+Inc&rft_dat=<gale_wiley>A491502847</gale_wiley>&svc_dat=viewit&rft_galeid=A491502847"
             },
             "context" : "PC",
             "adaptor" : "Primo Central",
@@ -675,17 +675,17 @@ http_interactions:
               },
               "timesCited" : { }
             },
-            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/cdi_gale_infotracacademiconefile_A491502847"
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/PC/FAKE_PRIMO_ARTICLE_SCOPE_gale_infotracacademiconefile_A491502847"
           } ],
           "timelog" : {
-            "PC_SEARCH_CALL_TIME" : "451",
-            "PC_BUILD_JSON_AND_HIGLIGHTS" : "42",
-            "PC_SEARCH_TIME_TOTAL" : "493",
-            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
-            "BUILD_COMBINED_RESULTS_MAP" : 494,
-            "COMBINED_SEARCH_TIME" : 501,
+            "PC_SEARCH_CALL_TIME" : "497",
+            "PC_BUILD_JSON_AND_HIGLIGHTS" : "48",
+            "PC_SEARCH_TIME_TOTAL" : "545",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 1,
+            "BUILD_COMBINED_RESULTS_MAP" : 547,
+            "COMBINED_SEARCH_TIME" : 553,
             "PROCESS_COMBINED_RESULTS" : 0,
-            "FEATURED_SEARCH_TIME" : 1
+            "FEATURED_SEARCH_TIME" : 2
           },
           "facets" : [ {
             "name" : "jtitle",
@@ -756,6 +756,9 @@ http_interactions:
               "value" : "Computer Science",
               "count" : "15"
             }, {
+              "value" : "Optimierungsalgorithmus",
+              "count" : "15"
+            }, {
               "value" : "Optimization Algorithms",
               "count" : "14"
             }, {
@@ -763,9 +766,6 @@ http_interactions:
               "count" : "14"
             }, {
               "value" : "Engineering, Electrical & Electronic",
-              "count" : "13"
-            }, {
-              "value" : "Optimierungsalgorithmus",
               "count" : "13"
             }, {
               "value" : "Analysis",
@@ -913,12 +913,12 @@ http_interactions:
               "count" : "12"
             }, {
               "value" : "2020",
-              "count" : "20"
+              "count" : "19"
             }, {
               "value" : "2021",
               "count" : "15"
             } ]
           } ]
         }
-  recorded_at: Mon, 17 May 2021 15:07:39 GMT
+  recorded_at: Wed, 19 May 2021 14:51:08 GMT
 recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### Why these changes are being introduced:

The 'view more books' and 'view more articles' links don't work properly
because the tab and scopes we use in Bento aren't enabled in the Primo
UI. Darcy, Adam Shire, and I discussed the problem and decided to continue
using the 'bento' tab, but enable the 'cdi' search scope in Primo, and
use a 'catalog' scope for local results instead of Alma.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2055

#### How this addresses that need:

* Removes hardcoding of search scopes and tabs in anticipation of
potential future name changes.
* Updates hardcoded scope names in the app where necessary.
* Adds PRIMO_MAIN_VIEW_TAB ENV variable, corresponding to Primo UI tab.
* Adds PRIMO_TAB ENV variable, corresponding to Bento tab.
* Changes existing Primo API ENV variables to more closely reflect their
actual functions (e.g., PRIMO_SEARCH_API_URL becomes PRIMO_API_URL), and
updates the SearchPrimo article accordingly. This will help clarify the
purpose of ENV variables when we start using additional Ex Libris APIs.

#### Side effects of this change:

* Regenerated all cassettes needed for Primo testing and updated tests
as needed.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
