### PR TITLE
Implement revised UI for Primo real-time availability

### DIFF
--- a/app/assets/stylesheets/_results.scss
+++ b/app/assets/stylesheets/_results.scss
@@ -133,9 +133,24 @@
   }
 
   .realtime-primo {
+    display:  flex;
+    justify-content:  space-between;
     padding-bottom: 5px;
     font-size: 1.4rem;
     text-indent: .5rem;
+
+    .location-info {
+      text-indent:  0;
+      padding-left: .5rem;
+    }
+
+    td .fa {
+      vertical-align: top;
+    }
+
+    .fa-question {
+      color: #FF7700;
+    }
   }
 }
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -4,11 +4,12 @@ class Result
   validates :title, presence: true
   validates :url, presence: true
 
-  attr_accessor :an, :authors, :availability_status, :available_url, :blurb, :check_sfx_url,
-                :citation, :date_range, :db_source, :fulltext_links,
-                :get_it_label, :in, :location, :marc_856, :online, :openurl,
-                :physical_description, :publisher, :record_links, :subjects,
-                :thumbnail, :title, :type, :uniform_title, :url, :winner, :year
+  attr_accessor :an, :authors, :availability, :available_url, :blurb, 
+                :check_sfx_url, :citation, :date_range, :db_source, 
+                :fulltext_links, :get_it_label, :in, :location, :marc_856, 
+                :online, :openurl, :other_availability, :physical_description, 
+                :publisher, :record_links, :subjects, :thumbnail, :title, 
+                :type, :uniform_title, :url, :winner, :year
 
   MAX_TITLE_LENGTH = ENV['MAX_TITLE_LENGTH'] || 150
 
@@ -152,13 +153,5 @@ class Result
 
   def alma_record?
     an.present? && an.start_with?('alma') ? true : false
-  end
-
-  def available?
-    self.availability_status.any? { |status| status == 'available' }
-  end
-
-  def check_holdings?
-    self.availability_status.any? { |status| status == 'check_holdings' }
   end
 end

--- a/app/views/search/_primo_rta.html.erb
+++ b/app/views/search/_primo_rta.html.erb
@@ -1,0 +1,21 @@
+<div id="<%= result.clean_an %>" class="result-local-locations">
+  <div class="realtime-primo">
+    <% if result.availability == 'available' %>
+      <i class="fa fa-check" aria-hidden="true"></i>
+      <p class="location-info">Available in <%= result.location[0] %> 
+        (<%= result.location[1] %>) <%= "and other locations" if 
+        result.other_availability %> - 
+        <%= link_to 'check options', full_record_link(result) %></p>
+    <% elsif result.availability == 'check_holdings' %>
+      <i class="fa fa-question" aria-hidden="true"></i>
+      <p class="location-info">May be available in <%= result.location[0] %> 
+        (<%= result.location[1] %>) - 
+        <%= link_to 'check options', full_record_link(result) %></p>
+    <% else %>
+      <i class="fa fa-times" aria-hidden="true"></i>
+      <p class="location-info">Not currently available in <%= result.location[0] %> 
+        (<%= result.location[1] %>) - 
+        <%= link_to 'check options', full_record_link(result) %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search/_result.html.erb
+++ b/app/views/search/_result.html.erb
@@ -92,28 +92,7 @@
   </div>
 
   <% if result.location.present? && params[:target] == ENV['PRIMO_BOOK_SCOPE'] %>
-    <div id="<%= result.clean_an %>" class="result-local-locations">
-      <div class="realtime-primo">
-        <% if result.available? %>
-          <i class="fa fa-check" aria-hidden="true"></i>
-          <span> Available in library</span>
-        <% elsif result.check_holdings? %>
-          <i class="fa fa-question" aria-hidden="true"></i>
-          <span> May be available in library</span>
-        <% else %>
-          <i class="fa fa-times" aria-hidden="true"></i>
-          <span> Not currently available in library</span>
-        <% end %>
-      </div>
-      <p class="sr">Library locations: </p>
-      <ul class="list-local-locations">
-      <% result.location.each do |location| %>
-        <li class="result-local-location">
-          <%= location[0] %>: <%= location[1] %>
-        </li>
-      <% end %>
-      </ul>
-    </div>
+    <%= render partial: "primo_rta", locals: { result: result } %>
   <% elsif result.location.present? %>
     <div id="stale_locations_<%= result.clean_an %>" class="result-local-locations">
       <p class="sr">Library locations: </p>

--- a/test/models/result_test.rb
+++ b/test/models/result_test.rb
@@ -255,23 +255,4 @@ class ResultTest < ActiveSupport::TestCase
     r = Result.new('title', 'http://example.com')
     assert_nil r.getit_url
   end
-
-  test 'Availabilty is evaluated as expected' do
-    r = Result.new('title', 'http://example.com')
-    r.availability_status = ['available']
-    assert r.available?
-
-    r.availability_status = ['available', 'unavailable']
-    assert r.available?
-
-    r.availability_status = ['unavailable']
-    assert_not r.available?
-
-    r.availability_status = ['foo']
-    assert_not r.available?
-
-    r.availability_status = ['check_holdings']
-    assert_not r.available?
-    assert r.check_holdings?
-  end
 end

