### PR TITLE
IMP-2093 Display record-level real-time availability

### DIFF
--- a/app/assets/stylesheets/_results.scss
+++ b/app/assets/stylesheets/_results.scss
@@ -131,6 +131,12 @@
   .realtime_status {
     font-size: $fs-xsmall;
   }
+
+  .realtime-primo {
+    padding-bottom: 5px;
+    font-size: 1.4rem;
+    text-indent: .5rem;
+  }
 }
 
 

--- a/app/models/normalize_primo_books.rb
+++ b/app/models/normalize_primo_books.rb
@@ -11,6 +11,7 @@ class NormalizePrimoBooks
     result.location = location
     result.subjects = subjects
     result.openurl = openurl
+    result.availability_status = availability_status
     result
   end
 
@@ -59,6 +60,13 @@ class NormalizePrimoBooks
       [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=', 
        ENV['EXL_INST_ID'], '&vid=', ENV['PRIMO_VID'], '&rft.mms_id=', mms_id,
        '&u.ignore_date_coverage=true'].join('')
+    end
+  end
+
+  def availability_status
+    return unless @record['delivery']['holding']
+    @record['delivery']['holding'].map do |loc|
+      loc['availabilityStatus']
     end
   end
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -4,7 +4,7 @@ class Result
   validates :title, presence: true
   validates :url, presence: true
 
-  attr_accessor :an, :authors, :available_url, :blurb, :check_sfx_url,
+  attr_accessor :an, :authors, :availability_status, :available_url, :blurb, :check_sfx_url,
                 :citation, :date_range, :db_source, :fulltext_links,
                 :get_it_label, :in, :location, :marc_856, :online, :openurl,
                 :physical_description, :publisher, :record_links, :subjects,
@@ -152,5 +152,13 @@ class Result
 
   def alma_record?
     an.present? && an.start_with?('alma') ? true : false
+  end
+
+  def available?
+    self.availability_status.any? { |status| status == 'available' }
+  end
+
+  def check_holdings?
+    self.availability_status.any? { |status| status == 'check_holdings' }
   end
 end

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -91,7 +91,30 @@
     <% end %>
   </div>
 
-  <% if result.location.present? %>
+  <% if result.location.present? && params[:target] == ENV['PRIMO_BOOK_SCOPE'] %>
+    <div id="<%= result.clean_an %>" class="result-local-locations">
+      <div class="realtime-primo">
+        <% if result.available? %>
+          <i class="fa fa-check" aria-hidden="true"></i>
+          <span> Available in library</span>
+        <% elsif result.check_holdings? %>
+          <i class="fa fa-question" aria-hidden="true"></i>
+          <span> May be available in library</span>
+        <% else %>
+          <i class="fa fa-times" aria-hidden="true"></i>
+          <span> Not currently available in library</span>
+        <% end %>
+      </div>
+      <p class="sr">Library locations: </p>
+      <ul class="list-local-locations">
+      <% result.location.each do |location| %>
+        <li class="result-local-location">
+          <%= location[0] %>: <%= location[1] %>
+        </li>
+      <% end %>
+      </ul>
+    </div>
+  <% elsif result.location.present? %>
     <div id="stale_locations_<%= result.clean_an %>" class="result-local-locations">
       <p class="sr">Library locations: </p>
       <ul class="list-local-locations">

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -25,6 +25,8 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
   end
 
   def physical_book
+    #Note that the availabilityStatus field in the this result has been 
+    # changed from 'available' to 'unavailable'
     VCR.use_cassette('physical book primo', 
                      allow_playback_repeats: true) do
       raw_query = SearchPrimo.new.search('Chʻomsŭkʻi, kkŭt ŏmnŭn tojŏn', 
@@ -111,5 +113,18 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
     result = physical_book['results'].first
     assert_nothing_raised { result.url }
     assert_nil result.openurl
+  end
+
+  test 'extracts availabilty status as expected' do
+    available_result = multi_location['results'].first
+    unavailable_result = physical_book['results'].first
+    assert_equal ['available', 'check_holdings'], available_result.availability_status
+    assert_equal ['unavailable'], unavailable_result.availability_status
+  end
+
+  test 'handles results without availability status' do
+    result = missing_fields_books['results'].first
+    assert_nothing_raised { result.availability_status }
+    assert_nil result.availability_status
   end
 end

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -255,4 +255,23 @@ class ResultTest < ActiveSupport::TestCase
     r = Result.new('title', 'http://example.com')
     assert_nil r.getit_url
   end
+
+  test 'Availabilty is evaluated as expected' do
+    r = Result.new('title', 'http://example.com')
+    r.availability_status = ['available']
+    assert r.available?
+
+    r.availability_status = ['available', 'unavailable']
+    assert r.available?
+
+    r.availability_status = ['unavailable']
+    assert_not r.available?
+
+    r.availability_status = ['foo']
+    assert_not r.available?
+
+    r.availability_status = ['check_holdings']
+    assert_not r.available?
+    assert r.check_holdings?
+  end
 end

--- a/test/vcr_cassettes/physical_book_primo.yml
+++ b/test/vcr_cassettes/physical_book_primo.yml
@@ -155,7 +155,7 @@ http_interactions:
                 "isValidUser" : true,
                 "organization" : "01MIT_INST",
                 "libraryCode" : "LSA",
-                "availabilityStatus" : "available",
+                "availabilityStatus" : "unavailable",
                 "subLocation" : "Off Campus Collection",
                 "subLocationCode" : "OCC",
                 "mainLocation" : "Library Storage Annex",


### PR DESCRIPTION
#### Why these changes are being introduced:

Our original plan was to use the Alma Bib API for RTA, but we are
considering whether a more lightweight option using the Primo Search API
is viable. This scaled back version of RTA will tell users whether any
physical copy is available for a given result.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2093

#### How this addresses that need:

* Updates the normalize_primo_books model to pull availability status
from catalog records and pass it into the result model.
* Adds availability? method to the result model that determines whether
any copies of a result are available for checkout.
* Adds check_holdings? method to the result model, which corresponds
with partial/unclear availability (e.g., one or more volumes is checked
out).
* Updates result view to display availability status.

#### Side effects of this change:

Minor CSS changes to clean up display of the new data.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
