### PR TITLE
IMP-2072 Change author links to regular searches

### DIFF
--- a/app/models/normalize_primo_common.rb
+++ b/app/models/normalize_primo_common.rb
@@ -55,8 +55,9 @@ class NormalizePrimoCommon
   end
 
   def author_link(author)
-    [ENV['MIT_PRIMO_URL'], '/discovery/browse?browseQuery=', 
-     author, '&browseScope=author&vid=', ENV['PRIMO_VID']].join('')
+    [ENV['MIT_PRIMO_URL'], '/discovery/search?query=creator,exact,', 
+     author, '&tab=', ENV['PRIMO_MAIN_VIEW_TAB'], '&search_scope=all&vid=', 
+     ENV['PRIMO_VID']].join('')
   end
 
   def year

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   ENV['PRIMO_TAB'] = 'FAKE_PRIMO_TAB'
   ENV['PRIMO_BOOK_SCOPE'] = 'FAKE_PRIMO_BOOK_SCOPE'
   ENV['PRIMO_ARTICLE_SCOPE'] = 'FAKE_PRIMO_ARTICLE_SCOPE'
+  ENV['PRIMO_MAIN_VIEW_TAB'] = 'all'
   ENV['MIT_PRIMO_URL'] = 'https://mit.primo.exlibrisgroup.com'
   ENV['SYNDETICS_PRIMO_URL'] = 'https://syndetics.com/index.php?client=primo'
 

--- a/test/models/normalize_primo_test.rb
+++ b/test/models/normalize_primo_test.rb
@@ -79,7 +79,7 @@ class NormalizePrimoTest < ActiveSupport::TestCase
     result = popcorn['results'].first
     assert_not_equal "Rudolph, J.$$QRudolph, J.", result.authors.first.first
     assert_equal ["Rudolph, J.",
-                  "https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Rudolph, J.&browseScope=author&vid=FAKE_PRIMO_VID"],
+                  "https://mit.primo.exlibrisgroup.com/discovery/search?query=creator,exact,Rudolph, J.&tab=all&search_scope=all&vid=FAKE_PRIMO_VID"],
                  result.authors.first
   end
 
@@ -87,10 +87,10 @@ class NormalizePrimoTest < ActiveSupport::TestCase
     result = monkeys['results'].second
     assert_not_equal ['Beran, Michael J ; Smith, J. David'], result.authors.first.first
     assert_equal ['Beran, Michael J',
-                  'https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Beran, Michael J&browseScope=author&vid=FAKE_PRIMO_VID'],
+                  'https://mit.primo.exlibrisgroup.com/discovery/search?query=creator,exact,Beran, Michael J&tab=all&search_scope=all&vid=FAKE_PRIMO_VID'],
                  result.authors.first
     assert_equal ['Smith, J. David',
-                  'https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Smith, J. David&browseScope=author&vid=FAKE_PRIMO_VID'],
+                  'https://mit.primo.exlibrisgroup.com/discovery/search?query=creator,exact,Smith, J. David&tab=all&search_scope=all&vid=FAKE_PRIMO_VID'],
                  result.authors.second
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

Primo browse search does not include CDI results, which will be
confusing for Bento author links, especially when clicking an author link
on a CDI record.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2072

#### How this addresses that need:

This reverts back to using regular Primo searches instead of browse
searches for author links.

#### Side effects of this change:

We are using the `exact` operator instead of `contains`, so the linked
search will include fewer results (but will be more accurate).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
