### PR TITLE
IMP-2176 Remove 'Learn more' link from footer

### DIFF
--- a/app/views/layouts/_site_footer.html.erb
+++ b/app/views/layouts/_site_footer.html.erb
@@ -1,5 +1,5 @@
 <div class="about-bento bit" role="complementary">
   <h3 class="title">About this search app</h3>
-  <p>Quick search at the MIT Libraries can be used to find books, movies, music, articles, journals, archives and manuscript collections, and other great stuff we have at the library. <a href="https://libraries.mit.edu/about-quick-search/">Learn more</a></p>
+  <p>Quick search at the MIT Libraries can be used to find books, movies, music, articles, journals, archives and manuscript collections, and other great stuff we have at the library.</p>
   <p>Not finding what you need? <%= link_to('Ask us', 'https://libraries.mit.edu/ask/') %></p>
 </div>


### PR DESCRIPTION
#### Why these changes are being introduced:

A link in the footer goes to a WP page that will be removed after we
launch Primo.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2176

#### How this addresses that need:

This removes the link that is no longer needed.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