--- a/test/vcr_cassettes/multi_available_book_primo.yml
+++ b/test/vcr_cassettes/multi_available_book_primo.yml
@@ -1,0 +1,1020 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,chomsky%20lyons&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - api-na.hosted.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Vary:
+      - accept-encoding
+      X-Exl-Api-Remaining:
+      - '549942'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,POST,DELETE,PUT,OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 04 Jun 2021 20:50:05 GMT
+      Server:
+      - CA-API-Gateway/9.0
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "info" : {
+            "totalResultsLocal" : 6,
+            "totalResultsPC" : -1,
+            "total" : 6,
+            "first" : 1,
+            "last" : 5
+          },
+          "highlights" : {
+            "general" : [ "Lyon" ],
+            "creator" : [ "Lyons" ],
+            "contributor" : [ "Lyons" ],
+            "lds09" : [ "Lyon" ],
+            "subject" : [ "Chomsky" ],
+            "toc" : [ "Chomsky", "Lyons" ],
+            "description" : [ "Lyons" ],
+            "title" : [ "Chomsky" ],
+            "termsUnion" : [ "Lyon", "Lyons", "Chomsky" ]
+          },
+          "docs" : [ {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990000523650206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Chomsky " ],
+                "subject" : [ "Chomsky, Noam", "Linguistics -- Research", "Generative grammar" ],
+                "format" : [ "184 p. ; 23 cm." ],
+                "identifier" : [ "$$CLC$$V   78303691;$$CISBN$$V0855276908 :;$$COCLC$$V(OCoLC)03613511" ],
+                "creationdate" : [ "1977" ],
+                "lds07" : [ "03613511    78303691 0855276908 :" ],
+                "lds09" : [ "Hassocks [Eng.] : Harvester Press,    1977   enk" ],
+                "lds10" : [ "Bibliography: p. 176-181." ],
+                "creator" : [ "Lyons, John, 1932-2020.$$QLyons, John" ],
+                "publisher" : [ "Hassocks Eng. : Harvester Press" ],
+                "mms" : [ "990000523650206761" ],
+                "edition" : [ "2d ed." ],
+                "place" : [ "Hassocks Eng.] :" ],
+                "version" : [ "2" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990000523650206761" ],
+                "recordid" : [ "alma990000523650206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "000052365-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "0.3110416" ]
+              },
+              "addata" : {
+                "aulast" : [ "Lyons" ],
+                "aufirst" : [ "John" ],
+                "auinit" : [ "J" ],
+                "au" : [ "Lyons, John" ],
+                "date" : [ "1977" ],
+                "isbn" : [ "0855276908" ],
+                "notes" : [ "Bibliography: p. 176-181." ],
+                "cop" : [ "Hassocks [Eng" ],
+                "pub" : [ "Harvester Press" ],
+                "oclcid" : [ "(mcm)52365", "(mcm)52365mit01", "mitb10052365", "(ocolc)3613511", "glis52365" ],
+                "lccn" : [ "78303691" ],
+                "edition" : [ "2d ed." ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Chomsky" ]
+              },
+              "sort" : {
+                "title" : [ "Chomsky / John Lyons." ],
+                "author" : [ "Lyons, John, 1932-2020." ],
+                "creationdate" : [ "1977" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "5" ],
+                "frbrgroupid" : [ "9074295209607163095" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P85.C548.L991 1977",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990000523650206761",
+                "holdId" : "2245676330006761",
+                "holKey" : "HoldingResultKey [mid=2245676330006761, libraryId=161684210006761, locationCode=STACK, callNumber=P85.C548.L991 1977]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P85.C548.L991 1977",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990000523650206761",
+                "holdId" : "2245676330006761",
+                "holKey" : "HoldingResultKey [mid=2245676330006761, libraryId=161684210006761, locationCode=STACK, callNumber=P85.C548.L991 1977]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              }, {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "LSA",
+                "availabilityStatus" : "available",
+                "subLocation" : "Off Campus Collection",
+                "subLocationCode" : "OCC",
+                "mainLocation" : "Library Storage Annex",
+                "callNumber" : "P85.C548.L991 1977",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990000523650206761",
+                "holdId" : "2245676370006761",
+                "holKey" : "HoldingResultKey [mid=2245676370006761, libraryId=161682860006761, locationCode=OCC, callNumber=P85.C548.L991 1977]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:1"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "available_in_library", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : true,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : true,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990000523650206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                }, {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990000523650206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:1"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0855276908,OCLC:,LCCN:78303691&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "http://FAKE_PRIMO_BOOK_SCOPE.hathitrust.org/api/volumes/oclc/3613511.html",
+                "displayLabel" : "Hathi Trust"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "P85.C548.L991 1977",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "p000000000085.c000000000548l000000000991000000001977",
+                "callNumberBrowseField" : "LOCAL_CL_09X"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990005193490206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Noam Chomsky." ],
+                "subject" : [ "Chomsky, Noam", "Linguists -- United States" ],
+                "format" : [ "xii, 143 p. illus. 20 cm." ],
+                "identifier" : [ "$$CLC$$V   73104148 //r87;$$CISBN$$V067051473X;$$COCLC$$V(OCoLC)00104474" ],
+                "creationdate" : [ "1970" ],
+                "lds07" : [ "P85.C47 00104474    73104148 //r87 067051473X" ],
+                "lds09" : [ "New York, Viking Press    1970   nyu" ],
+                "lds10" : [ "Bibliography: p. [135]-137." ],
+                "creator" : [ "Lyons, John, 1932-2020.$$QLyons, John" ],
+                "publisher" : [ "New York, Viking Press" ],
+                "mms" : [ "990005193490206761" ],
+                "series" : [ "Modern masters$$QModern masters", "Modern masters (New York, N.Y.)$$QModern masters (New York, N.Y.)" ],
+                "genre" : [ "Biography." ],
+                "place" : [ "New York," ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990005193490206761" ],
+                "recordid" : [ "alma990005193490206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "000519349-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "0.010820456" ]
+              },
+              "addata" : {
+                "aulast" : [ "Lyons" ],
+                "aufirst" : [ "John" ],
+                "auinit" : [ "J" ],
+                "au" : [ "Lyons, John" ],
+                "date" : [ "1970" ],
+                "isbn" : [ "067051473X" ],
+                "notes" : [ "Bibliography: p. [135]-137." ],
+                "cop" : [ "New York" ],
+                "pub" : [ "Viking Press" ],
+                "oclcid" : [ "(mcm)519349", "(mcm)519349mit01", "mitb10519349", "(ocolc)104474", "glis519349" ],
+                "lccn" : [ "73104148 //r87" ],
+                "seriestitle" : [ "Modern masters" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Noam Chomsky." ]
+              },
+              "sort" : {
+                "title" : [ "Noam Chomsky." ],
+                "author" : [ "Lyons, John, 1932-2020." ],
+                "creationdate" : [ "1970" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9004408189972816123" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ARC",
+                "availabilityStatus" : "available",
+                "subLocation" : "Noncirculating Collection 1",
+                "subLocationCode" : "NOLN1",
+                "mainLocation" : "Institute Archives",
+                "callNumber" : "P85.C47 L9 1970b",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990005193490206761",
+                "holdId" : "2238689010006761",
+                "holKey" : "HoldingResultKey [mid=2238689010006761, libraryId=161686860006761, locationCode=NOLN1, callNumber=P85.C47 L9 1970b]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ARC",
+                "availabilityStatus" : "available",
+                "subLocation" : "Noncirculating Collection 1",
+                "subLocationCode" : "NOLN1",
+                "mainLocation" : "Institute Archives",
+                "callNumber" : "P85.C47 L9 1970b",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990005193490206761",
+                "holdId" : "2238689010006761",
+                "holKey" : "HoldingResultKey [mid=2238689010006761, libraryId=161686860006761, locationCode=NOLN1, callNumber=P85.C47 L9 1970b]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              }, {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "LSA",
+                "availabilityStatus" : "available",
+                "subLocation" : "Off Campus Collection",
+                "subLocationCode" : "OCC",
+                "mainLocation" : "Library Storage Annex",
+                "callNumber" : "P85.C548.L991",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990005193490206761",
+                "holdId" : "2238689030006761",
+                "holKey" : "HoldingResultKey [mid=2238689030006761, libraryId=161682860006761, locationCode=OCC, callNumber=P85.C548.L991]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:1"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "available_in_library", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : true,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : true,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990005193490206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                }, {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990005193490206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:1"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:067051473X,OCLC:,LCCN:73104148&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "http://FAKE_PRIMO_BOOK_SCOPE.hathitrust.org/api/volumes/oclc/104474.html",
+                "displayLabel" : "Hathi Trust"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "P85.C47 L9 1970b",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "p!85 c47ǂl9 1970b 0",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990028242660206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Approaches to Intentionality." ],
+                "format" : [ "1 online resource" ],
+                "identifier" : [ "$$CISBN$$V9780198752226;$$CISBN$$V0198752229;$$COCLC$$V(OCoLC)1035791553" ],
+                "creationdate" : [ "Feb. 1998" ],
+                "lds07" : [ "153.8 1035791553 9780198752226 9780198752226 0198752229" ],
+                "lds09" : [ "New York : Oxford University Press, Incorporated    ncu" ],
+                "creator" : [ "Lyons, William, author.$$QLyons, William" ],
+                "publisher" : [ "New York : Oxford University Press, Incorporated" ],
+                "description" : [ "What is intentionality? Intentionality is a distinguishing characteristic of states of mind (such as beliefs, thoughts, wishes, dreams, and desires): that they are about things outside themselves. About this book: William Lyons explores various ways in which philosophers have tried to explain intentionality, and then suggests a new way. Part I of the book gives a critical account of the five most comprehensive and prominent current approaches to intentionality. These approaches can be summarised as the instrumentalist approach, derived from Carnap and Quine and culminating in the work of Daniel Dennett; the linguistic approach, derived from the work of Chomsky and exhibited most fully in the work of Jerry Fodor; the biological approach, developed by Ruth Garrett Millikan, Colin McGinn, and others; the information-processing approach which has been given a definitive form in the work of Fred Dretske; and the functional role approach of Brian Loar. In Part II, Professor Lyons sets out a multi-level, developmental approach to intentionality. Drawing upon work in neurophysiology and psychology, the author argues that intentionality is to be found, in different forms, at the levels of brain functioning, prelinguistic consciousness, language, and at the holistic level of `whole person performance' which is demarcated by our ordinary everyday talk about beliefs, desires, hopes, intentions, and the other `propositional attitudes'. Written in a direct, clear, and lively style, the extended survey of contemporary debate in Part I will be invaluable to the student of philosophy of mind or cognitive science as well as to the scholars and graduate students who will find an original new theory to contend with in Part II." ],
+                "mms" : [ "990028242660206761" ],
+                "dedupmemberids" : [ "9933132361006761" ],
+                "edition" : [ "Reprint." ],
+                "place" : [ "New York :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990028242660206761" ],
+                "recordid" : [ "alma990028242660206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002824266-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "9.5146673E-4" ]
+              },
+              "addata" : {
+                "aulast" : [ "Lyons" ],
+                "aufirst" : [ "William" ],
+                "auinit" : [ "W" ],
+                "au" : [ "Lyons, William" ],
+                "date" : [ "1998 - 0226", "Feb. 1998" ],
+                "isbn" : [ "9780198752226", "0198752229" ],
+                "abstract" : [ "What is intentionality? Intentionality is a distinguishing characteristic of states of mind (such as beliefs, thoughts, wishes, dreams, and desires): that they are about things outside themselves. About this book: William Lyons explores various ways in which philosophers have tried to explain intentionality, and then suggests a new way. Part I of the book gives a critical account of the five most comprehensive and prominent current approaches to intentionality. These approaches can be summarised as the instrumentalist approach, derived from Carnap and Quine and culminating in the work of Daniel Dennett; the linguistic approach, derived from the work of Chomsky and exhibited most fully in the work of Jerry Fodor; the biological approach, developed by Ruth Garrett Millikan, Colin McGinn, and others; the information-processing approach which has been given a definitive form in the work of Fred Dretske; and the functional role approach of Brian Loar. In Part II, Professor Lyons sets out a multi-level, developmental approach to intentionality. Drawing upon work in neurophysiology and psychology, the author argues that intentionality is to be found, in different forms, at the levels of brain functioning, prelinguistic consciousness, language, and at the holistic level of `whole person performance' which is demarcated by our ordinary everyday talk about beliefs, desires, hopes, intentions, and the other `propositional attitudes'. Written in a direct, clear, and lively style, the extended survey of contemporary debate in Part I will be invaluable to the student of philosophy of mind or cognitive science as well as to the scholars and graduate students who will find an original new theory to contend with in Part II." ],
+                "cop" : [ "New York" ],
+                "pub" : [ "Oxford University Press, Incorporated" ],
+                "oclcid" : [ "(mcm)2824266mit01", "(ocolc)1035791553" ],
+                "edition" : [ "Reprint." ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Approaches to Intentionality." ]
+              },
+              "sort" : {
+                "title" : [ "Approaches to Intentionality." ],
+                "author" : [ "Lyons, William, author." ],
+                "creationdate" : [ "1998" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9053082630735534342" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "NET",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "UNASSIGNED location",
+                "subLocationCode" : "UNASSIGNED",
+                "mainLocation" : "Internet Resource",
+                "callNumber" : "**See URL(s)",
+                "callNumberType" : "8",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028242660206761",
+                "holdId" : "2263127550006761",
+                "holKey" : "HoldingResultKey [mid=2263127550006761, libraryId=161683420006761, locationCode=UNASSIGNED, callNumber=**See URL(s)]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "NET",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "UNASSIGNED location",
+                "subLocationCode" : "UNASSIGNED",
+                "mainLocation" : "Internet Resource",
+                "callNumber" : "**See URL(s)",
+                "callNumberType" : "8",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028242660206761",
+                "holdId" : "2263127550006761",
+                "holKey" : "HoldingResultKey [mid=2263127550006761, libraryId=161683420006761, locationCode=UNASSIGNED, callNumber=**See URL(s)]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "check_holdings", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990028242660206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0198752229,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "https://www.oxfordscholarship.com/view/10.1093/acprof:oso/9780198752226.001.0001/acprof-9780198752226",
+                "displayLabel" : "$$Elinktorsrc"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "**See URL(s)",
+                "callNumberBrowseField" : "8"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "153.8",
+                "callNumberBrowseField" : "DEWEY_DECIMAL_CLASSIFICATION"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990023951670206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "fre" ],
+                "title" : [ "Arguments minimalistes : une présentation du Programme minimaliste de Noam Chomsky " ],
+                "subject" : [ "Chomsky, Noam", "Minimalist theory (Linguistics)" ],
+                "format" : [ "446 pages ; 23 cm." ],
+                "identifier" : [ "$$CISBN$$V9782847886832 (pbk.);$$CISBN$$V2847886834 (pbk.);$$COCLC$$V(OCoLC)945484734" ],
+                "creationdate" : [ "2015" ],
+                "lds07" : [ "P158.28.R68 2015 945484734 9782847886832 (pbk.) 2847886834 (pbk.)" ],
+                "lds09" : [ "Lyon : ENS éditions,  2015   fr" ],
+                "lds10" : [ "Includes bibliographical references (pages 421-434) and index." ],
+                "creator" : [ "Rouveret, Alain, author.$$QRouveret, Alain" ],
+                "publisher" : [ "Lyon : ENS éditions" ],
+                "mms" : [ "990023951670206761" ],
+                "series" : [ "Collection Langages$$QCollection Langages", "Langages (Lyon, France)$$QLangages (Lyon, France)" ],
+                "contents" : [ "1. Faculté de Langage -- Le langage est un objet du monde naturel -- Chomsky lecteur de Descartes et de Galilée -- Au-delà de l'adéquation explicative -- La thèse minimaliste forte -- La nécessité conceptuelle virtuelle -- Le facteur 3 -- Le problème de la variation -- 2. Architecture -- Conditions de design optimal -- Dérivations/représentations -- Le Lexique et la sélection lexicale -- Merge et Move -- Merge -- Move -- La préférence de Merge sur Move -- Spell-Out -- Un nouveau dispositif -- Spell-Out /Transfer cyclique -- LF/SEM -- 3. Traits et catégories -- La forme des items lexicaux -- Le Principe d'uniformité -- Quelques traits formels -- Les traits cp -- La personne et le nombre -- Le genre grammatical -- Catégories fonctionnelles -- Deux types de catégories -- La tête -- L'approche cartographique -- Présentation et objectifs -- La périphérie gauche -- Pourquoi les schémas cartographiques sont nécessaires -- L'interface syntaxe-morphologie -- Deux conceptions opposées -- Le Principe du miroir -- La Morphologie Distribuée -- La conception minimaliste -- 4. Structure syntagmatique -- De Syntactic Structures à Barriers -- Bare phrase structure IMerge -- Propriétés de la structure syntagmatique -- Caractérisation de Merge -- Labels et projections -- Autres instances de Merge -- Merge interne (mouvement) -- Merge de paire (adjonction) -- Merge parallèle (multidominance) -- La Condition d'extension -- Relations structurales basiques et dérivées -- Remarque sur la notion de gouvernement -- Conclusion -- 5. Étiquetage, linéarisation -- Étiquetage -- Un algorithme d'étiquetage -- Étiquetage par l'item lexical saillant -- La proposition de Donati et Cecchetto (2011) -- Linéarisation -- L'Axiome de correspondance linéaire -- Formulation du LCA -- Dérivation des propriétés de la théorie X-barre -- Adjoints et spécifieurs -- Réanalyses -- Problèmes -- Bare phrase structure et linéarisation -- Conclusion -- 6. Accord -- Pourquoi Agree? -- L'opération Agree : sondes, cibles, Condition d'activité -- L'accord sujet-verbe en français -- Légitimation casuelle des objets directs -- Complétude des sondes et des cibles -- La Condition de complétude -- Syntaxe des sujets dans les propositions infinitives -- Constructions à montée (raising structures) -- Constructions ECM (Exceptional Case marking, marquage casuel exceptionnel) -- Constructions à contrôle -- Le Temps défectif porte-t-il un trait [EPP]? -- Les constructions causatives et la défectivité de v -- Raffinements -- La Condition d'activité est-elle nécessaire? -- Intervention défective -- Les constructions à sujet explétif -- La construction existentielle en there -- Accord avec l'associé -- Composition en traits de there -- Absence d'effets d'intervention -- Sondes et cibles complètes et défectives -- Autres constructions explétives -- Le phénomène du sujet nul -- Les fonctions d'Agree -- Accord et sélection -- Accord et modification -- Accord syntaxique / accord morphologique -- 7.", "Mouvement -- Le mouvement est-il une imperfection? -- Le mouvement est une imperfection apparente -- Le mouvement n'est pas une imperfection -- La dualité de la sémantique -- Relations sémantiques et mouvement -- Une triple partition : interprétations, positions, stratégies -- Asymétrie des deux interfaces -- Le rôle de la morphologie -- Une conception téléologique du mouvement? -- Implémentation du mouvement -- Théorie du mouvement par copie -- Cyclicité et sous-jacence -- Intervention -- Condition d'uniformité des chaînes -- Mouvement A' -- Mouvement de tête -- Mouvement de tête et structure fonctionnelle -- Difficultés de l'approche syntaxique -- Analyses syntaxiques concurrentes -- Mouvement résiduel -- Mouvement phonologique -- Propriétés diagnostiques -- 8. Phases -- Trois arguments pour l'existence des phases -- La théorie des phases -- Difficultés -- Convergence -- Éclaircissements -- Le mouvement phasal -- Spell-Out / prononciation -- Statut phasal de vP et de DP -- Phases fortes / phases faibles -- Un vP généralisé? -- Les DP définissent-ils des phases? -- Les phases dans la théorie de la localité -- Le trait [EF] et le mouvement indirectement guidé par les traits -- Îlots forts -- Le cycle unique -- Extension de la théorie des phases : l'héritage de traits -- L'hypothèse de l'héritage -- Dérivation des constructions interrogatives -- La Condition du sujet -- L'héritage de traits dans le système C-T -- Héritage et nécessité conceptuelle -- Propriétés diagnostiques -- 9. Intervention -- Condition du lien minimal -- Formulation de la Minimal Link Condition -- Minimalité relativisée aux traits -- Îlots faibles -- La Contrainte de la personne et du cas -- Une çonception disjonctive de la localité -- Une unification impossible -- Agree, Move et la PIC -- 10. Processus silencieux -- Mouvement syntagmatique silencieux -- Localité des mouvements syntagmatiques silencieux -- Propositions minimalistes -- Mouvement silencieux, accord ou liage non sélectif? -- Dépendances référentielles -- Difficultés de l'approche classique -- Domaines locaux -- La théorie du liage en LF -- Reconstruction -- Liage anaphorique -- Traits impliqués dans le liage anaphorique -- Définition du domaine de liage -- Élimination de la Condition A -- Localité du liage anaphorique -- 11. Grammaire générative et minimalisme : permanences et mutations -- Le minimalisme est-il une révolution scientifique? -- Les innovations minimalistes -- Préférences -- Le syndrome du vaisseau Argo." ],
+                "place" : [ "Lyon :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990023951670206761" ],
+                "recordid" : [ "alma990023951670206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002395167-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "7.9520156E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Rouveret" ],
+                "aufirst" : [ "Alain" ],
+                "auinit" : [ "A" ],
+                "au" : [ "Rouveret, Alain" ],
+                "date" : [ "2015" ],
+                "isbn" : [ "9782847886832", "2847886834" ],
+                "notes" : [ "Includes bibliographical references (pages 421-434) and index." ],
+                "cop" : [ "Lyon" ],
+                "pub" : [ "ENS éditions" ],
+                "oclcid" : [ "(mcm)2395167mit01", "(ocolc)945484734" ],
+                "seriestitle" : [ "Collection Langages" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Arguments minimalistes : une présentation du Programme minimaliste de Noam Chomsky" ]
+              },
+              "sort" : {
+                "title" : [ "Arguments minimalistes : une présentation du Programme minimaliste de Noam Chomsky / Alain Rouveret." ],
+                "author" : [ "Rouveret, Alain, author." ],
+                "creationdate" : [ "2015" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9047313899768531315" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P158.28.R68 2015",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990023951670206761",
+                "holdId" : "227877880006761",
+                "holKey" : "HoldingResultKey [mid=227877880006761, libraryId=161684210006761, locationCode=STACK, callNumber=P158.28.R68 2015]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P158.28.R68 2015",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990023951670206761",
+                "holdId" : "227877880006761",
+                "holKey" : "HoldingResultKey [mid=227877880006761, libraryId=161684210006761, locationCode=STACK, callNumber=P158.28.R68 2015]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "available_in_library" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990023951670206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:2847886834,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "P158.28.R68 2015",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "p\"158.28 r68 2015",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990012623490206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Fuzzy grammar : a reader " ],
+                "subject" : [ "Relational grammar", "Grammar, Comparative and general" ],
+                "format" : [ "vii, 526 p. : ill. ; 25 cm." ],
+                "identifier" : [ "$$CISBN$$V019926256X;$$CISBN$$V0199262578 (pbk.) :;$$COCLC$$V(OCoLC)53156091" ],
+                "creationdate" : [ "2004" ],
+                "lds07" : [ "415 P158.6.F899 2004 53156091 019926256X 0199262578 (pbk.) :" ],
+                "lds09" : [ "Oxford ; Oxford University Press,    2004   enk" ],
+                "lds10" : [ "Includes bibliographical references and indexes." ],
+                "publisher" : [ "Oxford ; New York : Oxford University Press" ],
+                "mms" : [ "990012623490206761" ],
+                "contributor" : [ "Aarts, Bas, 1961-$$QAarts, Bas" ],
+                "contents" : [ "Introduction: The Nature of Grammatical Categories and their Representation -- Pt. I. Philosophical Background -- 1. Categories / Aristotle -- 2. Concepts / Gottlob Frege -- 3. Vagueness / Bertrand Russell -- 4. Family Resemblances / Ludwig Wittgenstein -- 5. The Phenomena of Vagueness / Rosanna Keefe -- Pt. II. Categories in Cognition -- 6. The Boundaries of Words and their Meanings / William Labov -- 7. Principles of Categorization / Eleanor Rosch -- 8. Categorizaton, Fuzziness, and Family Resemblances / Ray Jackendoff -- 9. Discreteness / Ronald W. Langacker -- 10. The Importance of Categorization / George Lakoff -- Pt. III. Categories in Grammar -- 11. Parts of Speech / Otto Jespersen -- 12. English Word Classes / David Crystal -- 13. A Notional Approach to the Parts of Speech / John Lyons -- 14. Syntactic Categories and Notional Features / John M. Anderson -- 15. Bounded Regions / Ronald W. Langacker -- 16. The Discourse Basis for Lexical Categories in Universal Grammar / Paul J. Hopper and Sandra A. Thompson -- 17. Grammatical Categories / John Taylor -- Pt. IV. Gradience in Grammar -- 18. Gradience / Dwight Bolinger -- 19. Degrees of Grammaticalness / Noam Chomsky -- 20. Descriptive Statement and Serial Relationship / Randolph Quirk -- 21. On the Analysis of Linguistic Vagueness / Jiri V. Neustupny -- 22. Nouniness / John Robert Ross -- 23. The Coordination-Subordination Gradient / Randolph Quirk, Sidney Greenbaum, Geoffrey Leech and Jan Svartvik -- 24. The Nature of Graded Judgments / Carson T. Schutze -- Pt. V. Criticisms and Responses -- 25. Description of Language Design / Martin Joos -- 26. 'Prototypes Save' / Anna Wierzbicka -- 27. Fuzziness and Categorization / Denis Bouchard -- 28. The Discrete Nature of Syntactic Categories: Against a Prototype-based Account / Frederick J. Newmeyer." ],
+                "place" : [ "Oxford ; New York :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990012623490206761" ],
+                "recordid" : [ "alma990012623490206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "001262349-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "1.03021885E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Aarts" ],
+                "aufirst" : [ "Bas" ],
+                "auinit" : [ "B" ],
+                "addau" : [ "Aarts, Bas" ],
+                "date" : [ "2004" ],
+                "isbn" : [ "019926256X", "0199262578" ],
+                "notes" : [ "Includes bibliographical references and indexes." ],
+                "cop" : [ "Oxford ;" ],
+                "pub" : [ "Oxford University Press" ],
+                "oclcid" : [ "(mcm)1262349mit01", "(ocolc)53156091" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Fuzzy grammar : a reader" ]
+              },
+              "sort" : {
+                "title" : [ "Fuzzy grammar : a reader / edited by Bas Aarts ... [et al.]." ],
+                "author" : [ "Aarts, Bas, 1961-" ],
+                "creationdate" : [ "2004" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9055918172470320464" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P158.6.F899 2004",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990012623490206761",
+                "holdId" : "2268993460006761",
+                "holKey" : "HoldingResultKey [mid=2268993460006761, libraryId=161684210006761, locationCode=STACK, callNumber=P158.6.F899 2004]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "P158.6.F899 2004",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990012623490206761",
+                "holdId" : "2268993460006761",
+                "holKey" : "HoldingResultKey [mid=2268993460006761, libraryId=161684210006761, locationCode=STACK, callNumber=P158.6.F899 2004]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "available_in_library" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990012623490206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:019926256X,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "P158.6.F899 2004",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "p\"158.6 f899 2004",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          } ],
+          "timelog" : {
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "149",
+            "CALL_SOLR_GET_IDS_LIST" : "329",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "276",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "46",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "2",
+            "RETRIVE_FROM_DB_RECORDS" : "45",
+            "RETRIVE_FROM_DB_RELATIONS" : "30",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "131",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "144",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "215",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "982",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
+            "BUILD_COMBINED_RESULTS_MAP" : 1039,
+            "COMBINED_SEARCH_TIME" : 1043,
+            "PROCESS_COMBINED_RESULTS" : 0,
+            "FEATURED_SEARCH_TIME" : 0
+          },
+          "facets" : [ ]
+        }
+  recorded_at: Fri, 04 Jun 2021 20:50:06 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/partially_available_book_primo.yml
+++ b/test/vcr_cassettes/partially_available_book_primo.yml
@@ -1,0 +1,769 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,works%20of%20michael%20de%20montaigne&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - api-na.hosted.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Vary:
+      - accept-encoding
+      X-Exl-Api-Remaining:
+      - '549966'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,POST,DELETE,PUT,OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 04 Jun 2021 20:16:14 GMT
+      Server:
+      - CA-API-Gateway/9.0
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "info" : {
+            "totalResultsLocal" : 4,
+            "totalResultsPC" : -1,
+            "total" : 4,
+            "first" : 1,
+            "last" : 4
+          },
+          "highlights" : {
+            "creator" : [ "Michael" ],
+            "contributor" : [ "Michael" ],
+            "toc" : [ "Montaigne", "Montaigne's", "Michael", "de" ],
+            "description" : [ "works", "Montaigne", "books" ],
+            "title" : [ "Works", "of Michael", "Michael", "de", "Montaigne" ],
+            "termsUnion" : [ "Michael", "Montaigne", "Montaigne's", "de", "works", "books", "Works", "of Michael" ]
+          },
+          "docs" : [ {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990005610540206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Works of Michael de Montaigne, comprising his essays, journey into Italy, and letters, with notes from all the commentators, biographical and bibliographical notices, etc." ],
+                "format" : [ "4 v. 19 cm." ],
+                "identifier" : [ "$$COCLC$$V(OCoLC)02301147" ],
+                "creationdate" : [ "1879 c1859" ],
+                "lds07" : [ "02301147" ],
+                "lds09" : [ "Boston, Houghton, Osgood,   1859   1879  1859   mau" ],
+                "creator" : [ "Montaigne, Michel de, 1533-1592.$$QMontaigne, Michel de" ],
+                "publisher" : [ "Boston, Houghton, Osgood" ],
+                "mms" : [ "990005610540206761" ],
+                "contributor" : [ "Hazlitt, William, 1778-1830.$$QHazlitt, William" ],
+                "place" : [ "Boston," ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990005610540206761" ],
+                "recordid" : [ "alma990005610540206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "000561054-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "1.425974E-4" ]
+              },
+              "addata" : {
+                "aulast" : [ "Montaigne" ],
+                "aufirst" : [ "Michel de" ],
+                "auinit" : [ "M" ],
+                "au" : [ "Montaigne, Michel de" ],
+                "addau" : [ "Hazlitt, William" ],
+                "date" : [ "1879 - 1859", "1879 c1859" ],
+                "cop" : [ "Boston" ],
+                "pub" : [ "Houghton, Osgood" ],
+                "oclcid" : [ "(mcm)561054", "(mcm)561054mit01", "mitb10561054", "(ocolc)2301147", "glis561054" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Works of Michael de Montaigne, comprising his essays, journey into Italy, and letters, with notes from all the commentators, biographical and bibliographical notices, etc." ]
+              },
+              "sort" : {
+                "title" : [ "Works of Michael de Montaigne, comprising his essays, journey into Italy, and letters, with notes from all the commentators, biographical and bibliographical notices, etc. By W. Hazlitt; a new and carefully rev. ed. Ed. by O. W. Wight." ],
+                "author" : [ "Montaigne, Michel de, 1533-1592." ],
+                "creationdate" : [ "1879" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9077687490227715757" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "LSA",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "Off Campus Collection",
+                "subLocationCode" : "OCC",
+                "mainLocation" : "Library Storage Annex",
+                "callNumber" : "PQ1642.E5.H431 1879",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990005610540206761",
+                "holdId" : "2223888750006761",
+                "holKey" : "HoldingResultKey [mid=2223888750006761, libraryId=161682860006761, locationCode=OCC, callNumber=PQ1642.E5.H431 1879]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "LSA",
+                "availabilityStatus" : "check_holdings",
+                "subLocation" : "Off Campus Collection",
+                "subLocationCode" : "OCC",
+                "mainLocation" : "Library Storage Annex",
+                "callNumber" : "PQ1642.E5.H431 1879",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990005610540206761",
+                "holdId" : "2223888750006761",
+                "holKey" : "HoldingResultKey [mid=2223888750006761, libraryId=161682860006761, locationCode=OCC, callNumber=PQ1642.E5.H431 1879]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "check_holdings" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990005610540206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "PQ1642.E5.H431 1879",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "pq000000001642.e000000000005.h000000000431000000001879",
+                "callNumberBrowseField" : "LOCAL_CL_09X"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990028178740206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Know-it-all society : truth and arrogance in political culture " ],
+                "subject" : [ "Information society -- Political aspects", "Polarization (Social sciences) -- Political aspects", "Social media -- Political aspects", "Internet -- Political aspects", "Identity politics", "Political culture" ],
+                "format" : [ "209 pages ; 22 cm" ],
+                "identifier" : [ "$$CLC$$V  2019014604;$$CISBN$$V9781631493614;$$CISBN$$V1631493612;$$COCLC$$V(OCoLC)1053997548;$$COCLC$$V(OCoLC)1110627469" ],
+                "creationdate" : [ "2019" ],
+                "lds07" : [ "302.23/1 HM851 1110627469 1053997548 1110627469   2019014604 9781631493614 1631493612" ],
+                "lds09" : [ "New York : Liveright Publishing Corporation,  2019   nyu" ],
+                "lds10" : [ "Includes bibliographical references and index." ],
+                "creator" : [ "Lynch, Michael P. (Michael Patrick), 1966- author.$$QLynch, Michael P." ],
+                "publisher" : [ "New York : Liveright Publishing Corporation" ],
+                "description" : [ "Examines how a growing culture of narcissism is behind the fragmented political landscapes of today, drawing on the works of classic philosophers to explain the essential role of truth and humility in democracy." ],
+                "mms" : [ "990028178740206761" ],
+                "edition" : [ "First edition." ],
+                "contents" : [ "Preamble: No ordinary question -- Montaigne's warning -- The outrage factory -- Where the spade turns -- Ideologies of arrogance and the American Right -- Liberalism and the philosophy of identity politics -- Truth and humility as democratic values." ],
+                "place" : [ "New York :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990028178740206761" ],
+                "recordid" : [ "alma990028178740206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002817874-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "7.406081E-7" ]
+              },
+              "addata" : {
+                "aulast" : [ "Lynch" ],
+                "aufirst" : [ "Michael P." ],
+                "auinit" : [ "M" ],
+                "au" : [ "Lynch, Michael P. (Michael Patrick)" ],
+                "date" : [ "2019" ],
+                "isbn" : [ "9781631493614", "1631493612" ],
+                "notes" : [ "Includes bibliographical references and index." ],
+                "abstract" : [ "Examines how a growing culture of narcissism is behind the fragmented political landscapes of today, drawing on the works of classic philosophers to explain the essential role of truth and humility in democracy." ],
+                "cop" : [ "New York" ],
+                "pub" : [ "Liveright Publishing Corporation" ],
+                "oclcid" : [ "(mcm)2817874mit01", "(ocolc)1053997548", "(ocolc)1110627469", "nhccybp" ],
+                "lccn" : [ "2019014604" ],
+                "edition" : [ "First edition." ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Know-it-all society : truth and arrogance in political culture" ]
+              },
+              "sort" : {
+                "title" : [ "Know-it-all society : truth and arrogance in political culture / Michael Patrick Lynch." ],
+                "author" : [ "Lynch, Michael P. (Michael Patrick), 1966- author." ],
+                "creationdate" : [ "2019" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9033749534253566912" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "DEW",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Dewey Library",
+                "callNumber" : "HM851.L96 2019",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028178740206761",
+                "holdId" : "229796990006761",
+                "holKey" : "HoldingResultKey [mid=229796990006761, libraryId=161684770006761, locationCode=STACK, callNumber=HM851.L96 2019]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "DEW",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Dewey Library",
+                "callNumber" : "HM851.L96 2019",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028178740206761",
+                "holdId" : "229796990006761",
+                "holKey" : "HoldingResultKey [mid=229796990006761, libraryId=161684770006761, locationCode=STACK, callNumber=HM851.L96 2019]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "available_in_library" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990028178740206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:1631493612,OCLC:,LCCN:2019014604&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "HM851.L96 2019",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "hm\"851ǂ l96 2019",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990022897100206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "The Cambridge Companion to Autobiography " ],
+                "subject" : [ "Autobiography" ],
+                "format" : [ "xix, 259 pages ; 23 cm." ],
+                "identifier" : [ "$$CLC$$V  2013047704;$$CISBN$$V9781107028104 (hardback);$$CISBN$$V1107028108 (hardback);$$CISBN$$V9781107609181 (paperback);$$CISBN$$V1107609186 (paperback);$$COCLC$$V(OCoLC)866563705" ],
+                "creationdate" : [ "2014" ],
+                "lds07" : [ "809/.93592 CT25.C355 2014 866563705   2013047704 9781107028104 (hardback) 1107028108 (hardback) 9781107609181 (paperback) 1107609186 (paperback)" ],
+                "lds09" : [ "New York : Cambridge University Press,  2014   nyu" ],
+                "lds10" : [ "Includes bibliographical references and index." ],
+                "lds01" : [ "Text in English." ],
+                "publisher" : [ "New York : Cambridge University Press" ],
+                "description" : [ "\"The Cambridge Companion to Autobiography offers a historical overview of the genre from the foundational works of Augustine, Montaigne, and Rousseau through the great autobiographies of the Romantic, Victorian, and modern eras. Seventeen essays from distinguished scholars and critics explore the diverse forms, audiences, styles, and motives of life writings traditionally classified under the rubric of autobiography. Chapters are arranged in chronological order and are grouped to reflect changing views of the psychological status, representative character, and moral authority of the autobiographical text. The volume closes with a group portrait of late-modernist and contemporary autobiographies that, by blurring the dividing line between fiction and non-fiction, expand our understanding of the genre. Accessibly written and comprehensive in scope, the volume will appeal especially to students and teachers of non-fiction narrative, creative writing, and literature more broadly\"-- Provided by publisher." ],
+                "mms" : [ "990022897100206761" ],
+                "contributor" : [ "DiBattista, Maria, 1947- editor.$$QDiBattista, Maria", "Wittman, Emily Ondine, 1971- editor.$$QWittman, Emily Ondine" ],
+                "series" : [ "Cambridge Companions to Literature$$QCambridge Companions to Literature", "Cambridge companions to literature.$$QCambridge companions to literature." ],
+                "contents" : [ "Introduction / Maria DiBattista and Emily O. Wittman -- Part I. Foundations -- Augustine's confessions / Adam Becker -- Medieval European autobiography / John V. Fleming -- Montaigne and the crisis of autobiography / Lawrence D. Kritzman -- Rousseau's autobiographies / Eli Friedlander -- Part II. Consolidations -- Romantic autobiography / Frances Wilson -- Victorian autobiography: sons and fathers / Deborah Epstein Nord -- American autobiography and history / Robert F. Sayre -- Part III. Deflections -- Kierkegaard and Nietzsche / Alastair Hannay -- Pessoa / Alfred MacAdam -- Transgressors: Andre Gide and Jean Genet / Jean-Michel Rabate -- Part IV. Prisms -- The true purpose of autobiography, or the fate of Vladmir Nabokov's Speak, Memory / Leland de la Durantaye -- African American autobiography / Trudier Harris -- Holocaust memoirs: writing forgetfully / Michael Bernard-Donals -- Women's autobiographies / Maria DiBattista -- The 'new' memoir / Patrick Madden -- Wending artifice: creative non-fiction / Mary Cappello." ],
+                "place" : [ "New York :" ],
+                "version" : [ "2" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990022897100206761" ],
+                "recordid" : [ "alma990022897100206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002289710-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "1.15026275E-7" ]
+              },
+              "addata" : {
+                "aulast" : [ "DiBattista", "Wittman" ],
+                "aufirst" : [ "Maria", "Emily Ondine" ],
+                "auinit" : [ "M", "E" ],
+                "addau" : [ "DiBattista, Maria", "Wittman, Emily Ondine" ],
+                "date" : [ "2014" ],
+                "isbn" : [ "9781107028104", "1107028108", "9781107609181", "1107609186" ],
+                "notes" : [ "Includes bibliographical references and index." ],
+                "abstract" : [ "\"The Cambridge Companion to Autobiography offers a historical overview of the genre from the foundational works of Augustine, Montaigne, and Rousseau through the great autobiographies of the Romantic, Victorian, and modern eras. Seventeen essays from distinguished scholars and critics explore the diverse forms, audiences, styles, and motives of life writings traditionally classified under the rubric of autobiography. Chapters are arranged in chronological order and are grouped to reflect changing views of the psychological status, representative character, and moral authority of the autobiographical text. The volume closes with a group portrait of late-modernist and contemporary autobiographies that, by blurring the dividing line between fiction and non-fiction, expand our understanding of the genre. Accessibly written and comprehensive in scope, the volume will appeal especially to students and teachers of non-fiction narrative, creative writing, and literature more broadly\"-- Provided by publisher." ],
+                "cop" : [ "New York" ],
+                "pub" : [ "Cambridge University Press" ],
+                "oclcid" : [ "(mcm)2289710mit01", "(ocolc)866563705", "nhccybp" ],
+                "lccn" : [ "2013047704" ],
+                "seriestitle" : [ "Cambridge Companions to Literature" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "The Cambridge Companion to Autobiography" ]
+              },
+              "sort" : {
+                "title" : [ "Cambridge Companion to Autobiography / edited by Maria DiBattista, Emily Wittman." ],
+                "author" : [ "DiBattista, Maria, 1947- editor." ],
+                "creationdate" : [ "2014" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "5" ],
+                "frbrgroupid" : [ "9033758617424065644" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "CT25.C355 2014",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990022897100206761",
+                "holdId" : "2265645930006761",
+                "holKey" : "HoldingResultKey [mid=2265645930006761, libraryId=161684210006761, locationCode=STACK, callNumber=CT25.C355 2014]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "CT25.C355 2014",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990022897100206761",
+                "holdId" : "2265645930006761",
+                "holKey" : "HoldingResultKey [mid=2265645930006761, libraryId=161684210006761, locationCode=STACK, callNumber=CT25.C355 2014]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "available_in_library" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990022897100206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:1107028108,OCLC:,LCCN:2013047704&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "CT25.C355 2014",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "ct!25 c355 2014",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990025238030206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Philosophy : the classics " ],
+                "subject" : [ "Philosophy" ],
+                "format" : [ "xvi, 294 pages ; 21 cm" ],
+                "identifier" : [ "$$CLC$$V  2013028411;$$CISBN$$V9780415534673;$$CISBN$$V0415534674;$$CISBN$$V9780415534666;$$CISBN$$V0415534666;$$CISBN$$V9781315849201;$$CISBN$$V1315849208;$$COCLC$$V(OCoLC)783169006;$$COCLC$$V(OCoLC)864686275;$$COCLC$$V(OCoLC)883615969;$$COCLC$$V(OCoLC)904035192" ],
+                "creationdate" : [ "2014" ],
+                "lds07" : [ "100 B72 864686275 783169006 864686275 883615969 904035192   2013028411 9780415534666 9780415534673 0415534674 9780415534666 0415534666 9781315849201 1315849208" ],
+                "lds09" : [ "London ; Routledge, Taylor & Francis Group,  2014   enk" ],
+                "lds10" : [ "Includes bibliographical references and index." ],
+                "creator" : [ "Warburton, Nigel, 1962-$$QWarburton, Nigel" ],
+                "publisher" : [ "London ; New York : Routledge, Taylor & Francis Group" ],
+                "description" : [ "In his exemplary clear style, Warburton introduces and assesses twenty-seven philosophical classics from Plato s Republic to Rawls A Theory of Justice. For the third edition there is new text design and revised further reading make this the ideal book for all students, while three new chapters on Nietzsche s Beyond Good and Evil, Russell s The Problems of Philosophy and Sartre s Existentialism and Humanism mean that all the A Level set texts are covered. This brisk and invigorating tour through the great books of western philosophy explores the works of Plato, Aristotle, Boethius, Machiavelli, Descartes, Hobbes, Spinoza, Locke, Hume, Rousseau, Kant, Schopenhauer, Mill, Kierkegaard, Marx and Engels, Nietzsche, Russell, Ayer, Sartre, Wittgenstein, and Rawls. Offering twenty-seven guidebooks for the price of one, this is the most comprehensive introduction to philosophers and their texts currently available. -- Provided by publisher." ],
+                "mms" : [ "990025238030206761" ],
+                "edition" : [ "Fourth edition." ],
+                "contents" : [ "Introductions -- 1. Plato The Republic -- 2. Aristotle Nicomachean Ethics -- 3. Boethius The Consolation of Philosophy -- 4. Niccolo Machiavlli The Prince -- 5. Michael Eyquem de Montaigne The Essays -- 6. Rene Descartes Meditations -- 7. Thomas Hobbes Leviathan -- 8. Baruch de Spinoza Ethics -- 9. John Locke An Essay Concerning Human Understanding -- 10. John Locke Second Treatise of Government -- 11. David Hume An Enquiry Concerning Human Understanding -- 12. David Hume Dialogues Concerning Natural Religion -- 13. Jean-Jacques Rousseau The Social Contract -- 14. Immanuel Kant Critique of Pure Reason -- 15. Immanuel Kant Groundwork of the Metaphysic of Morals -- 16. Thomas Paine The Rights of Man -- 17. Arthur Schopenhauer The World as Will and Idea -- 18. John Stuart Mill On Liberty -- 19. John Stuart Mill Utilitarianism -- 20. Søren Kierkegaard Either/Or -- 21. Karl Marx and Friedrich Engels The German Ideology, Part One -- 22. Friedrich Nietzsche Beyond Good and Evil -- 23. Friedrich Nietzsche On the Genealogy of Morality -- 24. Bertrand Russell The Problems of Philosophy -- 25. A.J. Ayer Language, Truth and Logic -- 26. R.G. Collingwood The Principles of Art -- 27. Jean-Paul Sartre Being and Nothingness -- 28. Jean-Paul Starte Existentialism and Humanism -- 29. Karl Popper The Open Society and Its Enemies -- 30. Ludwig Wittgenstein Philosophical Investigations -- 31. Thomas Kuhn The Structure of Scientific Revolutions -- 32. John Rawls A Theory of Justice -- Index." ],
+                "place" : [ "London ; New York :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990025238030206761" ],
+                "recordid" : [ "alma990025238030206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002523803-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "3.8462055E-8" ]
+              },
+              "addata" : {
+                "aulast" : [ "Warburton" ],
+                "aufirst" : [ "Nigel" ],
+                "auinit" : [ "N" ],
+                "au" : [ "Warburton, Nigel" ],
+                "date" : [ "2014" ],
+                "isbn" : [ "9780415534673", "0415534674", "9780415534666", "0415534666", "9781315849201", "1315849208" ],
+                "notes" : [ "Includes bibliographical references and index." ],
+                "abstract" : [ "In his exemplary clear style, Warburton introduces and assesses twenty-seven philosophical classics from Plato s Republic to Rawls A Theory of Justice. For the third edition there is new text design and revised further reading make this the ideal book for all students, while three new chapters on Nietzsche s Beyond Good and Evil, Russell s The Problems of Philosophy and Sartre s Existentialism and Humanism mean that all the A Level set texts are covered. This brisk and invigorating tour through the great books of western philosophy explores the works of Plato, Aristotle, Boethius, Machiavelli, Descartes, Hobbes, Spinoza, Locke, Hume, Rousseau, Kant, Schopenhauer, Mill, Kierkegaard, Marx and Engels, Nietzsche, Russell, Ayer, Sartre, Wittgenstein, and Rawls. Offering twenty-seven guidebooks for the price of one, this is the most comprehensive introduction to philosophers and their texts currently available. -- Provided by publisher." ],
+                "cop" : [ "London ;" ],
+                "pub" : [ "Routledge, Taylor & Francis Group" ],
+                "oclcid" : [ "(mcm)2523803mit01", "(ocolc)783169006", "(ocolc)864686275", "(ocolc)883615969", "(ocolc)904035192", "nhccybp" ],
+                "lccn" : [ "2013028411" ],
+                "edition" : [ "Fourth edition." ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Philosophy : the classics" ]
+              },
+              "sort" : {
+                "title" : [ "Philosophy : the classics / Nigel Warburton." ],
+                "author" : [ "Warburton, Nigel, 1962-" ],
+                "creationdate" : [ "2014" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9029472991566944962" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "B72.W37 2014",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990025238030206761",
+                "holdId" : "2226304300006761",
+                "holKey" : "HoldingResultKey [mid=2226304300006761, libraryId=161684210006761, locationCode=STACK, callNumber=B72.W37 2014]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "B72.W37 2014",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990025238030206761",
+                "holdId" : "2226304300006761",
+                "holKey" : "HoldingResultKey [mid=2226304300006761, libraryId=161684210006761, locationCode=STACK, callNumber=B72.W37 2014]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "available_in_library" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990025238030206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0415534674,OCLC:,LCCN:2013028411&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "B72.W37 2014",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "b!72ǂ w37 2014",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          } ],
+          "timelog" : {
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "73",
+            "CALL_SOLR_GET_IDS_LIST" : "3475",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "825",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "9",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "20",
+            "RETRIVE_FROM_DB_RECORDS" : "35",
+            "RETRIVE_FROM_DB_RELATIONS" : "6",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "734",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "91",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "197",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "4589",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
+            "BUILD_COMBINED_RESULTS_MAP" : 4669,
+            "COMBINED_SEARCH_TIME" : 4674,
+            "PROCESS_COMBINED_RESULTS" : 0,
+            "FEATURED_SEARCH_TIME" : 0
+          },
+          "facets" : [ ]
+        }
+  recorded_at: Fri, 04 Jun 2021 20:16:16 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/physical_book_primo.yml
+++ b/test/vcr_cassettes/physical_book_primo.yml
@@ -155,7 +155,7 @@ http_interactions:
                 "isValidUser" : true,
                 "organization" : "01MIT_INST",
                 "libraryCode" : "LSA",
-                "availabilityStatus" : "unavailable",
+                "availabilityStatus" : "available",
                 "subLocation" : "Off Campus Collection",
                 "subLocationCode" : "OCC",
                 "mainLocation" : "Library Storage Annex",

--- a/test/vcr_cassettes/unavailable_book_primo.yml
+++ b/test/vcr_cassettes/unavailable_book_primo.yml
@@ -1,0 +1,906 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://another_fake_server.example.com/v1/search?apikey=FAKE_PRIMO_API_KEY&limit=5&q=any,contains,they%20called%20us%20enemy&scope=FAKE_PRIMO_BOOK_SCOPE&tab=FAKE_PRIMO_TAB&vid=FAKE_PRIMO_VID
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - api-na.hosted.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Vary:
+      - accept-encoding
+      X-Exl-Api-Remaining:
+      - '549965'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET,POST,DELETE,PUT,OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Fri, 04 Jun 2021 20:16:17 GMT
+      Server:
+      - CA-API-Gateway/9.0
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "info" : {
+            "totalResultsLocal" : 98,
+            "totalResultsPC" : -1,
+            "total" : 98,
+            "first" : 1,
+            "last" : 5
+          },
+          "highlights" : {
+            "general" : [ "U.S" ],
+            "creator" : [ "U.S" ],
+            "contributor" : [ "U.S" ],
+            "lds09" : [ "U.S" ],
+            "subject" : [ "United", "States" ],
+            "toc" : [ "enemy", "Enemies", "enemies" ],
+            "description" : [ "United", "States", "They Called", "Called", "called", "enemy" ],
+            "title" : [ "enemy", "They called", "called", "us" ],
+            "termsUnion" : [ "U.S", "United", "States", "enemy", "Enemies", "enemies", "They Called", "Called", "called", "They called", "us" ]
+          },
+          "docs" : [ {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990028126970206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "crsinfo" : [ "$$R21W.744-FA20$$V21W.744-FA20: Comics Writing; 21W - Writing & Humanistic Studies$$MComics Writing" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "They called us enemy " ],
+                "subject" : [ "Takei, George, 1937-", "Takei, George, 1937- -- Childhood and youth", "Japanese Americans -- Evacuation and relocation, 1942-1945", "California -- History -- 1850-1950" ],
+                "format" : [ "204 pages : chiefly illustrations ; 23 cm" ],
+                "identifier" : [ "$$CISBN$$V9781603094504;$$CISBN$$V1603094504;$$COCLC$$V(OCoLC)1057852913" ],
+                "creationdate" : [ "2019" ],
+                "lds07" : [ "940.53/1773 D769.8.A6 1057852913 9781603094504 1603094504" ],
+                "lds09" : [ "Marietta, GA : Top Shelf Productions, 2019   2019  2019   gau" ],
+                "creator" : [ "Takei, George, 1937- author.$$QTakei, George" ],
+                "publisher" : [ "Marietta, GA : Top Shelf Productions" ],
+                "description" : [ "\"A stunning graphic memoir recounting actor/author/activist George Takei's childhood imprisoned within American concentration camps during World War II. Experience the forces that shaped an American icon -- and America itself -- in this gripping tale of courage, country, loyalty, and love. George Takei has captured hearts and minds worldwide with his captivating stage presence and outspoken commitment to equal rights. But long before he braved new frontiers in Star Trek, he woke up as a four-year-old boy to find his own birth country at war with his father's -- and their entire family forced from their home into an uncertain future. In 1942, at the order of President Franklin D. Roosevelt, every person of Japanese descent on the west coast was rounded up and shipped to one of ten 'relocation centers', hundreds or thousands of miles from home, where they would be held for years under armed guard. They Called Us Enemy is Takei's firsthand account of those years behind barbed wire, the joys and terrors of growing up under legalized racism, his mother's hard choices, his father's faith in democracy, and the way those experiences planted the seeds for his astonishing future. What is American? Who gets to decide? When the world is against you, what can one person do?\"--Provided by publisher." ],
+                "mms" : [ "990028126970206761" ],
+                "contributor" : [ "Eisinger, Justin, author.$$QEisinger, Justin", "Scott, Steven (Comics author), author.$$QScott, Steven", "Becker, Harmony, artist.$$QBecker, Harmony" ],
+                "genre" : [ "Comic books, strips, etc." ],
+                "place" : [ "Marietta, GA :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990028126970206761" ],
+                "recordid" : [ "alma990028126970206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002812697-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "0.8656729" ]
+              },
+              "addata" : {
+                "aulast" : [ "Takei" ],
+                "aufirst" : [ "George" ],
+                "auinit" : [ "G" ],
+                "au" : [ "Takei, George" ],
+                "addau" : [ "Eisinger, Justin", "Scott, Steven", "Becker, Harmony" ],
+                "date" : [ "2019 - 2019", "2019" ],
+                "isbn" : [ "9781603094504", "1603094504" ],
+                "abstract" : [ "\"A stunning graphic memoir recounting actor/author/activist George Takei's childhood imprisoned within American concentration camps during World War II. Experience the forces that shaped an American icon -- and America itself -- in this gripping tale of courage, country, loyalty, and love. George Takei has captured hearts and minds worldwide with his captivating stage presence and outspoken commitment to equal rights. But long before he braved new frontiers in Star Trek, he woke up as a four-year-old boy to find his own birth country at war with his father's -- and their entire family forced from their home into an uncertain future. In 1942, at the order of President Franklin D. Roosevelt, every person of Japanese descent on the west coast was rounded up and shipped to one of ten 'relocation centers', hundreds or thousands of miles from home, where they would be held for years under armed guard. They Called Us Enemy is Takei's firsthand account of those years behind barbed wire, the joys and terrors of growing up under legalized racism, his mother's hard choices, his father's faith in democracy, and the way those experiences planted the seeds for his astonishing future. What is American? Who gets to decide? When the world is against you, what can one person do?\"--Provided by publisher." ],
+                "cop" : [ "Marietta, GA" ],
+                "pub" : [ "Top Shelf Productions" ],
+                "oclcid" : [ "(mcm)2812697mit01", "nhccybp", "(ocolc)1057852913" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "They called us enemy" ]
+              },
+              "sort" : {
+                "title" : [ "They called us enemy / written by George Takei, Justin Eisinger, Steven Scott ; art by Harmony Becker." ],
+                "author" : [ "Takei, George, 1937- author." ],
+                "creationdate" : [ "2019" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9014278883951724869" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ENG",
+                "availabilityStatus" : "unavailable",
+                "subLocation" : "Course Support",
+                "subLocationCode" : "RSERV",
+                "mainLocation" : "Barker Library",
+                "callNumber" : "D769.8.A6 T347 2019",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028126970206761",
+                "holdId" : "2233638480006761",
+                "holKey" : "HoldingResultKey [mid=null, libraryId=161683650006761, locationCode=RSERV, callNumber=D769.8.A6 T347 2019]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ENG",
+                "availabilityStatus" : "unavailable",
+                "subLocation" : "Course Support",
+                "subLocationCode" : "RSERV",
+                "mainLocation" : "Barker Library",
+                "callNumber" : "D769.8.A6 T347 2019",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990028126970206761",
+                "holdId" : "2233638480006761",
+                "holKey" : "HoldingResultKey [mid=null, libraryId=161683650006761, locationCode=RSERV, callNumber=D769.8.A6 T347 2019]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "unavailable" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990028126970206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:1603094504,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "D769.8.A6 T347 2019",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "d\"769.8 a6ǂt347 2019",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990026123010206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "The enemy " ],
+                "subject" : [ "Hope", "United States -- History -- 20th century" ],
+                "format" : [ "99 pages ; 24 cm" ],
+                "identifier" : [ "$$CLC$$V  2006035575;$$CISBN$$V9780822338628;$$CISBN$$V0822338629;$$CISBN$$V9780822339601;$$CISBN$$V0822339609;$$COCLC$$V(OCoLC)75087943" ],
+                "creationdate" : [ "2007" ],
+                "lds07" : [ "811/.54 PS3553.A4883 E54 2007 75087943   2006035575 9780822338628 0822338629 9780822339601 0822339609" ],
+                "lds09" : [ "Durham : Duke University Press,    2007   ncu" ],
+                "lds01" : [ "In English, with some poems in Spanish." ],
+                "creator" : [ "Campo, Rafael, author.$$QCampo, Rafael" ],
+                "publisher" : [ "Durham : Duke University Press" ],
+                "description" : [ "\"In his fifth collection of poetry, the award-winning writer and physician Rafael Campo considers what it means to be the enemy in America today. Using the empathetic medium of a poetry grounded in the sentient physical body we all share, he writes of a country endlessly at war--not only against so-called evildoers abroad but also with its own troubled conscience. Yet whether he is addressing the U.S. invasion of Iraq, the battle against the AIDS pandemic, or the \"culture wars\" surrounding the issues of feminism and gay marriage, Campo's compelling poems affirm the notion that from even the most bitter of conflicts arises hope. That hope--expressed here in the Cuban exile's dream of someday returning to his homeland, in a dying IV drug user's wish for humane medical treatment, in a downcast housewife's desire to express herself meaningfully through art--is that somehow we can be better than ourselves. Through a kaleidoscopic lens of poetic forms, Campo reveals this greatest of human aspirations as the one sustaining us all\"-- Publisher's description." ],
+                "mms" : [ "990026123010206761" ],
+                "contents" : [ "I. The enemy. Dialogue with sun and poet -- Addressed to her (Provincetown, June 2002) -- \"Elsa, Varadero, 1934\" -- Night has fallen -- Personal mythology -- Piranhas -- Brief treatise on the new millennial poetics -- El viejo y la mar -- Ode to the man incidentally caught in the photograph of us on my desk -- The enemy -- God, gays, and guns -- Patriotic poem -- Post-9/11 parable -- Sestina dolorosa -- What passes now for moral discourse -- from Libro de preguntas -- II. Eighteen days in France. Eighteen days in France -- III. Towards a theory of memory. from Cien sonetos de amor -- A simple Cuban meal -- The sailfish -- Ganymede, to Zeus -- After the long drive -- For Jorge, after twenty years -- Song in the off-season -- Catastrophic sestina -- Toward a theory of memory -- Patagonia -- Defense of marriage -- The story of us -- The sodomite's lament -- Equinoctial downpour -- Pantoum for our imagined break-up -- The changing of the seasons -- Once, it seemed better -- October, last sail -- IV. Dawn, new age. Dawn, new age -- Allegorical -- Progress -- The crocuses -- Crybaby Haiku -- \"Silence=death\" -- Clinical vignettes -- You bring out the doctor in me -- Composite of three poems from the same anthology by Williams, Rukeyser, and Sexton -- Tuesday morning -- Arriving -- Absolution -- On doctoring -- Sick day." ],
+                "genre" : [ "Poetry." ],
+                "relation" : [ "$$Cform$$VOnline version: Campo, Rafael. Enemy. Durham : Duke University Press, 2007$$QEnemy.", "$$Cform$$VOnline version: Campo, Rafael. Enemy. Durham : Duke University Press, 2007$$QEnemy." ],
+                "mesh" : [ "Personal Narratives" ],
+                "place" : [ "Durham :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990026123010206761" ],
+                "recordid" : [ "alma990026123010206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "002612301-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "7.933078E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Campo" ],
+                "aufirst" : [ "Rafael" ],
+                "auinit" : [ "R" ],
+                "au" : [ "Campo, Rafael" ],
+                "date" : [ "2007" ],
+                "isbn" : [ "9780822338628", "0822338629", "9780822339601", "0822339609" ],
+                "abstract" : [ "\"In his fifth collection of poetry, the award-winning writer and physician Rafael Campo considers what it means to be the enemy in America today. Using the empathetic medium of a poetry grounded in the sentient physical body we all share, he writes of a country endlessly at war--not only against so-called evildoers abroad but also with its own troubled conscience. Yet whether he is addressing the U.S. invasion of Iraq, the battle against the AIDS pandemic, or the \"culture wars\" surrounding the issues of feminism and gay marriage, Campo's compelling poems affirm the notion that from even the most bitter of conflicts arises hope. That hope--expressed here in the Cuban exile's dream of someday returning to his homeland, in a dying IV drug user's wish for humane medical treatment, in a downcast housewife's desire to express herself meaningfully through art--is that somehow we can be better than ourselves. Through a kaleidoscopic lens of poetic forms, Campo reveals this greatest of human aspirations as the one sustaining us all\"-- Publisher's description." ],
+                "cop" : [ "Durham" ],
+                "pub" : [ "Duke University Press" ],
+                "oclcid" : [ "(mcm)2612301mit01", "(ocolc)75087943" ],
+                "lccn" : [ "2006035575" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "The enemy" ]
+              },
+              "sort" : {
+                "title" : [ "enemy / Rafael Campo." ],
+                "author" : [ "Campo, Rafael, author." ],
+                "creationdate" : [ "2007" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9008941241243458400" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ENG",
+                "availabilityStatus" : "unavailable",
+                "subLocation" : "Humanities & Science Temporary Collection",
+                "subLocationCode" : "HYSTK",
+                "mainLocation" : "Barker Library",
+                "callNumber" : "PS3553.A4883 E54 2007",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990026123010206761",
+                "holdId" : "2212643000006761",
+                "holKey" : "HoldingResultKey [mid=null, libraryId=161683650006761, locationCode=HYSTK, callNumber=PS3553.A4883 E54 2007]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "ENG",
+                "availabilityStatus" : "unavailable",
+                "subLocation" : "Humanities & Science Temporary Collection",
+                "subLocationCode" : "HYSTK",
+                "mainLocation" : "Barker Library",
+                "callNumber" : "PS3553.A4883 E54 2007",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990026123010206761",
+                "holdId" : "2212643000006761",
+                "holKey" : "HoldingResultKey [mid=null, libraryId=161683650006761, locationCode=HYSTK, callNumber=PS3553.A4883 E54 2007]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P" ],
+              "serviceMode" : [ "ovp" ],
+              "availability" : [ "unavailable" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990026123010206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0822338629,OCLC:,LCCN:2006035575&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "PS3553.A4883 E54 2007",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "ps#3553 a4883 e54 2007",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990008852250206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Future warfare : anthology " ],
+                "subject" : [ "United States Army -- Forecasting", "United States Army -- Operational readiness", "Military planning -- United States", "Warfare, Conventional -- Forecasting", "Maneuver warfare", "Rapid dominance (Military science)", "War -- Effect of technological innovations on", "Strategy", "Twenty-first century", "United States -- Military policy" ],
+                "format" : [ "xxii, 213 p. : ill., charts ; 23 cm." ],
+                "identifier" : [ "$$CISBN$$V1584870001;$$COCLC$$V(OCoLC)41447143" ],
+                "creationdate" : [ "1999" ],
+                "lds07" : [ "41447143 1584870001" ],
+                "lds09" : [ "Carlisle Barracks, Pa. : U.S. Army War College,    1999   pau" ],
+                "lds10" : [ "Includes bibliographical references and index." ],
+                "creator" : [ "Scales, Robert H., 1944-$$QScales, Robert H." ],
+                "publisher" : [ "Carlisle Barracks, Pa. : U.S. Army War College" ],
+                "mms" : [ "990008852250206761" ],
+                "contributor" : [ "Murray, Williamson.$$QMurray, Williamson.", "Van Riper, Paul K.$$QVan Riper, Paul K.", "Parmentola, John A.$$QParmentola, John A.", "Army War College (U.S.)$$QArmy War College (U.S.)" ],
+                "contents" : [ "Introduction / Williamson Murray -- 1. Cycles of war / Robert H. Scales, Jr. -- 2. Preparing for war in the 21st Century / Robert H. Scales, Jr., Paul K. Van Riper -- 3. Adaptive enemies: dealing with the strategic threat after 2010 / Robert H. Scales, Jr. -- 4. A sword with two edges: maneuver in 21st Century warfare / Robert H. Scales, Jr. -- 5. Clashes of visions: sizing and shaping our forces in a fiscally constrained environment / Robert H. Scales, Jr. -- 6. America's Army: preparing for tomorrow's security challenges / Robert H. Scales, Jr. -- 7. The dawn of a new age of warfare: and the clarion call for enhanced maneuver capabilities / Robert H. Scales, Jr. -- 8. The annual report for the Army After Next Project to the Chief of Staff of the Army / Robert H. Scales, Jr. -- 9. The Army After Next: intertwining military art, science, and technology out to the year 2025 / Robert H. Scales, Jr., John A. Parmentola -- 10. The indirect approach: how U.S. military forces can avoid the pitfalls of future urban warfare / Robert H. Scales, Jr. -- 11. Trust, not technology, sustains coalitions / Robert H. Scales, Jr. -- 12. In war, the U.S. can't go it alone / Robert H. Scales, Jr." ],
+                "genre" : [ "Forecasts." ],
+                "place" : [ "Carlisle Barracks, Pa. :" ],
+                "version" : [ "2" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990008852250206761" ],
+                "recordid" : [ "alma990008852250206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "000885225-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "5.9809514E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Scales" ],
+                "aufirst" : [ "Robert H." ],
+                "auinit" : [ "R" ],
+                "au" : [ "Scales, Robert H." ],
+                "addau" : [ "Murray, Williamson.", "Van Riper, Paul K.", "Parmentola, John A." ],
+                "date" : [ "1999" ],
+                "isbn" : [ "1584870001" ],
+                "notes" : [ "Includes bibliographical references and index." ],
+                "cop" : [ "Carlisle Barracks, Pa" ],
+                "pub" : [ "U.S. Army War College" ],
+                "oclcid" : [ "(mcm)885225", "(mcm)885225mit01", "mitb10885225", "(ocolc)41447143" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Future warfare : anthology" ]
+              },
+              "sort" : {
+                "title" : [ "Future warfare : anthology / Robert H. Scales, Jr." ],
+                "author" : [ "Scales, Robert H., 1944-" ],
+                "creationdate" : [ "1999" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "5" ],
+                "frbrgroupid" : [ "9084925621548105380" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "DEW",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Dewey Library",
+                "callNumber" : "U413.S33 1999",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990008852250206761",
+                "holdId" : "2252352830006761",
+                "holKey" : "HoldingResultKey [mid=2252352830006761, libraryId=161684770006761, locationCode=STACK, callNumber=U413.S33 1999]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "DEW",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Dewey Library",
+                "callNumber" : "U413.S33 1999",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990008852250206761",
+                "holdId" : "2252352830006761",
+                "holKey" : "HoldingResultKey [mid=2252352830006761, libraryId=161684770006761, locationCode=STACK, callNumber=U413.S33 1999]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "available_in_library", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990008852250206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:1584870001,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "http://FAKE_PRIMO_BOOK_SCOPE.hathitrust.org/api/volumes/oclc/41447143.html",
+                "displayLabel" : "Hathi Trust"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "U413.S33 1999",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "u000000000413.s000000000033000000001999",
+                "callNumberBrowseField" : "LOCAL_CL_09X"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990032496060206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Dangerous guests : enemy captives and revolutionary communities during the War for Independence " ],
+                "subject" : [ "Prisoners of war -- Pennsylvania -- Lancaster -- History -- 18th century", "Nationalism -- Pennsylvania -- Lancaster -- History -- 18th century", "Lancaster (Pa.) -- History -- Revolution, 1775-1783 -- Prisoners and prisons", "United States -- History -- Revolution, 1775-1783 -- Prisoners and prisons" ],
+                "format" : [ "1 online resource (ix, 247 pages) : illustrations, map", "text file PDF" ],
+                "identifier" : [ "$$CISBN$$V0801454948;$$CISBN$$V9780801454943;$$COCLC$$V(OCoLC)890952244;$$COCLC$$V(OCoLC)891382325;$$COCLC$$V(OCoLC)922998169;$$COCLC$$V(OCoLC)960201241;$$COCLC$$V(OCoLC)961646374;$$COCLC$$V(OCoLC)979575376;$$COCLC$$V(OCoLC)988539655;$$COCLC$$V(OCoLC)992902500;$$COCLC$$V(OCoLC)1013938847;$$COCLC$$V(OCoLC)1058558398;$$COCLC$$V(OCoLC)1058861163;$$COCLC$$V(OCoLC)1066644236;$$COCLC$$V(OCoLC)1076776940;$$COCLC$$V(OCoLC)1081184798;$$COCLC$$V(OCoLC)1097151200;$$CISBN$$V9780801450556;$$CISBN$$V0801450551" ],
+                "creationdate" : [ "2014" ],
+                "lds07" : [ "973.3 F159.L2 891382325 890952244 891382325 922998169 960201241 961646374 979575376 988539655 992902500 1013938847 1058558398 1058861163 1066644236 1076776940 1081184798 1097151200 10.7591/9780801454943 9780801450556 0801450551 0801454948 9780801454943" ],
+                "lds09" : [ "Ithaca : Cornell University Press,  2014   nyu" ],
+                "lds10" : [ "Includes bibliographical references and index." ],
+                "lds01" : [ "In English." ],
+                "creator" : [ "Miller, Ken, 1966- author.$$QMiller, Ken" ],
+                "publisher" : [ "Ithaca : Cornell University Press" ],
+                "description" : [ "In Dangerous Guests, Ken Miller reveals how wartime pressures nurtured a budding patriotism in the ethnically diverse revolutionary community of Lancaster, Pennsylvania. During the War for Independence, American revolutionaries held more than thirteen thousand prisoners--both British regulars and their so-called Hessian auxiliaries--in makeshift detention camps far from the fighting. As the Americans' principal site for incarcerating enemy prisoners of war, Lancaster stood at the nexus of two vastly different revolutionary worlds: one national, the other intensely local. Captives came under the control of local officials loosely supervised by state and national authorities. Concentrating the prisoners in the heart of their communities brought the revolutionaries' enemies to their doorstep, with residents now facing a daily war at home. Many prisoners openly defied their hosts, fleeing, plotting, and rebelling, often with the clandestine support of local loyalists. By early 1779, General George Washington, furious over the captives' ongoing attempts to subvert the American war effort, branded them \"dangerous guests in the bowels of our Country.\" The challenge of creating an autonomous national identity in the newly emerging United States was nowhere more evident than in Lancaster, where the establishment of a detention camp served as a flashpoint for new conflict in a community already unsettled by stark ethnic, linguistic, and religious differences. Many Lancaster residents soon sympathized with the Hessians detained in their town while the loyalist population considered the British detainees to be the true patriots of the war. Miller demonstrates that in Lancaster, the notably local character of the war reinforced not only preoccupations with internal security but also novel commitments to cause and country." ],
+                "mms" : [ "990032496060206761" ],
+                "contents" : [ "Prologue : a community at war -- \"A colony of aliens\" : diversity, politics, and war in pre-revolutionary Lancaster, Pennsylvania -- \"Divided we must inevitably fall\" : war comes to Lancaster -- \"A dangerous set of people\" : British captives and the making of revolutionary identity -- \"'Tis Britain alone that is our enemy\" : German captives and the making of American identity -- \"Enemies of our peace\" : captives, the disaffected, and the refinement of American patriotism -- \"The country is full of prisoners of war\" : nationalism, resistance, and assimilation -- Epilogue : the empty barracks." ],
+                "place" : [ "Ithaca :" ],
+                "version" : [ "1" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990032496060206761" ],
+                "recordid" : [ "alma990032496060206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "003249606-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "4.660318E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Miller" ],
+                "aufirst" : [ "Ken" ],
+                "auinit" : [ "K" ],
+                "au" : [ "Miller, Ken" ],
+                "date" : [ "2014" ],
+                "isbn" : [ "0801454948", "9780801454943", "9780801450556", "0801450551" ],
+                "notes" : [ "Includes bibliographical references and index." ],
+                "abstract" : [ "In Dangerous Guests, Ken Miller reveals how wartime pressures nurtured a budding patriotism in the ethnically diverse revolutionary community of Lancaster, Pennsylvania. During the War for Independence, American revolutionaries held more than thirteen thousand prisoners--both British regulars and their so-called Hessian auxiliaries--in makeshift detention camps far from the fighting. As the Americans' principal site for incarcerating enemy prisoners of war, Lancaster stood at the nexus of two vastly different revolutionary worlds: one national, the other intensely local. Captives came under the control of local officials loosely supervised by state and national authorities. Concentrating the prisoners in the heart of their communities brought the revolutionaries' enemies to their doorstep, with residents now facing a daily war at home. Many prisoners openly defied their hosts, fleeing, plotting, and rebelling, often with the clandestine support of local loyalists. By early 1779, General George Washington, furious over the captives' ongoing attempts to subvert the American war effort, branded them \"dangerous guests in the bowels of our Country.\" The challenge of creating an autonomous national identity in the newly emerging United States was nowhere more evident than in Lancaster, where the establishment of a detention camp served as a flashpoint for new conflict in a community already unsettled by stark ethnic, linguistic, and religious differences. Many Lancaster residents soon sympathized with the Hessians detained in their town while the loyalist population considered the British detainees to be the true patriots of the war. Miller demonstrates that in Lancaster, the notably local character of the war reinforced not only preoccupations with internal security but also novel commitments to cause and country." ],
+                "cop" : [ "Ithaca" ],
+                "pub" : [ "Cornell University Press" ],
+                "oclcid" : [ "(mcm)3249606mit01", "(ocolc)890952244", "(ocolc)891382325", "(ocolc)922998169", "(ocolc)960201241", "(ocolc)961646374", "(ocolc)979575376", "(ocolc)988539655", "(ocolc)992902500", "(ocolc)1013938847", "(ocolc)1058558398", "(ocolc)1058861163", "(ocolc)1066644236", "(ocolc)1076776940", "(ocolc)1081184798", "(ocolc)1097151200" ],
+                "doi" : [ "10.7591/9780801454943" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Dangerous guests : enemy captives and revolutionary communities during the War for Independence" ]
+              },
+              "sort" : {
+                "title" : [ "Dangerous guests : enemy captives and revolutionary communities during the War for Independence / Ken Miller." ],
+                "author" : [ "Miller, Ken, 1966- author." ],
+                "creationdate" : [ "2014" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "6" ],
+                "frbrgroupid" : [ "9024444437922131846" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : null,
+              "holding" : null,
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-E" ],
+              "serviceMode" : [ "Viewit" ],
+              "availability" : [ "not_restricted" ],
+              "availabilityLinks" : null,
+              "availabilityLinksUrl" : null,
+              "displayedAvailability" : "Not available",
+              "displayLocation" : null,
+              "additionalLocations" : null,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : null,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : null,
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:9780801454943,OCLC:,LCCN:&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "https://www.jstor.org/stable/10.7591/j.ctt1287ckk",
+                "displayLabel" : "$$Elinktorsrc"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : false,
+                "callNumber" : "",
+                "callNumberBrowseField" : ""
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "f\"159 l2ǂm55 2014",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          }, {
+            "context" : "L",
+            "adaptor" : "Local Search Engine",
+            "@id" : "https://na06.alma.exlibrisgroup.com/primaws/rest/pub/pnxs/L/990013865470206761",
+            "pnx" : {
+              "display" : {
+                "source" : [ "Alma" ],
+                "type" : [ "book" ],
+                "language" : [ "eng" ],
+                "title" : [ "Democratizing the enemy : the Japanese American internment " ],
+                "subject" : [ "Japanese Americans -- Evacuation and relocation, 1942-1945" ],
+                "format" : [ "xviii, 319 p. ; 24 cm." ],
+                "identifier" : [ "$$CLC$$V  2003057956;$$CISBN$$V0691009457 (acid-free paper);$$COCLC$$V(OCoLC)52631404;$$COCLC$$V(OCoLC)56459569" ],
+                "creationdate" : [ "c2004" ],
+                "lds07" : [ "940.53/089/956073 D769.8.A6.H39 2004 56459569 52631404 56459569   2003057956 0691009457 (acid-free paper)" ],
+                "lds09" : [ "Princeton, N.J. : Princeton University Press,    2004   nju" ],
+                "lds10" : [ "Includes bibliographical references (p. [223]-303) and index." ],
+                "creator" : [ "Hayashi, Brian Masaru, 1955-$$QHayashi, Brian Masaru" ],
+                "publisher" : [ "Princeton, N.J. : Princeton University Press" ],
+                "description" : [ "Publisher's description: During World War II some 120,000 Japanese Americans were forcibly removed from their homes and detained in concentration camps in several states. These Japanese Americans lost millions of dollars in property and were forced to live in so-called \"assembly centers\" surrounded by barbed wire fences and armed sentries. In this insightful and groundbreaking work, Brian Hayashi reevaluates the three-year ordeal of interred Japanese Americans. Using previously undiscovered documents, he examines the forces behind the U.S. government's decision to establish internment camps. His conclusion: the motives of government officials and top military brass likely transcended the standard explanations of racism, wartime hysteria, and leadership failure. Among the other surprising factors that played into the decision, Hayashi writes, were land development in the American West and plans for the American occupation of Japan. What was the long-term impact of America's actions? While many historians have explored that question, Hayashi takes a fresh look at how U.S. concentration camps affected not only their victims and American civil liberties, but also people living in locations as diverse as American Indian reservations and northeast Thailand." ],
+                "mms" : [ "990013865470206761" ],
+                "contents" : [ "Prologue : beyond Civil Rights -- 1. Governors and their advisers, 1918-1942 -- 2. The governed : Japanese Americans and politics, 1880-1942 -- 3. Establishing the structures of internment, from limited to mass internment, 1942-1943 -- 4. The liberal democratic way of management, 1942-1943 -- 5. \"Why awake a sleeping lion?\" : governance during the quiet period, 1943-1944 -- 6. \"Taking away the candy\" : relocation, the twilight of the Japanese Empire, and Japanese American politics, 1944-1945 -- 7. The long shadow of internment -- Epilogue : toward human rights." ],
+                "place" : [ "Princeton, N.J. :" ],
+                "version" : [ "2" ]
+              },
+              "control" : {
+                "sourcerecordid" : [ "990013865470206761" ],
+                "recordid" : [ "alma990013865470206761" ],
+                "sourceid" : "alma",
+                "originalsourceid" : [ "001386547-MIT01" ],
+                "sourcesystem" : [ "ILS" ],
+                "sourceformat" : [ "MARC21" ],
+                "score" : [ "1.649389E-5" ]
+              },
+              "addata" : {
+                "aulast" : [ "Hayashi" ],
+                "aufirst" : [ "Brian Masaru" ],
+                "auinit" : [ "B" ],
+                "au" : [ "Hayashi, Brian Masaru" ],
+                "date" : [ "2004", "c2004" ],
+                "isbn" : [ "0691009457" ],
+                "notes" : [ "Includes bibliographical references (p. [223]-303) and index." ],
+                "abstract" : [ "Publisher's description: During World War II some 120,000 Japanese Americans were forcibly removed from their homes and detained in concentration camps in several states. These Japanese Americans lost millions of dollars in property and were forced to live in so-called \"assembly centers\" surrounded by barbed wire fences and armed sentries. In this insightful and groundbreaking work, Brian Hayashi reevaluates the three-year ordeal of interred Japanese Americans. Using previously undiscovered documents, he examines the forces behind the U.S. government's decision to establish internment camps. His conclusion: the motives of government officials and top military brass likely transcended the standard explanations of racism, wartime hysteria, and leadership failure. Among the other surprising factors that played into the decision, Hayashi writes, were land development in the American West and plans for the American occupation of Japan. What was the long-term impact of America's actions? While many historians have explored that question, Hayashi takes a fresh look at how U.S. concentration camps affected not only their victims and American civil liberties, but also people living in locations as diverse as American Indian reservations and northeast Thailand." ],
+                "cop" : [ "Princeton, N.J" ],
+                "pub" : [ "Princeton University Press" ],
+                "oclcid" : [ "(mcm)1386547mit01", "(ocolc)52631404", "(ocolc)56459569" ],
+                "lccn" : [ "2003057956" ],
+                "format" : [ "book" ],
+                "genre" : [ "book" ],
+                "ristype" : [ "BOOK" ],
+                "btitle" : [ "Democratizing the enemy : the Japanese American internment" ]
+              },
+              "sort" : {
+                "title" : [ "Democratizing the enemy : the Japanese American internment / Brian Masaru Hayashi." ],
+                "author" : [ "Hayashi, Brian Masaru, 1955-" ],
+                "creationdate" : [ "2004" ]
+              },
+              "facets" : {
+                "frbrtype" : [ "5" ],
+                "frbrgroupid" : [ "9084586021147358975" ]
+              }
+            },
+            "delivery" : {
+              "bestlocation" : {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "D769.8.A6.H39 2004",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990013865470206761",
+                "holdId" : "2219189240006761",
+                "holKey" : "HoldingResultKey [mid=2219189240006761, libraryId=161684210006761, locationCode=STACK, callNumber=D769.8.A6.H39 2004]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              },
+              "holding" : [ {
+                "isValidUser" : true,
+                "organization" : "01MIT_INST",
+                "libraryCode" : "HUM",
+                "availabilityStatus" : "available",
+                "subLocation" : "Stacks",
+                "subLocationCode" : "STACK",
+                "mainLocation" : "Hayden Library",
+                "callNumber" : "D769.8.A6.H39 2004",
+                "callNumberType" : "0",
+                "holdingURL" : "OVP",
+                "adaptorid" : "ALMA_01",
+                "ilsApiId" : "990013865470206761",
+                "holdId" : "2219189240006761",
+                "holKey" : "HoldingResultKey [mid=2219189240006761, libraryId=161684210006761, locationCode=STACK, callNumber=D769.8.A6.H39 2004]",
+                "matchForHoldings" : [ {
+                  "matchOn" : "MainLocation",
+                  "holdingRecord" : "852##b"
+                } ],
+                "stackMapUrl" : "",
+                "relatedTitle" : null,
+                "yearFilter" : null,
+                "volumeFilter" : null,
+                "singleUnavailableItemProcessType" : null,
+                "boundWith" : false,
+                "@id" : "_:0"
+              } ],
+              "electronicServices" : null,
+              "filteredByGroupServices" : null,
+              "quickAccessService" : null,
+              "deliveryCategory" : [ "Alma-P", "Alma-E" ],
+              "serviceMode" : [ "ovp", "Viewit" ],
+              "availability" : [ "available_in_library", "not_restricted" ],
+              "availabilityLinks" : [ "detailsgetit1" ],
+              "availabilityLinksUrl" : [ ],
+              "displayedAvailability" : null,
+              "displayLocation" : true,
+              "additionalLocations" : false,
+              "physicalItemTextCodes" : null,
+              "feDisplayOtherLocations" : false,
+              "almaInstitutionsList" : [ ],
+              "recordInstitutionCode" : null,
+              "recordOwner" : "01MIT_INST",
+              "hasFilteredServices" : null,
+              "digitalAuxiliaryMode" : false,
+              "hideResourceSharing" : false,
+              "sharedDigitalCandidates" : null,
+              "GetIt1" : [ {
+                "category" : "Alma-P",
+                "links" : [ {
+                  "isLinktoOnline" : false,
+                  "getItTabText" : "service_getit",
+                  "adaptorid" : "ALMA_01",
+                  "ilsApiId" : "990013865470206761",
+                  "link" : "OVP",
+                  "inst4opac" : "01MIT_INST",
+                  "displayText" : null,
+                  "@id" : "_:0"
+                } ]
+              } ],
+              "physicalServiceId" : null,
+              "link" : [ {
+                "@id" : ":_0",
+                "linkType" : "thumbnail",
+                "linkURL" : "https://proxy-na.hosted.exlibrisgroup.com/exl_rewrite/books.google.com/books?bibkeys=ISBN:0691009457,OCLC:,LCCN:2003057956&jscmd=viewapi&callback=updateGBSCover",
+                "displayLabel" : "thumbnail"
+              }, {
+                "@id" : ":_1",
+                "linkType" : "linktorsrc",
+                "linkURL" : "https://archive.org/details/democratizingene00haya",
+                "displayLabel" : "Internet Archive"
+              }, {
+                "@id" : ":_2",
+                "linkType" : "linktorsrc",
+                "linkURL" : "http://www.degruyter.com/isbn/9781400837748",
+                "displayLabel" : "$$Elinktorsrc"
+              }, {
+                "@id" : ":_3",
+                "linkType" : "addlink",
+                "linkURL" : "http://www.loc.gov/catdir/description/prin051/2003057956.html",
+                "displayLabel" : "Publisher description"
+              } ],
+              "hasD" : null
+            },
+            "enrichment" : {
+              "virtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "D769.8.A6.H39 2004",
+                "callNumberBrowseField" : "0"
+              },
+              "bibVirtualBrowseObject" : {
+                "isVirtualBrowseEnabled" : true,
+                "callNumber" : "d\"769.8 a6 h39 2004",
+                "callNumberBrowseField" : "LOC_CL"
+              }
+            }
+          } ],
+          "timelog" : {
+            "BUILD_RESULTS_RETRIVE_FROM_DB" : "470",
+            "CALL_SOLR_GET_IDS_LIST" : "135",
+            "PRIMA_LOCAL_SEARCH_SET_AVALIABILITY" : "602",
+            "RETRIVE_COLLECTION_DISCOVERY_INFO" : "219",
+            "RETRIVE_FROM_DB_COURSE_INFO" : "143",
+            "RETRIVE_FROM_DB_RECORDS" : "73",
+            "RETRIVE_FROM_DB_RELATIONS" : "23",
+            "SET_AVAILABILTY_GET_LIBRARY_DETAILS" : "477",
+            "SET_AVAILABILTY_HOLDING_DEDUPS" : "125",
+            "PRIMA_LOCAL_INFO_FACETS_BUILD_DOCS_HIGHLIGHTS" : "671",
+            "PRIMA_LOCAL_SEARCH_TOTAL" : "1892",
+            "BUILD_BLEND_AND_CACHE_RESULTS" : 0,
+            "BUILD_COMBINED_RESULTS_MAP" : 1972,
+            "COMBINED_SEARCH_TIME" : 1977,
+            "PROCESS_COMBINED_RESULTS" : 0,
+            "FEATURED_SEARCH_TIME" : 0
+          },
+          "facets" : [ ]
+        }
+  recorded_at: Fri, 04 Jun 2021 20:16:18 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### Why these changes are being introduced:

This introduces changes requested during UX review of our initial
RTA iteration.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2120

#### How this addresses that need:

* Displays only one location (the 'best location' as determined by
Alma/Primo), instead of every location where the item is held.
* Refactors availability status logic accordingly. The app now displays
'best location' availability and indicates whether the item is available
in other locations.
* Adds requested CSS updates.

#### Side effects of this change:

* Changed newlines for attr_accessor in the result model. This is purely
aesthetic to keep line width reasonable, but it might make it hard to
see the changes: `availability` and `other_availability` were added, and
`availability_status` was removed.
* Two new cassettes:
    * partially_available_book_primo
    * unavailable_book_primo
* Reverts changes to physical_book_primo availability status, which is
no longer necessary.
* Refactors Primo RTA view logic to its own partial, as it was starting
to get smelly.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
