### PR TITLE
Add feature flag to redirect full record links to Primo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ custom hint metadata.
 - `GOOGLE_CUSTOM_SEARCH_ID`: your Google Custom Search engine ID
 - `MAX_AUTHORS`: the maximum number of authors displayed in any record.
   If exceeded, 'et al' will be appended after this number.
+- `ALMA_SRU`: URL for Alma SRU query on alma.all_for_ui param. This is 
+used to determine whether to redirect Bento full record links to Primo 
+full records.
+- `PRIMO_REDIRECTS`: toggles feature flag to enable Primo redirects for 
+Bento full records.
+- `PRIMO_SPLASH_PAGE`: URL for Libraries splash page explaining the 
+transition from EDS to Primo.
 - `PRIMO_SEARCH`: toggles feature flag to use Primo instead of EDS.
 - `PRIMO_API_KEY`: the Primo API key.
 - `PRIMO_API_URL`: the server URL for the Primo API.

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -24,6 +24,11 @@ class RecordController < ApplicationController
   # See https://github.com/ebsco/edsapi-ruby/ . The page which gives all the
   # affordances of the record object is lib/ebsco/eds/record.rb.
   def record
+    if Flipflop.enabled?(:primo_redirects)
+      primo_redirect 
+      return
+    end
+
     with_session_error_handling { fetch_eds_record }
     if @record
       @keywords = extract_eds_text(@record.eds_author_supplied_keywords)
@@ -34,11 +39,7 @@ class RecordController < ApplicationController
       # want.
       @previous = params[:previous]
       rainbowify? if Flipflop.enabled?(:pride)
-      if Flipflop.enabled?(:primo_redirects)
-        primo_redirect
-      else
-        render 'record'
-      end
+      render 'record'
     else
       render 'errors/eds_session_error'
     end
@@ -46,7 +47,10 @@ class RecordController < ApplicationController
 
   # this method should never be cached because we need a fresh expiring URL
   def direct_link
-    primo_redirect if Flipflop.enabled?(:primo_redirects)
+    if Flipflop.enabled?(:primo_redirects)
+      primo_redirect 
+      return
+    end
 
     fetch_eds_record
     redirect_to @record.fulltext_link[:url]

--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -34,7 +34,11 @@ class RecordController < ApplicationController
       # want.
       @previous = params[:previous]
       rainbowify? if Flipflop.enabled?(:pride)
-      render 'record'
+      if Flipflop.enabled?(:primo_redirects)
+        primo_redirect
+      else
+        render 'record'
+      end
     else
       render 'errors/eds_session_error'
     end
@@ -42,6 +46,8 @@ class RecordController < ApplicationController
 
   # this method should never be cached because we need a fresh expiring URL
   def direct_link
+    primo_redirect if Flipflop.enabled?(:primo_redirects)
+
     fetch_eds_record
     redirect_to @record.fulltext_link[:url]
   end
@@ -138,5 +144,32 @@ class RecordController < ApplicationController
     return stuff if stuff.is_a? Array
     parsed_html = Nokogiri::HTML.fragment(CGI.unescapeHTML(stuff))
     parsed_html.search('searchlink').map(&:text).map(&:strip)
+  end
+
+  def alma_sru
+    return unless params[:an].start_with?('mit')
+    alma_system_id = params[:an].split('.').last.concat('MIT01')
+    url = ENV.fetch('ALMA_SRU') + alma_system_id
+    response = HTTP.get(url)
+    Nokogiri::XML.parse(response)
+  end
+
+  def alma_docid
+    return if alma_sru.blank?
+    records = alma_sru.xpath('//srw:searchRetrieveResponse/srw:records/srw:record', 'srw' => 'http://www.loc.gov/zing/srw/')
+
+    # We should attempt a redirect iff there is one record
+    return unless records.length == 1
+    records.xpath('//srw:recordIdentifier', 'srw' => 'http://www.loc.gov/zing/srw/').text().prepend('alma')
+  end
+
+  def primo_redirect
+    redirect_url = if alma_docid.present?
+                     [ENV.fetch('MIT_PRIMO_URL'), '/discovery/fulldisplay?docid=', 
+                      alma_docid, '&vid=', ENV.fetch('PRIMO_VID')].join('')
+                   else
+                     ENV.fetch('PRIMO_SPLASH_PAGE')
+                   end
+    redirect_to redirect_url, status: 308
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,8 +29,10 @@ Rails.application.configure do
   ENV['ALEPH_HINT_SOURCE'] = 'https://fake.example.com/s/fake/getserial_mini.xml?dl=1'
   ENV['FULL_RECORD_TOGGLE_BUTTON'] = 'true'
 
+  ENV['ALMA_SRU'] = 'https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.all_for_ui='
   ENV['EXL_INST_ID'] = '01MIT_INST'
   ENV['PRIMO_SEARCH'] = 'true'
+  ENV['PRIMO_REDIRECTS'] = 'false'
   ENV['PRIMO_API_URL'] = 'https://another_fake_server.example.com/v1'
   ENV['PRIMO_API_KEY'] = 'FAKE_PRIMO_API_KEY'
   ENV['PRIMO_VID'] = 'FAKE_PRIMO_VID'
@@ -38,6 +40,7 @@ Rails.application.configure do
   ENV['PRIMO_BOOK_SCOPE'] = 'FAKE_PRIMO_BOOK_SCOPE'
   ENV['PRIMO_ARTICLE_SCOPE'] = 'FAKE_PRIMO_ARTICLE_SCOPE'
   ENV['PRIMO_MAIN_VIEW_TAB'] = 'all'
+  ENV['PRIMO_SPLASH_PAGE'] = 'https://libraries.mit.edu/news/library-platform-before/32066/'
   ENV['MIT_PRIMO_URL'] = 'https://mit.primo.exlibrisgroup.com'
   ENV['SYNDETICS_PRIMO_URL'] = 'https://syndetics.com/index.php?client=primo'
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -50,4 +50,8 @@ Flipflop.configure do
   feature :primo_search,
     default: ActiveModel::Type::Boolean.new.cast(ENV.fetch('PRIMO_SEARCH')),
     description: 'Returns results from Primo Search API instead of EDS'
+
+  feature :primo_redirects,
+    default: ActiveModel::Type::Boolean.new.cast(ENV.fetch('PRIMO_REDIRECTS')),
+    description: 'Determines if Bento full record links should be redirected to Primo'
 end

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class RecordControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+  def teardown
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
   test 'should get record' do
     VCR.use_cassette('record: bananas', allow_playback_repeats: true) do
       get record_url('cat00916a', 'mit.001492509')
@@ -109,7 +116,7 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cache_path for pride enabled' do
-    Flipflop.stubs(:enabled?).returns(true)
+    @test_strategy.switch!(:pride, true)
     VCR.use_cassette('record: bananas', allow_playback_repeats: true) do
       get record_url('cat00916a', 'mit.001492509')
       assert_equal(@controller.send(:cache_path),
@@ -132,6 +139,28 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
                      allow_playback_repeats: true) do
       get record_url('phl', 'PHL2218518')
       assert_includes(@response.body, 'The requested record was not found.')
+    end
+  end
+
+  test 'redirects to Primo record if available' do
+    @test_strategy.switch!(:primo_redirects, true)
+    VCR.use_cassette('sru book', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_redirected_to 'https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990014925090206761&vid=FAKE_PRIMO_VID'
+    end
+    VCR.use_cassette('sru journal', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'cat00916a', an: 'mit.000292123' }
+      assert_response 308
+      assert_redirected_to 'https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990002921230206761&vid=FAKE_PRIMO_VID'
+    end
+  end
+
+  test 'redirects to splash page if Primo record is not available' do
+    @test_strategy.switch!(:primo_redirects, true)
+    VCR.use_cassette('sru article', allow_playback_repeats: true) do
+      get record_url, params: { db_source: 'aci', an: '123877356' }
+      assert_response 308
+      assert_redirected_to ENV.fetch('PRIMO_SPLASH_PAGE')
     end
   end
 end

--- a/test/controllers/record_controller_test.rb
+++ b/test/controllers/record_controller_test.rb
@@ -4,9 +4,6 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
   def setup
     @test_strategy = Flipflop::FeatureSet.current.test!
   end
-  def teardown
-    @test_strategy = Flipflop::FeatureSet.current.test!
-  end
 
   test 'should get record' do
     VCR.use_cassette('record: bananas', allow_playback_repeats: true) do
@@ -142,10 +139,11 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'redirects to Primo record if available' do
+  test 'redirects full record to Primo record if available' do
     @test_strategy.switch!(:primo_redirects, true)
     VCR.use_cassette('sru book', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response 308
       assert_redirected_to 'https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990014925090206761&vid=FAKE_PRIMO_VID'
     end
     VCR.use_cassette('sru journal', allow_playback_repeats: true) do
@@ -155,12 +153,33 @@ class RecordControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'redirects to splash page if Primo record is not available' do
+  test 'redirects direct link to Primo record if available' do
+    @test_strategy.switch!(:primo_redirects, true)
+    VCR.use_cassette('sru book', allow_playback_repeats: true) do
+      get record_direct_link_url, params: { db_source: 'cat00916a', an: 'mit.001492509' }
+      assert_response 308
+      assert_redirected_to 'https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990014925090206761&vid=FAKE_PRIMO_VID'
+    end
+    VCR.use_cassette('sru journal', allow_playback_repeats: true) do
+      get record_direct_link_url, params: { db_source: 'cat00916a', an: 'mit.000292123' }
+      assert_response 308
+      assert_redirected_to 'https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990002921230206761&vid=FAKE_PRIMO_VID'
+    end
+  end
+
+  test 'redirects full record to splash page if Primo record is not available' do
     @test_strategy.switch!(:primo_redirects, true)
     VCR.use_cassette('sru article', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'aci', an: '123877356' }
       assert_response 308
       assert_redirected_to ENV.fetch('PRIMO_SPLASH_PAGE')
     end
+  end
+
+  test 'redirects direct link to to splash page if Primo record is not available' do
+    @test_strategy.switch!(:primo_redirects, true)
+    get record_direct_link_url, params: { db_source: 'aci', an: '123877356' }
+    assert_response 308
+    assert_redirected_to ENV.fetch('PRIMO_SPLASH_PAGE')
   end
 end

--- a/test/integration/record_test.rb
+++ b/test/integration/record_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class RecordTest < ActionDispatch::IntegrationTest
+  def setup
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+  def teardown
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
   test 'article title is shown' do
     VCR.use_cassette('record: article', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'aci', an: '123877356' }
@@ -287,7 +294,7 @@ class RecordTest < ActionDispatch::IntegrationTest
   end
 
   test 'should be able to display rainbows' do
-    get '/toggle/?feature=pride'
+    @test_strategy.switch!(:pride, true)
     VCR.use_cassette('record: rainbows', allow_playback_repeats: true) do
       get record_url, params: { db_source: 'cat00916a', an: 'mit.002613248' }
       assert_response :success

--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class SearchTest < ActionDispatch::IntegrationTest
+  def setup
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+  def teardown
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
   test 'blank search term redirects to search' do
     get '/search/bento?q=%20'
     follow_redirect!
@@ -120,7 +127,7 @@ class SearchTest < ActionDispatch::IntegrationTest
   test 'local full_record_link when enabled' do
     VCR.use_cassette('popcorn articles',
                      allow_playback_repeats: true) do
-      get '/toggle?feature=local_full_record' # enable feature
+      @test_strategy.switch!(:local_full_record, true) # enable feature
       get '/search/search_boxed?q=popcorn&target=articles'
       assert_response :success
       assert_select('a.bento-link') do |value|

--- a/test/vcr_cassettes/sru_article.yml
+++ b/test/vcr_cassettes/sru_article.yml
@@ -1,0 +1,639 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:35 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+  recorded_at: Wed, 16 Jun 2021 20:22:35 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:35 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 166643ff-51e8-47ec-9610-ab3012979f77
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '777872804'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+  recorded_at: Wed, 16 Jun 2021 20:22:35 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:35 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - d4ca0aec-26cd-48c3-a1fe-8b4797545e03
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '974705124'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+  recorded_at: Wed, 16 Jun 2021 20:22:35 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:35 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 9a8d5e19-96fd-4393-9487-4ba8985593c2
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '777872804'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '26533'
+    body:
+      encoding: UTF-8
+      string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"relevance","Label":"Relevance","AddAction":"setsort(relevance)"},{"Id":"date","Label":"Date
+        Newest","AddAction":"setsort(date)"},{"Id":"date2","Label":"Date Oldest","AddAction":"setsort(date2)"}],"AvailableSearchFields":[{"FieldCode":"TX","Label":"All
+        Text"},{"FieldCode":"AU","Label":"Author"},{"FieldCode":"TI","Label":"Title"},{"FieldCode":"SU","Label":"Subject
+        Terms"},{"FieldCode":"SO","Label":"Source"},{"FieldCode":"AB","Label":"Abstract"},{"FieldCode":"IS","Label":"ISSN"},{"FieldCode":"IB","Label":"ISBN"}],"AvailableExpanders":[{"Id":"thesaurus","Label":"Apply
+        related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
+        search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"},{"Id":"relatedsubjects","Label":"Apply
+        equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"2"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
+        Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
+        Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
+        Barton Catalog","AddAction":"addlimiter(LB:MIT Barton Catalog)","LimiterValues":[{"Value":"Barker
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Barker Library)"},{"Value":"Dewey
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Dewey Library)"},{"Value":"Hayden
+        Library - Humanities","AddAction":"addlimiter(LB:MIT Barton Catalog-Hayden
+        Library - Humanities)"},{"Value":"Hayden Library - Science","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Library - Science)"},{"Value":"Hayden Reserves","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Reserves)"},{"Value":"Institute Archives","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Institute Archives)"},{"Value":"Internet Resource","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Internet Resource)"},{"Value":"Lewis Music Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Lewis Music Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Visual Collections)"}]},{"Value":"MIT Course Reserves","AddAction":"addlimiter(LB:MIT
+        Course Reserves)","LimiterValues":[{"Value":"Barker Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Barker Library)"},{"Value":"Dewey Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Dewey Library)"},{"Value":"Hayden Library - Humanities","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Hayden Library - Humanities)"},{"Value":"Hayden Library -
+        Science","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Library - Science)"},{"Value":"Hayden
+        Reserves","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Reserves)"},{"Value":"Institute
+        Archives","AddAction":"addlimiter(LB:MIT Course Reserves-Institute Archives)"},{"Value":"Internet
+        Resource","AddAction":"addlimiter(LB:MIT Course Reserves-Internet Resource)"},{"Value":"Lewis
+        Music Library","AddAction":"addlimiter(LB:MIT Course Reserves-Lewis Music
+        Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Visual Collections)"}]}],"DefaultOn":"n","Order":"8"},{"Id":"FT1","Label":"Available
+        in Library Collection","Type":"select","AddAction":"addlimiter(FT1:value)","DefaultOn":"n","Order":"9"},{"Id":"FC","Label":"Catalog
+        Only","Type":"select","AddAction":"addlimiter(FC:value)","DefaultOn":"n","Order":"10"},{"Id":"LA99","Label":"Language","Type":"multiselectvalue","LimiterValues":[{"Value":"Afrikaans","AddAction":"addlimiter(LA99:Afrikaans)"},{"Value":"Albanian","AddAction":"addlimiter(LA99:Albanian)"},{"Value":"Aleut","AddAction":"addlimiter(LA99:Aleut)"},{"Value":"Arabic","AddAction":"addlimiter(LA99:Arabic)"},{"Value":"Chinese","AddAction":"addlimiter(LA99:Chinese)"},{"Value":"Czech","AddAction":"addlimiter(LA99:Czech)"},{"Value":"Danish","AddAction":"addlimiter(LA99:Danish)"},{"Value":"Dutch;
+        Flemish","AddAction":"addlimiter(LA99:Dutch; Flemish)"},{"Value":"English","AddAction":"addlimiter(LA99:English)"},{"Value":"Finnish","AddAction":"addlimiter(LA99:Finnish)"},{"Value":"French","AddAction":"addlimiter(LA99:French)"},{"Value":"German","AddAction":"addlimiter(LA99:German)"},{"Value":"Haitian;
+        Haitian Creole","AddAction":"addlimiter(LA99:Haitian; Haitian Creole)"},{"Value":"Hebrew","AddAction":"addlimiter(LA99:Hebrew)"},{"Value":"Hmong;
+        Mong","AddAction":"addlimiter(LA99:Hmong; Mong)"},{"Value":"Indonesian","AddAction":"addlimiter(LA99:Indonesian)"},{"Value":"Inupiaq","AddAction":"addlimiter(LA99:Inupiaq)"},{"Value":"Italian","AddAction":"addlimiter(LA99:Italian)"},{"Value":"Japanese","AddAction":"addlimiter(LA99:Japanese)"},{"Value":"Korean","AddAction":"addlimiter(LA99:Korean)"},{"Value":"Lao","AddAction":"addlimiter(LA99:Lao)"},{"Value":"Latin","AddAction":"addlimiter(LA99:Latin)"},{"Value":"Lithuanian","AddAction":"addlimiter(LA99:Lithuanian)"},{"Value":"Navajo;
+        Navaho","AddAction":"addlimiter(LA99:Navajo; Navaho)"},{"Value":"Persian","AddAction":"addlimiter(LA99:Persian)"},{"Value":"Polish","AddAction":"addlimiter(LA99:Polish)"},{"Value":"Portuguese","AddAction":"addlimiter(LA99:Portuguese)"},{"Value":"Pushto;
+        Pashto","AddAction":"addlimiter(LA99:Pushto; Pashto)"},{"Value":"Romanian;
+        Moldavian; Moldovan","AddAction":"addlimiter(LA99:Romanian; Moldavian; Moldovan)"},{"Value":"Russian","AddAction":"addlimiter(LA99:Russian)"},{"Value":"Spanish;
+        Castilian","AddAction":"addlimiter(LA99:Spanish; Castilian)"},{"Value":"Swedish","AddAction":"addlimiter(LA99:Swedish)"},{"Value":"Tagalog","AddAction":"addlimiter(LA99:Tagalog)"},{"Value":"Thai","AddAction":"addlimiter(LA99:Thai)"},{"Value":"Turkish","AddAction":"addlimiter(LA99:Turkish)"},{"Value":"Ukrainian","AddAction":"addlimiter(LA99:Ukrainian)"},{"Value":"Vietnamese","AddAction":"addlimiter(LA99:Vietnamese)"},{"Value":"Croatian","AddAction":"addlimiter(LA99:Croatian)"},{"Value":"Dutch\/Flemish","AddAction":"addlimiter(LA99:Dutch\/Flemish)"},{"Value":"Hungarian","AddAction":"addlimiter(LA99:Hungarian)"},{"Value":"Norwegian","AddAction":"addlimiter(LA99:Norwegian)"},{"Value":"Romanian","AddAction":"addlimiter(LA99:Romanian)"},{"Value":"Serbian","AddAction":"addlimiter(LA99:Serbian)"},{"Value":"Slovak","AddAction":"addlimiter(LA99:Slovak)"},{"Value":"Slovenian","AddAction":"addlimiter(LA99:Slovenian)"},{"Value":"Spanish","AddAction":"addlimiter(LA99:Spanish)"},{"Value":"Swahili","AddAction":"addlimiter(LA99:Swahili)"},{"Value":"Bosnian","AddAction":"addlimiter(LA99:Bosnian)"},{"Value":"Latvian","AddAction":"addlimiter(LA99:Latvian)"},{"Value":"Catalan","AddAction":"addlimiter(LA99:Catalan)"},{"Value":"Abkhazian","AddAction":"addlimiter(LA99:Abkhazian)"},{"Value":"Amharic","AddAction":"addlimiter(LA99:Amharic)"},{"Value":"Armenian","AddAction":"addlimiter(LA99:Armenian)"},{"Value":"Mapudungun;
+        Mapuche","AddAction":"addlimiter(LA99:Mapudungun; Mapuche)"},{"Value":"Asturian;
+        Bable; Leonese; Asturleonese","AddAction":"addlimiter(LA99:Asturian; Bable;
+        Leonese; Asturleonese)"},{"Value":"Australian languages","AddAction":"addlimiter(LA99:Australian
+        languages)"},{"Value":"Basque","AddAction":"addlimiter(LA99:Basque)"},{"Value":"Bengali","AddAction":"addlimiter(LA99:Bengali)"},{"Value":"Breton","AddAction":"addlimiter(LA99:Breton)"},{"Value":"Burmese","AddAction":"addlimiter(LA99:Burmese)"},{"Value":"Central
+        American Indian languages","AddAction":"addlimiter(LA99:Central American Indian
+        languages)"},{"Value":"Catalan; Valencian","AddAction":"addlimiter(LA99:Catalan;
+        Valencian)"},{"Value":"Chechen","AddAction":"addlimiter(LA99:Chechen)"},{"Value":"Coptic","AddAction":"addlimiter(LA99:Coptic)"},{"Value":"English,
+        Middle (1100-1500)","AddAction":"addlimiter(LA99:English\\, Middle \\(1100-1500\\))"},{"Value":"Esperanto","AddAction":"addlimiter(LA99:Esperanto)"},{"Value":"Estonian","AddAction":"addlimiter(LA99:Estonian)"},{"Value":"Faroese","AddAction":"addlimiter(LA99:Faroese)"},{"Value":"Fijian","AddAction":"addlimiter(LA99:Fijian)"},{"Value":"Germanic
+        languages","AddAction":"addlimiter(LA99:Germanic languages)"},{"Value":"Geez","AddAction":"addlimiter(LA99:Geez)"},{"Value":"Irish","AddAction":"addlimiter(LA99:Irish)"},{"Value":"Galician","AddAction":"addlimiter(LA99:Galician)"},{"Value":"Greek,
+        Ancient (to 1453)","AddAction":"addlimiter(LA99:Greek\\, Ancient \\(to 1453\\))"},{"Value":"Greek,
+        Modern (1453-)","AddAction":"addlimiter(LA99:Greek\\, Modern \\(1453-\\))"},{"Value":"Hindi","AddAction":"addlimiter(LA99:Hindi)"},{"Value":"Icelandic","AddAction":"addlimiter(LA99:Icelandic)"},{"Value":"Ido","AddAction":"addlimiter(LA99:Ido)"},{"Value":"Interlingua
+        (International Auxiliary Language Association)","AddAction":"addlimiter(LA99:Interlingua
+        \\(International Auxiliary Language Association\\))"},{"Value":"Javanese","AddAction":"addlimiter(LA99:Javanese)"},{"Value":"Judeo-Arabic","AddAction":"addlimiter(LA99:Judeo-Arabic)"},{"Value":"Kannada","AddAction":"addlimiter(LA99:Kannada)"},{"Value":"Luxembourgish;
+        Letzeburgesch","AddAction":"addlimiter(LA99:Luxembourgish; Letzeburgesch)"},{"Value":"Malayalam","AddAction":"addlimiter(LA99:Malayalam)"},{"Value":"Austronesian
+        languages","AddAction":"addlimiter(LA99:Austronesian languages)"},{"Value":"Malay","AddAction":"addlimiter(LA99:Malay)"},{"Value":"Maltese","AddAction":"addlimiter(LA99:Maltese)"},{"Value":"Mongolian","AddAction":"addlimiter(LA99:Mongolian)"},{"Value":"Nahuatl
+        languages","AddAction":"addlimiter(LA99:Nahuatl languages)"},{"Value":"Neapolitan","AddAction":"addlimiter(LA99:Neapolitan)"},{"Value":"Bokmål,
+        Norwegian; Norwegian Bokmål","AddAction":"addlimiter(LA99:Bokmål\\, Norwegian;
+        Norwegian Bokmål)"},{"Value":"Norse, Old","AddAction":"addlimiter(LA99:Norse\\,
+        Old)"},{"Value":"Occitan (post 1500)","AddAction":"addlimiter(LA99:Occitan
+        \\(post 1500\\))"},{"Value":"Ojibwa","AddAction":"addlimiter(LA99:Ojibwa)"},{"Value":"Philippine
+        languages","AddAction":"addlimiter(LA99:Philippine languages)"},{"Value":"Romany","AddAction":"addlimiter(LA99:Romany)"},{"Value":"Samaritan
+        Aramaic","AddAction":"addlimiter(LA99:Samaritan Aramaic)"},{"Value":"Sanskrit","AddAction":"addlimiter(LA99:Sanskrit)"},{"Value":"Sinhala;
+        Sinhalese","AddAction":"addlimiter(LA99:Sinhala; Sinhalese)"},{"Value":"Sundanese","AddAction":"addlimiter(LA99:Sundanese)"},{"Value":"Sumerian","AddAction":"addlimiter(LA99:Sumerian)"},{"Value":"Classical
+        Syriac","AddAction":"addlimiter(LA99:Classical Syriac)"},{"Value":"Tibetan","AddAction":"addlimiter(LA99:Tibetan)"},{"Value":"Ugaritic","AddAction":"addlimiter(LA99:Ugaritic)"},{"Value":"Welsh","AddAction":"addlimiter(LA99:Welsh)"},{"Value":"Yiddish","AddAction":"addlimiter(LA99:Yiddish)"},{"Value":"Zapotec","AddAction":"addlimiter(LA99:Zapotec)"},{"Value":"Azerbaijani","AddAction":"addlimiter(LA99:Azerbaijani)"},{"Value":"Bulgarian","AddAction":"addlimiter(LA99:Bulgarian)"},{"Value":"Greek","AddAction":"addlimiter(LA99:Greek)"},{"Value":"Serbo-Croatian","AddAction":"addlimiter(LA99:Serbo-Croatian)"},{"Value":"Urdu","AddAction":"addlimiter(LA99:Urdu)"},{"Value":"Belorussian","AddAction":"addlimiter(LA99:Belorussian)"},{"Value":"Dutch","AddAction":"addlimiter(LA99:Dutch)"},{"Value":"Georgian","AddAction":"addlimiter(LA99:Georgian)"},{"Value":"Kazakh","AddAction":"addlimiter(LA99:Kazakh)"},{"Value":"Malayan","AddAction":"addlimiter(LA99:Malayan)"},{"Value":"Moldavian","AddAction":"addlimiter(LA99:Moldavian)"},{"Value":"Ukranian","AddAction":"addlimiter(LA99:Ukranian)"},{"Value":"Uzbek","AddAction":"addlimiter(LA99:Uzbek)"},{"Value":"English,
+        Old (ca.450-1100)","AddAction":"addlimiter(LA99:English\\, Old \\(ca.450-1100\\))"},{"Value":"Belarusian","AddAction":"addlimiter(LA99:Belarusian)"},{"Value":"Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic","AddAction":"addlimiter(LA99:Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic)"},{"Value":"Creoles
+        and pidgins, English based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        English based)"},{"Value":"French, Middle (ca.1400-1600)","AddAction":"addlimiter(LA99:French\\,
+        Middle \\(ca.1400-1600\\))"},{"Value":"French, Old (842-ca.1400)","AddAction":"addlimiter(LA99:French\\,
+        Old \\(842-ca.1400\\))"},{"Value":"Gaelic; Scottish Gaelic","AddAction":"addlimiter(LA99:Gaelic;
+        Scottish Gaelic)"},{"Value":"Manx","AddAction":"addlimiter(LA99:Manx)"},{"Value":"German,
+        Middle High (ca.1050-1500)","AddAction":"addlimiter(LA99:German\\, Middle
+        High \\(ca.1050-1500\\))"},{"Value":"Gujarati","AddAction":"addlimiter(LA99:Gujarati)"},{"Value":"Hawaiian","AddAction":"addlimiter(LA99:Hawaiian)"},{"Value":"Iloko","AddAction":"addlimiter(LA99:Iloko)"},{"Value":"Uncoded
+        languages","AddAction":"addlimiter(LA99:Uncoded languages)"},{"Value":"Multiple
+        languages","AddAction":"addlimiter(LA99:Multiple languages)"},{"Value":"Turkish,
+        Ottoman (1500-1928)","AddAction":"addlimiter(LA99:Turkish\\, Ottoman \\(1500-1928\\))"},{"Value":"Pangasinan","AddAction":"addlimiter(LA99:Pangasinan)"},{"Value":"Pali","AddAction":"addlimiter(LA99:Pali)"},{"Value":"Prakrit
+        languages","AddAction":"addlimiter(LA99:Prakrit languages)"},{"Value":"Romance
+        languages","AddAction":"addlimiter(LA99:Romance languages)"},{"Value":"Romansh","AddAction":"addlimiter(LA99:Romansh)"},{"Value":"Scots","AddAction":"addlimiter(LA99:Scots)"},{"Value":"Slavic
+        languages","AddAction":"addlimiter(LA99:Slavic languages)"},{"Value":"Samoan","AddAction":"addlimiter(LA99:Samoan)"},{"Value":"Tahitian","AddAction":"addlimiter(LA99:Tahitian)"},{"Value":"Undetermined","AddAction":"addlimiter(LA99:Undetermined)"},{"Value":"Volapük","AddAction":"addlimiter(LA99:Volapük)"},{"Value":"No
+        linguistic content; Not applicable","AddAction":"addlimiter(LA99:No linguistic
+        content; Not applicable)"},{"Value":"FRENCH","AddAction":"addlimiter(LA99:FRENCH)"},{"Value":"PORTUGUESE","AddAction":"addlimiter(LA99:PORTUGUESE)"},{"Value":"RUSSIAN","AddAction":"addlimiter(LA99:RUSSIAN)"},{"Value":"SPANISH","AddAction":"addlimiter(LA99:SPANISH)"},{"Value":"GERMAN","AddAction":"addlimiter(LA99:GERMAN)"},{"Value":"ENGLISH","AddAction":"addlimiter(LA99:ENGLISH)"},{"Value":"CHINESE","AddAction":"addlimiter(LA99:CHINESE)"},{"Value":"Macedonian","AddAction":"addlimiter(LA99:Macedonian)"},{"Value":"Iranian
+        languages","AddAction":"addlimiter(LA99:Iranian languages)"},{"Value":"Marshallese","AddAction":"addlimiter(LA99:Marshallese)"},{"Value":"Nepali","AddAction":"addlimiter(LA99:Nepali)"},{"Value":"Nepal
+        Bhasa; Newari","AddAction":"addlimiter(LA99:Nepal Bhasa; Newari)"},{"Value":"Greek,
+        Modern","AddAction":"addlimiter(LA99:Greek\\, Modern)"},{"Value":"Acoli","AddAction":"addlimiter(LA99:Acoli)"},{"Value":"Afro-Asiatic
+        languages","AddAction":"addlimiter(LA99:Afro-Asiatic languages)"},{"Value":"Ainu","AddAction":"addlimiter(LA99:Ainu)"},{"Value":"Akan","AddAction":"addlimiter(LA99:Akan)"},{"Value":"Algonquian
+        languages","AddAction":"addlimiter(LA99:Algonquian languages)"},{"Value":"Southern
+        Altai","AddAction":"addlimiter(LA99:Southern Altai)"},{"Value":"Apache languages","AddAction":"addlimiter(LA99:Apache
+        languages)"},{"Value":"Avaric","AddAction":"addlimiter(LA99:Avaric)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Banda
+        languages","AddAction":"addlimiter(LA99:Banda languages)"},{"Value":"Bamileke
+        languages","AddAction":"addlimiter(LA99:Bamileke languages)"},{"Value":"Baluchi","AddAction":"addlimiter(LA99:Baluchi)"},{"Value":"Bambara","AddAction":"addlimiter(LA99:Bambara)"},{"Value":"Balinese","AddAction":"addlimiter(LA99:Balinese)"},{"Value":"Bemba","AddAction":"addlimiter(LA99:Bemba)"},{"Value":"Berber
+        languages","AddAction":"addlimiter(LA99:Berber languages)"},{"Value":"Bhojpuri","AddAction":"addlimiter(LA99:Bhojpuri)"},{"Value":"Bislama","AddAction":"addlimiter(LA99:Bislama)"},{"Value":"Bantu
+        languages","AddAction":"addlimiter(LA99:Bantu languages)"},{"Value":"Braj","AddAction":"addlimiter(LA99:Braj)"},{"Value":"Batak
+        languages","AddAction":"addlimiter(LA99:Batak languages)"},{"Value":"Buriat","AddAction":"addlimiter(LA99:Buriat)"},{"Value":"Galibi
+        Carib","AddAction":"addlimiter(LA99:Galibi Carib)"},{"Value":"Caucasian languages","AddAction":"addlimiter(LA99:Caucasian
+        languages)"},{"Value":"Chibcha","AddAction":"addlimiter(LA99:Chibcha)"},{"Value":"Corsican","AddAction":"addlimiter(LA99:Corsican)"},{"Value":"Creoles
+        and pidgins, French-based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        French-based)"},{"Value":"Creoles and pidgins, Portuguese-based","AddAction":"addlimiter(LA99:Creoles
+        and pidgins\\, Portuguese-based)"},{"Value":"Creoles and pidgins","AddAction":"addlimiter(LA99:Creoles
+        and pidgins)"},{"Value":"Slave (Athapascan)","AddAction":"addlimiter(LA99:Slave
+        \\(Athapascan\\))"},{"Value":"Duala","AddAction":"addlimiter(LA99:Duala)"},{"Value":"Dutch,
+        Middle (ca.1050-1350)","AddAction":"addlimiter(LA99:Dutch\\, Middle \\(ca.1050-1350\\))"},{"Value":"Dzongkha","AddAction":"addlimiter(LA99:Dzongkha)"},{"Value":"Efik","AddAction":"addlimiter(LA99:Efik)"},{"Value":"Egyptian
+        (Ancient)","AddAction":"addlimiter(LA99:Egyptian \\(Ancient\\))"},{"Value":"Ewe","AddAction":"addlimiter(LA99:Ewe)"},{"Value":"Fang","AddAction":"addlimiter(LA99:Fang)"},{"Value":"Filipino;
+        Pilipino","AddAction":"addlimiter(LA99:Filipino; Pilipino)"},{"Value":"Finno-Ugrian
+        languages","AddAction":"addlimiter(LA99:Finno-Ugrian languages)"},{"Value":"Fulah","AddAction":"addlimiter(LA99:Fulah)"},{"Value":"Ga","AddAction":"addlimiter(LA99:Ga)"},{"Value":"Gilbertese","AddAction":"addlimiter(LA99:Gilbertese)"},{"Value":"German,
+        Old High (ca.750-1050)","AddAction":"addlimiter(LA99:German\\, Old High \\(ca.750-1050\\))"},{"Value":"Gondi","AddAction":"addlimiter(LA99:Gondi)"},{"Value":"Swiss
+        German; Alemannic; Alsatian","AddAction":"addlimiter(LA99:Swiss German; Alemannic;
+        Alsatian)"},{"Value":"Haida","AddAction":"addlimiter(LA99:Haida)"},{"Value":"Hausa","AddAction":"addlimiter(LA99:Hausa)"},{"Value":"Igbo","AddAction":"addlimiter(LA99:Igbo)"},{"Value":"Inuktitut","AddAction":"addlimiter(LA99:Inuktitut)"},{"Value":"Indic
+        languages","AddAction":"addlimiter(LA99:Indic languages)"},{"Value":"Indo-European
+        languages","AddAction":"addlimiter(LA99:Indo-European languages)"},{"Value":"Iroquoian
+        languages","AddAction":"addlimiter(LA99:Iroquoian languages)"},{"Value":"Kabyle","AddAction":"addlimiter(LA99:Kabyle)"},{"Value":"Kalaallisut;
+        Greenlandic","AddAction":"addlimiter(LA99:Kalaallisut; Greenlandic)"},{"Value":"Kamba","AddAction":"addlimiter(LA99:Kamba)"},{"Value":"Karen
+        languages","AddAction":"addlimiter(LA99:Karen languages)"},{"Value":"Khoisan
+        languages","AddAction":"addlimiter(LA99:Khoisan languages)"},{"Value":"Central
+        Khmer","AddAction":"addlimiter(LA99:Central Khmer)"},{"Value":"Kinyarwanda","AddAction":"addlimiter(LA99:Kinyarwanda)"},{"Value":"Kirghiz;
+        Kyrgyz","AddAction":"addlimiter(LA99:Kirghiz; Kyrgyz)"},{"Value":"Kpelle","AddAction":"addlimiter(LA99:Kpelle)"},{"Value":"Kurdish","AddAction":"addlimiter(LA99:Kurdish)"},{"Value":"Ladino","AddAction":"addlimiter(LA99:Ladino)"},{"Value":"Lingala","AddAction":"addlimiter(LA99:Lingala)"},{"Value":"Luba-Katanga","AddAction":"addlimiter(LA99:Luba-Katanga)"},{"Value":"Ganda","AddAction":"addlimiter(LA99:Ganda)"},{"Value":"Lunda","AddAction":"addlimiter(LA99:Lunda)"},{"Value":"Madurese","AddAction":"addlimiter(LA99:Madurese)"},{"Value":"Mandingo","AddAction":"addlimiter(LA99:Mandingo)"},{"Value":"Maori","AddAction":"addlimiter(LA99:Maori)"},{"Value":"Marathi","AddAction":"addlimiter(LA99:Marathi)"},{"Value":"Masai","AddAction":"addlimiter(LA99:Masai)"},{"Value":"Mende","AddAction":"addlimiter(LA99:Mende)"},{"Value":"Mon-Khmer
+        languages","AddAction":"addlimiter(LA99:Mon-Khmer languages)"},{"Value":"Malagasy","AddAction":"addlimiter(LA99:Malagasy)"},{"Value":"Mayan
+        languages","AddAction":"addlimiter(LA99:Mayan languages)"},{"Value":"North
+        American Indian languages","AddAction":"addlimiter(LA99:North American Indian
+        languages)"},{"Value":"Ndebele, North; North Ndebele","AddAction":"addlimiter(LA99:Ndebele\\,
+        North; North Ndebele)"},{"Value":"Niger-Kordofanian languages","AddAction":"addlimiter(LA99:Niger-Kordofanian
+        languages)"},{"Value":"Chichewa; Chewa; Nyanja","AddAction":"addlimiter(LA99:Chichewa;
+        Chewa; Nyanja)"},{"Value":"Nyankole","AddAction":"addlimiter(LA99:Nyankole)"},{"Value":"Papuan
+        languages","AddAction":"addlimiter(LA99:Papuan languages)"},{"Value":"Pampanga;
+        Kapampangan","AddAction":"addlimiter(LA99:Pampanga; Kapampangan)"},{"Value":"Panjabi;
+        Punjabi","AddAction":"addlimiter(LA99:Panjabi; Punjabi)"},{"Value":"Papiamento","AddAction":"addlimiter(LA99:Papiamento)"},{"Value":"Provençal,
+        Old (to 1500);Occitan, Old (to 1500)","AddAction":"addlimiter(LA99:Provençal\\,
+        Old \\(to 1500\\);Occitan\\, Old \\(to 1500\\))"},{"Value":"Quechua","AddAction":"addlimiter(LA99:Quechua)"},{"Value":"Rajasthani","AddAction":"addlimiter(LA99:Rajasthani)"},{"Value":"Rarotongan;
+        Cook Islands Maori","AddAction":"addlimiter(LA99:Rarotongan; Cook Islands
+        Maori)"},{"Value":"Rundi","AddAction":"addlimiter(LA99:Rundi)"},{"Value":"South
+        American Indian languages","AddAction":"addlimiter(LA99:South American Indian
+        languages)"},{"Value":"Salishan languages","AddAction":"addlimiter(LA99:Salishan
+        languages)"},{"Value":"Sino-Tibetan languages","AddAction":"addlimiter(LA99:Sino-Tibetan
+        languages)"},{"Value":"Sami languages","AddAction":"addlimiter(LA99:Sami languages)"},{"Value":"Shona","AddAction":"addlimiter(LA99:Shona)"},{"Value":"Somali","AddAction":"addlimiter(LA99:Somali)"},{"Value":"Sotho,
+        Southern","AddAction":"addlimiter(LA99:Sotho\\, Southern)"},{"Value":"Sardinian","AddAction":"addlimiter(LA99:Sardinian)"},{"Value":"Nilo-Saharan
+        languages","AddAction":"addlimiter(LA99:Nilo-Saharan languages)"},{"Value":"Swati","AddAction":"addlimiter(LA99:Swati)"},{"Value":"Susu","AddAction":"addlimiter(LA99:Susu)"},{"Value":"Syriac","AddAction":"addlimiter(LA99:Syriac)"},{"Value":"Tamil","AddAction":"addlimiter(LA99:Tamil)"},{"Value":"Tatar","AddAction":"addlimiter(LA99:Tatar)"},{"Value":"Telugu","AddAction":"addlimiter(LA99:Telugu)"},{"Value":"Tajik","AddAction":"addlimiter(LA99:Tajik)"},{"Value":"Tigrinya","AddAction":"addlimiter(LA99:Tigrinya)"},{"Value":"Tamashek","AddAction":"addlimiter(LA99:Tamashek)"},{"Value":"Tonga
+        (Nyasa)","AddAction":"addlimiter(LA99:Tonga \\(Nyasa\\))"},{"Value":"Tonga
+        (Tonga Islands)","AddAction":"addlimiter(LA99:Tonga \\(Tonga Islands\\))"},{"Value":"Tok
+        Pisin","AddAction":"addlimiter(LA99:Tok Pisin)"},{"Value":"Tswana","AddAction":"addlimiter(LA99:Tswana)"},{"Value":"Turkmen","AddAction":"addlimiter(LA99:Turkmen)"},{"Value":"Tumbuka","AddAction":"addlimiter(LA99:Tumbuka)"},{"Value":"Altaic
+        languages","AddAction":"addlimiter(LA99:Altaic languages)"},{"Value":"Twi","AddAction":"addlimiter(LA99:Twi)"},{"Value":"Tuvinian","AddAction":"addlimiter(LA99:Tuvinian)"},{"Value":"Uighur;
+        Uyghur","AddAction":"addlimiter(LA99:Uighur; Uyghur)"},{"Value":"Umbundu","AddAction":"addlimiter(LA99:Umbundu)"},{"Value":"Wakashan
+        languages","AddAction":"addlimiter(LA99:Wakashan languages)"},{"Value":"Wolof","AddAction":"addlimiter(LA99:Wolof)"},{"Value":"Xhosa","AddAction":"addlimiter(LA99:Xhosa)"},{"Value":"Yao","AddAction":"addlimiter(LA99:Yao)"},{"Value":"Yoruba","AddAction":"addlimiter(LA99:Yoruba)"},{"Value":"Yupik
+        languages","AddAction":"addlimiter(LA99:Yupik languages)"},{"Value":"Zulu","AddAction":"addlimiter(LA99:Zulu)"},{"Value":"Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki","AddAction":"addlimiter(LA99:Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki)"},{"Value":"Venda","AddAction":"addlimiter(LA99:Venda)"},{"Value":"Aragonese","AddAction":"addlimiter(LA99:Aragonese)"}],"DefaultOn":"n","Order":"11"}],"AvailableSearchModes":[{"Mode":"bool","Label":"Boolean\/Phrase","DefaultOn":"n","AddAction":"setsearchmode(bool)"},{"Mode":"all","Label":"Find
+        all my search terms","DefaultOn":"y","AddAction":"setsearchmode(all)"},{"Mode":"any","Label":"Find
+        any of my search terms","DefaultOn":"n","AddAction":"setsearchmode(any)"},{"Mode":"smart","Label":"SmartText
+        Searching","DefaultOn":"n","AddAction":"setsearchmode(smart)"}],"AvailableRelatedContent":[{"Type":"emp","Label":"Exact
+        Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
+        Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
+        You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief","IncludeImageQuickView":{"Id":"ImageQuickViewResults","Label":"Image
+        Quick View Results","DefaultOn":"n"}},"ApplicationSettings":{"SessionTimeout":"900"},"ApiSettings":{"MaxRecordJumpAhead":"250"},"ExportFormatSettings":{"AvailableFormats":[{"Id":"RIS","Label":"RIS
+        Format"}]},"CitationStyleSettings":{"AvailableStyles":[{"Id":"abnt","Label":"ABNT"},{"Id":"ama","Label":"AMA
+        11th Edition"},{"Id":"apa","Label":"APA 7th Edition"},{"Id":"chicago","Label":"Chicago
+        17th Edition"},{"Id":"harvard","Label":"Harvard"},{"Id":"harvardaustralian","Label":"Harvard:
+        Australian"},{"Id":"mla","Label":"MLA 8th Edition"},{"Id":"turabian","Label":"Chicago
+        17th Edition"},{"Id":"vancouver","Label":"Vancouver\/ICMJE"}]}}'
+  recorded_at: Wed, 16 Jun 2021 20:22:36 GMT
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
+    body:
+      encoding: UTF-8
+      string: '{"DbId":"aci","An":"123877356","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:36 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - d010ec4c-7873-4f51-8ad4-776dcdf47943
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '777872804'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '3039'
+    body:
+      encoding: UTF-8
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"aci","DbLabel":"Applied Science
+        & Technology Source","An":"123877356","AccessLevel":"2","PubType":"Academic
+        Journal","PubTypeId":"academicJournal"},"PLink":"https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=aci&AN=123877356&authtype=sso&custid=s8978330","FullText":{"Links":[{"Type":"pdflink"}],"Text":{"Availability":"0"},"CustomLinks":[{"Url":"http:\/\/sfx.mit.edu\/sfx_local?genre=article&isbn=&issn=20796374&title=Biosensors
+        (2079-6374)&volume=7&issue=2&date=20170601&atitle=Ultrasensitive%20Label-Free%20Sensing%20of%20IL-6%20Based%20on%20PASE%20Functionalized%20Carbon%20Nanotube%20Micro-Arrays%20with%20RNA-Aptamers%20as%20Molecular%20Recognition%20Elements.&aulast=Khosravi,
+        Farhad&spage=17&sid=EBSCO:Applied%20Science%20%26%20Technology%20Source&pid=<authors>Khosravi,
+        Farhad<\/authors><ui>123877356<\/ui><date>20170601<\/date><db>Applied%20Science%20%26%20Technology%20Source<\/db>","Name":"SFX
+        link filtered to collection fthi1 (For su)","Category":"fullText","Text":"","Icon":"http:\/\/libraries.mit.edu\/img\/sfx\/sfx-mit.gif"}]},"Items":[{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AU&quot; term=&quot;%22Khosravi%2C+Farhad%22&quot;&gt;Khosravi,
+        Farhad&lt;\/searchLink&gt;&lt;relatesTo&gt;1&lt;\/relatesTo&gt;, &lt;i&gt;fkhosravi@wpi.edu&lt;\/i&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AU&quot; term=&quot;%22Loeian%2C+Seyed+Masoud%22&quot;&gt;Loeian,
+        Seyed Masoud&lt;\/searchLink&gt;&lt;relatesTo&gt;1&lt;\/relatesTo&gt;, &lt;i&gt;smloeian@wpi.edu&lt;\/i&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;AU&quot; term=&quot;%22Panchapakesan%2C+Balaji%22&quot;&gt;Panchapakesan,
+        Balaji&lt;\/searchLink&gt;&lt;relatesTo&gt;1&lt;\/relatesTo&gt;, &lt;i&gt;bpanchapakesan@wpi.edu&lt;\/i&gt;"},{"Name":"TitleSource","Label":"Source","Group":"Src","Data":"&lt;searchLink
+        fieldCode=&quot;JN&quot; term=&quot;%22Biosensors+%282079-6374%29%22&quot;&gt;Biosensors
+        (2079-6374)&lt;\/searchLink&gt;; Jun2017, Vol. 7 Issue 2, p17, 13p"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Identifiers":[{"Type":"doi","Value":"10.3390\/bios7020017"}],"Languages":[{"Code":"eng","Text":"English"}],"PhysicalDescription":{"Pagination":{"PageCount":"13","StartPage":"17"}},"Titles":[{"TitleFull":"Ultrasensitive
+        Label-Free Sensing of IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays
+        with RNA-Aptamers as Molecular Recognition Elements.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Khosravi,
+        Farhad"}}},{"PersonEntity":{"Name":{"NameFull":"Loeian, Seyed Masoud"}}},{"PersonEntity":{"Name":{"NameFull":"Panchapakesan,
+        Balaji"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"06","Text":"Jun2017","Type":"published","Y":"2017"}],"Identifiers":[{"Type":"issn-print","Value":"20796374"}],"Numbering":[{"Type":"volume","Value":"7"},{"Type":"issue","Value":"2"}],"Titles":[{"TitleFull":"Biosensors
+        (2079-6374)","Type":"main"}]}}]}}},"IllustrationInfo":{}}}'
+  recorded_at: Wed, 16 Jun 2021 20:22:36 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/ExportFormat?an=123877356&dbid=aci&format=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:36 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - a3ac0253-4d3c-4170-9ebf-e205c829b768
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '974705124'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '3640'
+    body:
+      encoding: UTF-8
+      string: '{"Format":"RIS","Label":"RIS Format","Data":"TY  - JOUR\u000d\u000aAU  -
+        Khosravi, Farhad\u000d\u000aAU  - Loeian, Seyed Masoud\u000d\u000aAU  - Panchapakesan,
+        Balaji\u000d\u000aT1  - Ultrasensitive Label-Free Sensing of IL-6 Based on
+        PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular
+        Recognition Elements.\u000d\u000aJO  - Biosensors (2079-6374)\u000d\u000aJF  -
+        Biosensors (2079-6374)\u000d\u000aJ1  - Biosensors (2079-6374)\u000d\u000aPY  -
+        2017\/06\/\/\u000d\u000aY1  - 2017\/06\/\/\u000d\u000aVL  - 7\u000d\u000aIS  -
+        2\u000d\u000aCP  - 2\u000d\u000aM3  - Article\u000d\u000aSP  - 17\u000d\u000aSN  -
+        20796374\u000d\u000aAB  - This study demonstrates the rapid and label-free
+        detection of Interleukin-6 (IL-6) using carbon nanotube micro-arrays with
+        aptamer as the molecular recognition element. Single wall carbon nanotubes
+        micro-arrays biosensors were manufactured using photo-lithography, metal deposition,
+        and etching techniques. Nanotube biosensors were functionalized with 1-Pyrenebutanoic
+        Acid Succinimidyl Ester (PASE) conjugated IL-6 aptamers. Real time response
+        of the sensor conductance was monitored with increasing concentration of IL-6
+        (1 pg\/mL to 10 ng\/mL), exposure to the sensing surface in buffer solution,
+        and clinically relevant spiked blood samples. Non-specific Bovine Serum Albumin
+        (BSA), PBS samples, and anti-IgG functionalized devices gave similar signatures
+        in the real time conductance versus time experiments with no significant change
+        in sensor signal. Exposure of the aptamer functionalized nanotube surface
+        to IL-6 decreased the conductance with increasing concentration of IL-6. Experiments
+        based on field effect transistor arrays suggested shift in drain current versus
+        gate voltage for 1 pg and 1 ng of IL-6 exposure. Non-specific BSA did not
+        produce any appreciable shift in the Ids versus Vg suggesting specific interactions
+        of IL-6 on PASE conjugated aptamer surface gave rise to the change in electrical
+        signal. Both Z axis and phase image in an Atomic Force Microscope (AFM) suggested
+        unambiguous molecular interaction of the IL-6 on the nanotube-aptamer surface
+        at 1 pg\/mL concentration. The concentration of 1 pg falls below the diagnostic
+        gray zone for cancer (2.3 pg-4 ng\/mL), which is an indicator of early stage
+        cancer. Thus, nanotube micro-arrays could potentially be developed for creating
+        multiplexed assays involving cancer biomarker proteins and possibly circulating
+        tumor cells all in a single assay using PASE functionalization protocol. [ABSTRACT
+        FROM AUTHOR]\u000d\u000aKW  - Carbon nanotubes\u000d\u000aKW  - Biosensors\u000d\u000aKW  -
+        Molecular recognition\u000d\u000aKW  - Carbon Nanotube Biosensors\u000d\u000aKW  -
+        Field Effect Transistors\u000d\u000aKW  - IL6\u000d\u000aN1  - Accession Number:
+        123877356; Authors: Khosravi, Farhad 1 Email Address: fkhosravi@wpi.edu; Loeian,
+        Seyed Masoud 1 Email Address: smloeian@wpi.edu; Panchapakesan, Balaji 1 Email
+        Address: bpanchapakesan@wpi.edu; Affiliations:  1: Small Systems Laboratory,
+        Department of Mechanical Engineering, Worcester Polytechnic Institute, Worcester,
+        MA 01532, USA; Subject: Carbon nanotubes; Subject: Biosensors; Subject: Molecular
+        recognition; Author-Supplied Keyword: Carbon Nanotube Biosensors; Author-Supplied
+        Keyword: Field Effect Transistors; Author-Supplied Keyword: IL6; Number of
+        Pages: 13p; Record Type: Article\u000d\u000aL3  - 10.3390\/bios7020017\u000d\u000aUR  -
+        https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=aci&AN=123877356&authtype=sso&custid=s8978330\u000d\u000aDP  -
+        EBSCOhost\u000d\u000aDB  - aci\u000d\u000aER  - \u000d\u000a"}'
+  recorded_at: Wed, 16 Jun 2021 20:22:36 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CitationStyles?an=123877356&dbid=aci&styles=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:22:36 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Msg-Correlid:
+      - b14a5c1f-d05c-4295-a86a-000e17ebf3e8
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '4011'
+    body:
+      encoding: UTF-8
+      string: '{"Citations":[{"Id":"abnt","Label":"ABNT","SectionLabel":"References","Data":"KHOSRAVI,
+        F.; LOEIAN, S. M.; PANCHAPAKESAN, B. Ultrasensitive Label-Free Sensing of
+        IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers
+        as Molecular Recognition Elements. <b>Biosensors (2079-6374)<\/b>, <i>[s.
+        l.]<\/i>, v. 7, n. 2, p. 17, 2017. DOI 10.3390\/bios7020017. Disponível em:
+        https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=aci&AN=123877356&authtype=sso&custid=s8978330.
+        Acesso em: 16 jun. 2021.","Caption":"Brazilian National Standards"},{"Id":"ama","Label":"AMA
+        11th Edition","SectionLabel":"Reference List","Data":"Khosravi F, Loeian SM,
+        Panchapakesan B. Ultrasensitive Label-Free Sensing of IL-6 Based on PASE Functionalized
+        Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular Recognition Elements.
+        <i>Biosensors (2079-6374)<\/i>. 2017;7(2):17. doi:10.3390\/bios7020017","Caption":"American
+        Medical Assoc."},{"Id":"apa","Label":"APA 7th Edition","SectionLabel":"References","Data":"Khosravi,
+        F., Loeian, S. M., & Panchapakesan, B. (2017). Ultrasensitive Label-Free Sensing
+        of IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers
+        as Molecular Recognition Elements. <i>Biosensors (2079-6374)<\/i>, <i>7<\/i>(2),
+        17. https:\/\/doi.org\/10.3390\/bios7020017","Caption":"American Psychological
+        Assoc.","Indent":1},{"Id":"chicago","Label":"Chicago 17th Edition","SectionLabel":"Reference
+        List","Data":"Khosravi, Farhad, Seyed Masoud Loeian, and Balaji Panchapakesan.
+        2017. “Ultrasensitive Label-Free Sensing of IL-6 Based on PASE Functionalized
+        Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular Recognition Elements.”
+        <i>Biosensors (2079-6374)<\/i> 7 (2): 17. doi:10.3390\/bios7020017.","Caption":"Author-Date","Indent":1},{"Id":"harvard","Label":"Harvard","SectionLabel":"References","Data":"Khosravi,
+        F., Loeian, S. M. and Panchapakesan, B. (2017) ‘Ultrasensitive Label-Free
+        Sensing of IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays
+        with RNA-Aptamers as Molecular Recognition Elements’, <i>Biosensors (2079-6374)<\/i>,
+        7(2), p. 17. doi: 10.3390\/bios7020017."},{"Id":"harvardaustralian","Label":"Harvard:
+        Australian","SectionLabel":"References","Data":"Khosravi, F, Loeian, SM &
+        Panchapakesan, B 2017, ‘Ultrasensitive Label-Free Sensing of IL-6 Based on
+        PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular
+        Recognition Elements’, <i>Biosensors (2079-6374)<\/i>, vol. 7, no. 2, p. 17,
+        viewed 16 June 2021, <https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=aci&AN=123877356&authtype=sso&custid=s8978330>."},{"Id":"mla","Label":"MLA
+        8th Edition","SectionLabel":"Works Cited","Data":"Khosravi, Farhad, et al.
+        “Ultrasensitive Label-Free Sensing of IL-6 Based on PASE Functionalized Carbon
+        Nanotube Micro-Arrays with RNA-Aptamers as Molecular Recognition Elements.”
+        <i>Biosensors (2079-6374)<\/i>, vol. 7, no. 2, June 2017, p. 17. <i>EBSCOhost<\/i>,
+        doi:10.3390\/bios7020017.","Caption":"Modern Language Assoc.","Indent":1},{"Id":"turabian","Label":"Chicago
+        17th Edition","SectionLabel":"Bibliography","Data":"Khosravi, Farhad, Seyed
+        Masoud Loeian, and Balaji Panchapakesan. “Ultrasensitive Label-Free Sensing
+        of IL-6 Based on PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers
+        as Molecular Recognition Elements.” <i>Biosensors (2079-6374)<\/i> 7, no.
+        2 (June 2017): 17. doi:10.3390\/bios7020017.","Caption":"Notes & Bibliography","Indent":1},{"Id":"vancouver","Label":"Vancouver\/ICMJE","SectionLabel":"References","Data":"Khosravi
+        F, Loeian SM, Panchapakesan B. Ultrasensitive Label-Free Sensing of IL-6 Based
+        on PASE Functionalized Carbon Nanotube Micro-Arrays with RNA-Aptamers as Molecular
+        Recognition Elements. Biosensors (2079-6374) [Internet]. 2017 Jun [cited 2021
+        Jun 16];7(2):17. Available from: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=aci&AN=123877356&authtype=sso&custid=s8978330"}]}'
+  recorded_at: Wed, 16 Jun 2021 20:22:37 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/sru_book.yml
+++ b/test/vcr_cassettes/sru_book.yml
@@ -1,0 +1,1844 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:44 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+  recorded_at: Wed, 16 Jun 2021 20:00:45 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:45 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 36e81b15-da6b-410c-a736-f02a0f79ada6
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-381234571"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"dd97bef9-eab1-4265-89cf-673fa49b90ad.qQgvyQMyAqRIp32LD3kBlGFIHOR62tg\/6pqWhTh1uxc="}'
+  recorded_at: Wed, 16 Jun 2021 20:00:45 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:45 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 11c87ab0-7315-44af-8440-25d29b5a7151
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '766386613'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '100'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"FakeSessiontoken"}'
+  recorded_at: Wed, 16 Jun 2021 20:00:46 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:45 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - f9b678e7-dc80-4e20-b40f-e9f3af404f0d
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-381234571"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '26533'
+    body:
+      encoding: UTF-8
+      string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"relevance","Label":"Relevance","AddAction":"setsort(relevance)"},{"Id":"date","Label":"Date
+        Newest","AddAction":"setsort(date)"},{"Id":"date2","Label":"Date Oldest","AddAction":"setsort(date2)"}],"AvailableSearchFields":[{"FieldCode":"TX","Label":"All
+        Text"},{"FieldCode":"AU","Label":"Author"},{"FieldCode":"TI","Label":"Title"},{"FieldCode":"SU","Label":"Subject
+        Terms"},{"FieldCode":"SO","Label":"Source"},{"FieldCode":"AB","Label":"Abstract"},{"FieldCode":"IS","Label":"ISSN"},{"FieldCode":"IB","Label":"ISBN"}],"AvailableExpanders":[{"Id":"thesaurus","Label":"Apply
+        related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
+        search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"},{"Id":"relatedsubjects","Label":"Apply
+        equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"2"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
+        Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
+        Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
+        Barton Catalog","AddAction":"addlimiter(LB:MIT Barton Catalog)","LimiterValues":[{"Value":"Barker
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Barker Library)"},{"Value":"Dewey
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Dewey Library)"},{"Value":"Hayden
+        Library - Humanities","AddAction":"addlimiter(LB:MIT Barton Catalog-Hayden
+        Library - Humanities)"},{"Value":"Hayden Library - Science","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Library - Science)"},{"Value":"Hayden Reserves","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Reserves)"},{"Value":"Institute Archives","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Institute Archives)"},{"Value":"Internet Resource","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Internet Resource)"},{"Value":"Lewis Music Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Lewis Music Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Visual Collections)"}]},{"Value":"MIT Course Reserves","AddAction":"addlimiter(LB:MIT
+        Course Reserves)","LimiterValues":[{"Value":"Barker Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Barker Library)"},{"Value":"Dewey Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Dewey Library)"},{"Value":"Hayden Library - Humanities","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Hayden Library - Humanities)"},{"Value":"Hayden Library -
+        Science","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Library - Science)"},{"Value":"Hayden
+        Reserves","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Reserves)"},{"Value":"Institute
+        Archives","AddAction":"addlimiter(LB:MIT Course Reserves-Institute Archives)"},{"Value":"Internet
+        Resource","AddAction":"addlimiter(LB:MIT Course Reserves-Internet Resource)"},{"Value":"Lewis
+        Music Library","AddAction":"addlimiter(LB:MIT Course Reserves-Lewis Music
+        Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Visual Collections)"}]}],"DefaultOn":"n","Order":"8"},{"Id":"FT1","Label":"Available
+        in Library Collection","Type":"select","AddAction":"addlimiter(FT1:value)","DefaultOn":"n","Order":"9"},{"Id":"FC","Label":"Catalog
+        Only","Type":"select","AddAction":"addlimiter(FC:value)","DefaultOn":"n","Order":"10"},{"Id":"LA99","Label":"Language","Type":"multiselectvalue","LimiterValues":[{"Value":"Afrikaans","AddAction":"addlimiter(LA99:Afrikaans)"},{"Value":"Albanian","AddAction":"addlimiter(LA99:Albanian)"},{"Value":"Aleut","AddAction":"addlimiter(LA99:Aleut)"},{"Value":"Arabic","AddAction":"addlimiter(LA99:Arabic)"},{"Value":"Chinese","AddAction":"addlimiter(LA99:Chinese)"},{"Value":"Czech","AddAction":"addlimiter(LA99:Czech)"},{"Value":"Danish","AddAction":"addlimiter(LA99:Danish)"},{"Value":"Dutch;
+        Flemish","AddAction":"addlimiter(LA99:Dutch; Flemish)"},{"Value":"English","AddAction":"addlimiter(LA99:English)"},{"Value":"Finnish","AddAction":"addlimiter(LA99:Finnish)"},{"Value":"French","AddAction":"addlimiter(LA99:French)"},{"Value":"German","AddAction":"addlimiter(LA99:German)"},{"Value":"Haitian;
+        Haitian Creole","AddAction":"addlimiter(LA99:Haitian; Haitian Creole)"},{"Value":"Hebrew","AddAction":"addlimiter(LA99:Hebrew)"},{"Value":"Hmong;
+        Mong","AddAction":"addlimiter(LA99:Hmong; Mong)"},{"Value":"Indonesian","AddAction":"addlimiter(LA99:Indonesian)"},{"Value":"Inupiaq","AddAction":"addlimiter(LA99:Inupiaq)"},{"Value":"Italian","AddAction":"addlimiter(LA99:Italian)"},{"Value":"Japanese","AddAction":"addlimiter(LA99:Japanese)"},{"Value":"Korean","AddAction":"addlimiter(LA99:Korean)"},{"Value":"Lao","AddAction":"addlimiter(LA99:Lao)"},{"Value":"Latin","AddAction":"addlimiter(LA99:Latin)"},{"Value":"Lithuanian","AddAction":"addlimiter(LA99:Lithuanian)"},{"Value":"Navajo;
+        Navaho","AddAction":"addlimiter(LA99:Navajo; Navaho)"},{"Value":"Persian","AddAction":"addlimiter(LA99:Persian)"},{"Value":"Polish","AddAction":"addlimiter(LA99:Polish)"},{"Value":"Portuguese","AddAction":"addlimiter(LA99:Portuguese)"},{"Value":"Pushto;
+        Pashto","AddAction":"addlimiter(LA99:Pushto; Pashto)"},{"Value":"Romanian;
+        Moldavian; Moldovan","AddAction":"addlimiter(LA99:Romanian; Moldavian; Moldovan)"},{"Value":"Russian","AddAction":"addlimiter(LA99:Russian)"},{"Value":"Spanish;
+        Castilian","AddAction":"addlimiter(LA99:Spanish; Castilian)"},{"Value":"Swedish","AddAction":"addlimiter(LA99:Swedish)"},{"Value":"Tagalog","AddAction":"addlimiter(LA99:Tagalog)"},{"Value":"Thai","AddAction":"addlimiter(LA99:Thai)"},{"Value":"Turkish","AddAction":"addlimiter(LA99:Turkish)"},{"Value":"Ukrainian","AddAction":"addlimiter(LA99:Ukrainian)"},{"Value":"Vietnamese","AddAction":"addlimiter(LA99:Vietnamese)"},{"Value":"Croatian","AddAction":"addlimiter(LA99:Croatian)"},{"Value":"Dutch\/Flemish","AddAction":"addlimiter(LA99:Dutch\/Flemish)"},{"Value":"Hungarian","AddAction":"addlimiter(LA99:Hungarian)"},{"Value":"Norwegian","AddAction":"addlimiter(LA99:Norwegian)"},{"Value":"Romanian","AddAction":"addlimiter(LA99:Romanian)"},{"Value":"Serbian","AddAction":"addlimiter(LA99:Serbian)"},{"Value":"Slovak","AddAction":"addlimiter(LA99:Slovak)"},{"Value":"Slovenian","AddAction":"addlimiter(LA99:Slovenian)"},{"Value":"Spanish","AddAction":"addlimiter(LA99:Spanish)"},{"Value":"Swahili","AddAction":"addlimiter(LA99:Swahili)"},{"Value":"Bosnian","AddAction":"addlimiter(LA99:Bosnian)"},{"Value":"Latvian","AddAction":"addlimiter(LA99:Latvian)"},{"Value":"Catalan","AddAction":"addlimiter(LA99:Catalan)"},{"Value":"Abkhazian","AddAction":"addlimiter(LA99:Abkhazian)"},{"Value":"Amharic","AddAction":"addlimiter(LA99:Amharic)"},{"Value":"Armenian","AddAction":"addlimiter(LA99:Armenian)"},{"Value":"Mapudungun;
+        Mapuche","AddAction":"addlimiter(LA99:Mapudungun; Mapuche)"},{"Value":"Asturian;
+        Bable; Leonese; Asturleonese","AddAction":"addlimiter(LA99:Asturian; Bable;
+        Leonese; Asturleonese)"},{"Value":"Australian languages","AddAction":"addlimiter(LA99:Australian
+        languages)"},{"Value":"Basque","AddAction":"addlimiter(LA99:Basque)"},{"Value":"Bengali","AddAction":"addlimiter(LA99:Bengali)"},{"Value":"Breton","AddAction":"addlimiter(LA99:Breton)"},{"Value":"Burmese","AddAction":"addlimiter(LA99:Burmese)"},{"Value":"Central
+        American Indian languages","AddAction":"addlimiter(LA99:Central American Indian
+        languages)"},{"Value":"Catalan; Valencian","AddAction":"addlimiter(LA99:Catalan;
+        Valencian)"},{"Value":"Chechen","AddAction":"addlimiter(LA99:Chechen)"},{"Value":"Coptic","AddAction":"addlimiter(LA99:Coptic)"},{"Value":"English,
+        Middle (1100-1500)","AddAction":"addlimiter(LA99:English\\, Middle \\(1100-1500\\))"},{"Value":"Esperanto","AddAction":"addlimiter(LA99:Esperanto)"},{"Value":"Estonian","AddAction":"addlimiter(LA99:Estonian)"},{"Value":"Faroese","AddAction":"addlimiter(LA99:Faroese)"},{"Value":"Fijian","AddAction":"addlimiter(LA99:Fijian)"},{"Value":"Germanic
+        languages","AddAction":"addlimiter(LA99:Germanic languages)"},{"Value":"Geez","AddAction":"addlimiter(LA99:Geez)"},{"Value":"Irish","AddAction":"addlimiter(LA99:Irish)"},{"Value":"Galician","AddAction":"addlimiter(LA99:Galician)"},{"Value":"Greek,
+        Ancient (to 1453)","AddAction":"addlimiter(LA99:Greek\\, Ancient \\(to 1453\\))"},{"Value":"Greek,
+        Modern (1453-)","AddAction":"addlimiter(LA99:Greek\\, Modern \\(1453-\\))"},{"Value":"Hindi","AddAction":"addlimiter(LA99:Hindi)"},{"Value":"Icelandic","AddAction":"addlimiter(LA99:Icelandic)"},{"Value":"Ido","AddAction":"addlimiter(LA99:Ido)"},{"Value":"Interlingua
+        (International Auxiliary Language Association)","AddAction":"addlimiter(LA99:Interlingua
+        \\(International Auxiliary Language Association\\))"},{"Value":"Javanese","AddAction":"addlimiter(LA99:Javanese)"},{"Value":"Judeo-Arabic","AddAction":"addlimiter(LA99:Judeo-Arabic)"},{"Value":"Kannada","AddAction":"addlimiter(LA99:Kannada)"},{"Value":"Luxembourgish;
+        Letzeburgesch","AddAction":"addlimiter(LA99:Luxembourgish; Letzeburgesch)"},{"Value":"Malayalam","AddAction":"addlimiter(LA99:Malayalam)"},{"Value":"Austronesian
+        languages","AddAction":"addlimiter(LA99:Austronesian languages)"},{"Value":"Malay","AddAction":"addlimiter(LA99:Malay)"},{"Value":"Maltese","AddAction":"addlimiter(LA99:Maltese)"},{"Value":"Mongolian","AddAction":"addlimiter(LA99:Mongolian)"},{"Value":"Nahuatl
+        languages","AddAction":"addlimiter(LA99:Nahuatl languages)"},{"Value":"Neapolitan","AddAction":"addlimiter(LA99:Neapolitan)"},{"Value":"Bokmål,
+        Norwegian; Norwegian Bokmål","AddAction":"addlimiter(LA99:Bokmål\\, Norwegian;
+        Norwegian Bokmål)"},{"Value":"Norse, Old","AddAction":"addlimiter(LA99:Norse\\,
+        Old)"},{"Value":"Occitan (post 1500)","AddAction":"addlimiter(LA99:Occitan
+        \\(post 1500\\))"},{"Value":"Ojibwa","AddAction":"addlimiter(LA99:Ojibwa)"},{"Value":"Philippine
+        languages","AddAction":"addlimiter(LA99:Philippine languages)"},{"Value":"Romany","AddAction":"addlimiter(LA99:Romany)"},{"Value":"Samaritan
+        Aramaic","AddAction":"addlimiter(LA99:Samaritan Aramaic)"},{"Value":"Sanskrit","AddAction":"addlimiter(LA99:Sanskrit)"},{"Value":"Sinhala;
+        Sinhalese","AddAction":"addlimiter(LA99:Sinhala; Sinhalese)"},{"Value":"Sundanese","AddAction":"addlimiter(LA99:Sundanese)"},{"Value":"Sumerian","AddAction":"addlimiter(LA99:Sumerian)"},{"Value":"Classical
+        Syriac","AddAction":"addlimiter(LA99:Classical Syriac)"},{"Value":"Tibetan","AddAction":"addlimiter(LA99:Tibetan)"},{"Value":"Ugaritic","AddAction":"addlimiter(LA99:Ugaritic)"},{"Value":"Welsh","AddAction":"addlimiter(LA99:Welsh)"},{"Value":"Yiddish","AddAction":"addlimiter(LA99:Yiddish)"},{"Value":"Zapotec","AddAction":"addlimiter(LA99:Zapotec)"},{"Value":"Azerbaijani","AddAction":"addlimiter(LA99:Azerbaijani)"},{"Value":"Bulgarian","AddAction":"addlimiter(LA99:Bulgarian)"},{"Value":"Greek","AddAction":"addlimiter(LA99:Greek)"},{"Value":"Serbo-Croatian","AddAction":"addlimiter(LA99:Serbo-Croatian)"},{"Value":"Urdu","AddAction":"addlimiter(LA99:Urdu)"},{"Value":"Belorussian","AddAction":"addlimiter(LA99:Belorussian)"},{"Value":"Dutch","AddAction":"addlimiter(LA99:Dutch)"},{"Value":"Georgian","AddAction":"addlimiter(LA99:Georgian)"},{"Value":"Kazakh","AddAction":"addlimiter(LA99:Kazakh)"},{"Value":"Malayan","AddAction":"addlimiter(LA99:Malayan)"},{"Value":"Moldavian","AddAction":"addlimiter(LA99:Moldavian)"},{"Value":"Ukranian","AddAction":"addlimiter(LA99:Ukranian)"},{"Value":"Uzbek","AddAction":"addlimiter(LA99:Uzbek)"},{"Value":"English,
+        Old (ca.450-1100)","AddAction":"addlimiter(LA99:English\\, Old \\(ca.450-1100\\))"},{"Value":"Belarusian","AddAction":"addlimiter(LA99:Belarusian)"},{"Value":"Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic","AddAction":"addlimiter(LA99:Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic)"},{"Value":"Creoles
+        and pidgins, English based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        English based)"},{"Value":"French, Middle (ca.1400-1600)","AddAction":"addlimiter(LA99:French\\,
+        Middle \\(ca.1400-1600\\))"},{"Value":"French, Old (842-ca.1400)","AddAction":"addlimiter(LA99:French\\,
+        Old \\(842-ca.1400\\))"},{"Value":"Gaelic; Scottish Gaelic","AddAction":"addlimiter(LA99:Gaelic;
+        Scottish Gaelic)"},{"Value":"Manx","AddAction":"addlimiter(LA99:Manx)"},{"Value":"German,
+        Middle High (ca.1050-1500)","AddAction":"addlimiter(LA99:German\\, Middle
+        High \\(ca.1050-1500\\))"},{"Value":"Gujarati","AddAction":"addlimiter(LA99:Gujarati)"},{"Value":"Hawaiian","AddAction":"addlimiter(LA99:Hawaiian)"},{"Value":"Iloko","AddAction":"addlimiter(LA99:Iloko)"},{"Value":"Uncoded
+        languages","AddAction":"addlimiter(LA99:Uncoded languages)"},{"Value":"Multiple
+        languages","AddAction":"addlimiter(LA99:Multiple languages)"},{"Value":"Turkish,
+        Ottoman (1500-1928)","AddAction":"addlimiter(LA99:Turkish\\, Ottoman \\(1500-1928\\))"},{"Value":"Pangasinan","AddAction":"addlimiter(LA99:Pangasinan)"},{"Value":"Pali","AddAction":"addlimiter(LA99:Pali)"},{"Value":"Prakrit
+        languages","AddAction":"addlimiter(LA99:Prakrit languages)"},{"Value":"Romance
+        languages","AddAction":"addlimiter(LA99:Romance languages)"},{"Value":"Romansh","AddAction":"addlimiter(LA99:Romansh)"},{"Value":"Scots","AddAction":"addlimiter(LA99:Scots)"},{"Value":"Slavic
+        languages","AddAction":"addlimiter(LA99:Slavic languages)"},{"Value":"Samoan","AddAction":"addlimiter(LA99:Samoan)"},{"Value":"Tahitian","AddAction":"addlimiter(LA99:Tahitian)"},{"Value":"Undetermined","AddAction":"addlimiter(LA99:Undetermined)"},{"Value":"Volapük","AddAction":"addlimiter(LA99:Volapük)"},{"Value":"No
+        linguistic content; Not applicable","AddAction":"addlimiter(LA99:No linguistic
+        content; Not applicable)"},{"Value":"FRENCH","AddAction":"addlimiter(LA99:FRENCH)"},{"Value":"PORTUGUESE","AddAction":"addlimiter(LA99:PORTUGUESE)"},{"Value":"RUSSIAN","AddAction":"addlimiter(LA99:RUSSIAN)"},{"Value":"SPANISH","AddAction":"addlimiter(LA99:SPANISH)"},{"Value":"GERMAN","AddAction":"addlimiter(LA99:GERMAN)"},{"Value":"ENGLISH","AddAction":"addlimiter(LA99:ENGLISH)"},{"Value":"CHINESE","AddAction":"addlimiter(LA99:CHINESE)"},{"Value":"Macedonian","AddAction":"addlimiter(LA99:Macedonian)"},{"Value":"Iranian
+        languages","AddAction":"addlimiter(LA99:Iranian languages)"},{"Value":"Marshallese","AddAction":"addlimiter(LA99:Marshallese)"},{"Value":"Nepali","AddAction":"addlimiter(LA99:Nepali)"},{"Value":"Nepal
+        Bhasa; Newari","AddAction":"addlimiter(LA99:Nepal Bhasa; Newari)"},{"Value":"Greek,
+        Modern","AddAction":"addlimiter(LA99:Greek\\, Modern)"},{"Value":"Acoli","AddAction":"addlimiter(LA99:Acoli)"},{"Value":"Afro-Asiatic
+        languages","AddAction":"addlimiter(LA99:Afro-Asiatic languages)"},{"Value":"Ainu","AddAction":"addlimiter(LA99:Ainu)"},{"Value":"Akan","AddAction":"addlimiter(LA99:Akan)"},{"Value":"Algonquian
+        languages","AddAction":"addlimiter(LA99:Algonquian languages)"},{"Value":"Southern
+        Altai","AddAction":"addlimiter(LA99:Southern Altai)"},{"Value":"Apache languages","AddAction":"addlimiter(LA99:Apache
+        languages)"},{"Value":"Avaric","AddAction":"addlimiter(LA99:Avaric)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Banda
+        languages","AddAction":"addlimiter(LA99:Banda languages)"},{"Value":"Bamileke
+        languages","AddAction":"addlimiter(LA99:Bamileke languages)"},{"Value":"Baluchi","AddAction":"addlimiter(LA99:Baluchi)"},{"Value":"Bambara","AddAction":"addlimiter(LA99:Bambara)"},{"Value":"Balinese","AddAction":"addlimiter(LA99:Balinese)"},{"Value":"Bemba","AddAction":"addlimiter(LA99:Bemba)"},{"Value":"Berber
+        languages","AddAction":"addlimiter(LA99:Berber languages)"},{"Value":"Bhojpuri","AddAction":"addlimiter(LA99:Bhojpuri)"},{"Value":"Bislama","AddAction":"addlimiter(LA99:Bislama)"},{"Value":"Bantu
+        languages","AddAction":"addlimiter(LA99:Bantu languages)"},{"Value":"Braj","AddAction":"addlimiter(LA99:Braj)"},{"Value":"Batak
+        languages","AddAction":"addlimiter(LA99:Batak languages)"},{"Value":"Buriat","AddAction":"addlimiter(LA99:Buriat)"},{"Value":"Galibi
+        Carib","AddAction":"addlimiter(LA99:Galibi Carib)"},{"Value":"Caucasian languages","AddAction":"addlimiter(LA99:Caucasian
+        languages)"},{"Value":"Chibcha","AddAction":"addlimiter(LA99:Chibcha)"},{"Value":"Corsican","AddAction":"addlimiter(LA99:Corsican)"},{"Value":"Creoles
+        and pidgins, French-based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        French-based)"},{"Value":"Creoles and pidgins, Portuguese-based","AddAction":"addlimiter(LA99:Creoles
+        and pidgins\\, Portuguese-based)"},{"Value":"Creoles and pidgins","AddAction":"addlimiter(LA99:Creoles
+        and pidgins)"},{"Value":"Slave (Athapascan)","AddAction":"addlimiter(LA99:Slave
+        \\(Athapascan\\))"},{"Value":"Duala","AddAction":"addlimiter(LA99:Duala)"},{"Value":"Dutch,
+        Middle (ca.1050-1350)","AddAction":"addlimiter(LA99:Dutch\\, Middle \\(ca.1050-1350\\))"},{"Value":"Dzongkha","AddAction":"addlimiter(LA99:Dzongkha)"},{"Value":"Efik","AddAction":"addlimiter(LA99:Efik)"},{"Value":"Egyptian
+        (Ancient)","AddAction":"addlimiter(LA99:Egyptian \\(Ancient\\))"},{"Value":"Ewe","AddAction":"addlimiter(LA99:Ewe)"},{"Value":"Fang","AddAction":"addlimiter(LA99:Fang)"},{"Value":"Filipino;
+        Pilipino","AddAction":"addlimiter(LA99:Filipino; Pilipino)"},{"Value":"Finno-Ugrian
+        languages","AddAction":"addlimiter(LA99:Finno-Ugrian languages)"},{"Value":"Fulah","AddAction":"addlimiter(LA99:Fulah)"},{"Value":"Ga","AddAction":"addlimiter(LA99:Ga)"},{"Value":"Gilbertese","AddAction":"addlimiter(LA99:Gilbertese)"},{"Value":"German,
+        Old High (ca.750-1050)","AddAction":"addlimiter(LA99:German\\, Old High \\(ca.750-1050\\))"},{"Value":"Gondi","AddAction":"addlimiter(LA99:Gondi)"},{"Value":"Swiss
+        German; Alemannic; Alsatian","AddAction":"addlimiter(LA99:Swiss German; Alemannic;
+        Alsatian)"},{"Value":"Haida","AddAction":"addlimiter(LA99:Haida)"},{"Value":"Hausa","AddAction":"addlimiter(LA99:Hausa)"},{"Value":"Igbo","AddAction":"addlimiter(LA99:Igbo)"},{"Value":"Inuktitut","AddAction":"addlimiter(LA99:Inuktitut)"},{"Value":"Indic
+        languages","AddAction":"addlimiter(LA99:Indic languages)"},{"Value":"Indo-European
+        languages","AddAction":"addlimiter(LA99:Indo-European languages)"},{"Value":"Iroquoian
+        languages","AddAction":"addlimiter(LA99:Iroquoian languages)"},{"Value":"Kabyle","AddAction":"addlimiter(LA99:Kabyle)"},{"Value":"Kalaallisut;
+        Greenlandic","AddAction":"addlimiter(LA99:Kalaallisut; Greenlandic)"},{"Value":"Kamba","AddAction":"addlimiter(LA99:Kamba)"},{"Value":"Karen
+        languages","AddAction":"addlimiter(LA99:Karen languages)"},{"Value":"Khoisan
+        languages","AddAction":"addlimiter(LA99:Khoisan languages)"},{"Value":"Central
+        Khmer","AddAction":"addlimiter(LA99:Central Khmer)"},{"Value":"Kinyarwanda","AddAction":"addlimiter(LA99:Kinyarwanda)"},{"Value":"Kirghiz;
+        Kyrgyz","AddAction":"addlimiter(LA99:Kirghiz; Kyrgyz)"},{"Value":"Kpelle","AddAction":"addlimiter(LA99:Kpelle)"},{"Value":"Kurdish","AddAction":"addlimiter(LA99:Kurdish)"},{"Value":"Ladino","AddAction":"addlimiter(LA99:Ladino)"},{"Value":"Lingala","AddAction":"addlimiter(LA99:Lingala)"},{"Value":"Luba-Katanga","AddAction":"addlimiter(LA99:Luba-Katanga)"},{"Value":"Ganda","AddAction":"addlimiter(LA99:Ganda)"},{"Value":"Lunda","AddAction":"addlimiter(LA99:Lunda)"},{"Value":"Madurese","AddAction":"addlimiter(LA99:Madurese)"},{"Value":"Mandingo","AddAction":"addlimiter(LA99:Mandingo)"},{"Value":"Maori","AddAction":"addlimiter(LA99:Maori)"},{"Value":"Marathi","AddAction":"addlimiter(LA99:Marathi)"},{"Value":"Masai","AddAction":"addlimiter(LA99:Masai)"},{"Value":"Mende","AddAction":"addlimiter(LA99:Mende)"},{"Value":"Mon-Khmer
+        languages","AddAction":"addlimiter(LA99:Mon-Khmer languages)"},{"Value":"Malagasy","AddAction":"addlimiter(LA99:Malagasy)"},{"Value":"Mayan
+        languages","AddAction":"addlimiter(LA99:Mayan languages)"},{"Value":"North
+        American Indian languages","AddAction":"addlimiter(LA99:North American Indian
+        languages)"},{"Value":"Ndebele, North; North Ndebele","AddAction":"addlimiter(LA99:Ndebele\\,
+        North; North Ndebele)"},{"Value":"Niger-Kordofanian languages","AddAction":"addlimiter(LA99:Niger-Kordofanian
+        languages)"},{"Value":"Chichewa; Chewa; Nyanja","AddAction":"addlimiter(LA99:Chichewa;
+        Chewa; Nyanja)"},{"Value":"Nyankole","AddAction":"addlimiter(LA99:Nyankole)"},{"Value":"Papuan
+        languages","AddAction":"addlimiter(LA99:Papuan languages)"},{"Value":"Pampanga;
+        Kapampangan","AddAction":"addlimiter(LA99:Pampanga; Kapampangan)"},{"Value":"Panjabi;
+        Punjabi","AddAction":"addlimiter(LA99:Panjabi; Punjabi)"},{"Value":"Papiamento","AddAction":"addlimiter(LA99:Papiamento)"},{"Value":"Provençal,
+        Old (to 1500);Occitan, Old (to 1500)","AddAction":"addlimiter(LA99:Provençal\\,
+        Old \\(to 1500\\);Occitan\\, Old \\(to 1500\\))"},{"Value":"Quechua","AddAction":"addlimiter(LA99:Quechua)"},{"Value":"Rajasthani","AddAction":"addlimiter(LA99:Rajasthani)"},{"Value":"Rarotongan;
+        Cook Islands Maori","AddAction":"addlimiter(LA99:Rarotongan; Cook Islands
+        Maori)"},{"Value":"Rundi","AddAction":"addlimiter(LA99:Rundi)"},{"Value":"South
+        American Indian languages","AddAction":"addlimiter(LA99:South American Indian
+        languages)"},{"Value":"Salishan languages","AddAction":"addlimiter(LA99:Salishan
+        languages)"},{"Value":"Sino-Tibetan languages","AddAction":"addlimiter(LA99:Sino-Tibetan
+        languages)"},{"Value":"Sami languages","AddAction":"addlimiter(LA99:Sami languages)"},{"Value":"Shona","AddAction":"addlimiter(LA99:Shona)"},{"Value":"Somali","AddAction":"addlimiter(LA99:Somali)"},{"Value":"Sotho,
+        Southern","AddAction":"addlimiter(LA99:Sotho\\, Southern)"},{"Value":"Sardinian","AddAction":"addlimiter(LA99:Sardinian)"},{"Value":"Nilo-Saharan
+        languages","AddAction":"addlimiter(LA99:Nilo-Saharan languages)"},{"Value":"Swati","AddAction":"addlimiter(LA99:Swati)"},{"Value":"Susu","AddAction":"addlimiter(LA99:Susu)"},{"Value":"Syriac","AddAction":"addlimiter(LA99:Syriac)"},{"Value":"Tamil","AddAction":"addlimiter(LA99:Tamil)"},{"Value":"Tatar","AddAction":"addlimiter(LA99:Tatar)"},{"Value":"Telugu","AddAction":"addlimiter(LA99:Telugu)"},{"Value":"Tajik","AddAction":"addlimiter(LA99:Tajik)"},{"Value":"Tigrinya","AddAction":"addlimiter(LA99:Tigrinya)"},{"Value":"Tamashek","AddAction":"addlimiter(LA99:Tamashek)"},{"Value":"Tonga
+        (Nyasa)","AddAction":"addlimiter(LA99:Tonga \\(Nyasa\\))"},{"Value":"Tonga
+        (Tonga Islands)","AddAction":"addlimiter(LA99:Tonga \\(Tonga Islands\\))"},{"Value":"Tok
+        Pisin","AddAction":"addlimiter(LA99:Tok Pisin)"},{"Value":"Tswana","AddAction":"addlimiter(LA99:Tswana)"},{"Value":"Turkmen","AddAction":"addlimiter(LA99:Turkmen)"},{"Value":"Tumbuka","AddAction":"addlimiter(LA99:Tumbuka)"},{"Value":"Altaic
+        languages","AddAction":"addlimiter(LA99:Altaic languages)"},{"Value":"Twi","AddAction":"addlimiter(LA99:Twi)"},{"Value":"Tuvinian","AddAction":"addlimiter(LA99:Tuvinian)"},{"Value":"Uighur;
+        Uyghur","AddAction":"addlimiter(LA99:Uighur; Uyghur)"},{"Value":"Umbundu","AddAction":"addlimiter(LA99:Umbundu)"},{"Value":"Wakashan
+        languages","AddAction":"addlimiter(LA99:Wakashan languages)"},{"Value":"Wolof","AddAction":"addlimiter(LA99:Wolof)"},{"Value":"Xhosa","AddAction":"addlimiter(LA99:Xhosa)"},{"Value":"Yao","AddAction":"addlimiter(LA99:Yao)"},{"Value":"Yoruba","AddAction":"addlimiter(LA99:Yoruba)"},{"Value":"Yupik
+        languages","AddAction":"addlimiter(LA99:Yupik languages)"},{"Value":"Zulu","AddAction":"addlimiter(LA99:Zulu)"},{"Value":"Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki","AddAction":"addlimiter(LA99:Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki)"},{"Value":"Venda","AddAction":"addlimiter(LA99:Venda)"},{"Value":"Aragonese","AddAction":"addlimiter(LA99:Aragonese)"}],"DefaultOn":"n","Order":"11"}],"AvailableSearchModes":[{"Mode":"bool","Label":"Boolean\/Phrase","DefaultOn":"n","AddAction":"setsearchmode(bool)"},{"Mode":"all","Label":"Find
+        all my search terms","DefaultOn":"y","AddAction":"setsearchmode(all)"},{"Mode":"any","Label":"Find
+        any of my search terms","DefaultOn":"n","AddAction":"setsearchmode(any)"},{"Mode":"smart","Label":"SmartText
+        Searching","DefaultOn":"n","AddAction":"setsearchmode(smart)"}],"AvailableRelatedContent":[{"Type":"emp","Label":"Exact
+        Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
+        Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
+        You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief","IncludeImageQuickView":{"Id":"ImageQuickViewResults","Label":"Image
+        Quick View Results","DefaultOn":"n"}},"ApplicationSettings":{"SessionTimeout":"900"},"ApiSettings":{"MaxRecordJumpAhead":"250"},"ExportFormatSettings":{"AvailableFormats":[{"Id":"RIS","Label":"RIS
+        Format"}]},"CitationStyleSettings":{"AvailableStyles":[{"Id":"abnt","Label":"ABNT"},{"Id":"ama","Label":"AMA
+        11th Edition"},{"Id":"apa","Label":"APA 7th Edition"},{"Id":"chicago","Label":"Chicago
+        17th Edition"},{"Id":"harvard","Label":"Harvard"},{"Id":"harvardaustralian","Label":"Harvard:
+        Australian"},{"Id":"mla","Label":"MLA 8th Edition"},{"Id":"turabian","Label":"Chicago
+        17th Edition"},{"Id":"vancouver","Label":"Vancouver\/ICMJE"}]}}'
+  recorded_at: Wed, 16 Jun 2021 20:00:46 GMT
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
+    body:
+      encoding: UTF-8
+      string: '{"DbId":"cat00916a","An":"mit.001492509","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:46 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - bda2e2f5-6778-4234-893d-3b6ab8e78154
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-381234571"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '6623'
+    body:
+      encoding: UTF-8
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"cat00916a","DbLabel":"MIT
+        Barton Catalog","An":"mit.001492509","RelevancyScore":"1038","AccessLevel":"3","PubType":"Book","PubTypeId":"book"},"PLink":"https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330","ImageInfo":[{"Size":"thumb","Target":"https:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=S&Value=9781841958811"},{"Size":"medium","Target":"https:\/\/contentcafe2.btol.com\/ContentCafe\/jacket.aspx?UserID=ebsco-test&Password=ebsco-test&Return=T&Type=M&Value=9781841958811"}],"CustomLinks":[{"Url":"https:\/\/library.mit.edu\/item\/001492509","Name":"MIT
+        Barton Catalog Full Record (cat00916a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"},{"Url":"https:\/\/mit.on.worldcat.org\/oclc\/166367812","Name":"WorldCat
+        customlink","Category":"ill","Text":"Get it in the library","MouseOverText":"Get
+        items from MIT & non-MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Bananas
+        : how the United Fruit Company shaped the world \/ Peter Chapman."},{"Name":"Language","Label":"Language","Group":"Lang","Data":"English"},{"Name":"Author","Label":"Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22Chapman%2C+Peter%22&quot;&gt;Chapman,
+        Peter&lt;\/searchLink&gt;, 1948-"},{"Name":"PubInfo","Label":"Publication
+        Information","Group":"PubInfo","Data":"Edinburgh ; New York : Canongate ;
+        [Berkeley, Calif.?] : Distributed by Publishers Group West, c2007."},{"Name":"EditionInfo","Label":"Edition","Group":"PubInfo","Data":"1st
+        American ed."},{"Name":"DatePub","Label":"Publication Date","Group":"Date","Data":"2007"},{"Name":"PhysDesc","Label":"Physical
+        Description","Group":"PhysDesc","Data":"xv, 224 p. : map ; 21 cm."},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Book"},{"Name":"TypeDocument","Label":"Document
+        Type","Group":"TypDoc","Data":"Bibliographies; Non-fiction"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Banana+trade+--+Central+America+--+History%22&quot;&gt;Banana
+        trade -- Central America -- History&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink
+        fieldCode=&quot;DE&quot; term=&quot;%22Bananas+--+Social+aspects%22&quot;&gt;Bananas
+        -- Social aspects&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22International+business+enterprises+--+Corrupt+practices%22&quot;&gt;International
+        business enterprises -- Corrupt practices&lt;\/searchLink&gt;"},{"Name":"SubjectGeographic","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Central+America+--+History+--+1951-1979%22&quot;&gt;Central
+        America -- History -- 1951-1979&lt;\/searchLink&gt;"},{"Name":"SubjectCompany","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22United+Fruit+Company+--+History%22&quot;&gt;United
+        Fruit Company -- History&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22United+Fruit+Company+--+Corrupt+practices%22&quot;&gt;United
+        Fruit Company -- Corrupt practices&lt;\/searchLink&gt;"},{"Name":"Abstract","Label":"Abstract","Group":"Ab","Data":"Summary:
+        In this exploration of corporate maneuvering and subterfuge, journalist Chapman
+        shows how the importer United Fruit set the precedent for the institutionalized
+        power and influence of today&#39;s multinational companies. This infamous
+        company was arguably the most controversial global corporation ever--from
+        the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from
+        an office on the 44th floor of the Pan Am building in New York City. From
+        the marketing of the banana as the first fast food, to the company&#39;s involvement
+        in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala,
+        Chapman weaves a tale of big business, political deceit, and outright violence
+        to show how one company wreaked havoc in the &quot;banana republics&quot;
+        of Central America, and how terrifyingly similar the age of United Fruit is
+        to our age of rapid globalization.--From publisher description."},{"Name":"TOC","Label":"Content
+        Notes","Group":"TOC","Data":"1. From the Memory of Men -- 2. Lament for a
+        Dying Fruit -- 3. Roots of Empire -- 4. Monopoly -- 5. The Banana Man -- 6.
+        Taming the Enclave -- 7. Banana Republics -- 8. On the Inside -- 9. Coup --
+        10. &#39;Betrayal&#39; -- 11. Decline and Fall -- 12. Old and Dark Forces
+        -- Epilogue: United Fruit World."},{"Name":"Note","Label":"Notes","Group":"Note","Data":"Originally
+        published as: Jungle capitalists.&lt;br \/&gt;Map on lining papers.&lt;br
+        \/&gt;Includes bibliographical references (p. 211-215) and index."},{"Name":"TitleAlt","Label":"Other
+        Titles","Group":"TiAlt","Data":"&lt;searchLink fieldCode=&quot;TI&quot; term=&quot;%22Jungle+capitalists%22&quot;&gt;Jungle
+        capitalists&lt;\/searchLink&gt;"},{"Name":"ISBN","Label":"ISBN","Group":"ISBN","Data":"9781841958811
+        :&lt;br \/&gt;1841958816 :"},{"Name":"NumberOther","Label":"OCLC","Group":"ID","Data":"166367812"},{"Name":"AN","Label":"Accession
+        Number","Group":"ID","Data":"mit.001492509"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"United
+        Fruit Company -- History","Type":"general"},{"SubjectFull":"United Fruit Company
+        -- Corrupt practices","Type":"general"},{"SubjectFull":"Banana trade -- Central
+        America -- History","Type":"general"},{"SubjectFull":"Bananas -- Social aspects","Type":"general"},{"SubjectFull":"International
+        business enterprises -- Corrupt practices","Type":"general"},{"SubjectFull":"Central
+        America -- History -- 1951-1979","Type":"general"}],"Titles":[{"TitleFull":"Bananas
+        : how the United Fruit Company shaped the world.","Type":"main"}]},"BibRelationships":{"HasContributorRelationships":[{"PersonEntity":{"Name":{"NameFull":"Chapman,
+        Peter"}}}],"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"2007"}],"Identifiers":[{"Type":"isbn-print","Value":"9781841958811"},{"Type":"isbn-print","Value":"1841958816"}],"Titles":[{"TitleFull":"Bananas
+        : how the United Fruit Company shaped the world \/ Peter Chapman.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Hayden
+        Library - Stacks","ShelfLocator":"HD9259.B3.U523 2007b"}]}}],"IllustrationInfo":{}}}'
+  recorded_at: Wed, 16 Jun 2021 20:00:47 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/ExportFormat?an=mit.001492509&dbid=cat00916a&format=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:47 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 5d1df7a0-1cd9-4ff0-8fdb-8c89081a25c5
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '766386613'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '2706'
+    body:
+      encoding: UTF-8
+      string: '{"Format":"RIS","Label":"RIS Format","Data":"TY  - Book\u000d\u000aID  -
+        mit.001492509\u000d\u000aAU  - Chapman, Peter\u000d\u000aT1  - Bananas : how
+        the United Fruit Company shaped the world.\u000d\u000aY1  - 2007\/\/\/\u000d\u000aM3  -
+        Bibliographies\u000d\u000aM3  - Non-fiction\u000d\u000aPB  - Edinburgh ; New
+        York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group West,
+        c2007.\u000d\u000aPB  - 1st American ed.\u000d\u000aAV  - Hayden Library -
+        Stacks HD9259.B3.U523 2007b\u000d\u000aSN  - 9781841958811\u000d\u000aSN  -
+        1841958816\u000d\u000aN2  - Summary: In this exploration of corporate maneuvering
+        and subterfuge, journalist Chapman shows how the importer United Fruit set
+        the precedent for the institutionalized power and influence of today''s multinational
+        companies. This infamous company was arguably the most controversial global
+        corporation ever--from the jungles of Costa Rica to the dramatic suicide of
+        its CEO, who leapt from an office on the 44th floor of the Pan Am building
+        in New York City. From the marketing of the banana as the first fast food,
+        to the company''s involvement in an invasion of Honduras, the Bay of Pigs
+        crisis, and a bloody coup in Guatemala, Chapman weaves a tale of big business,
+        political deceit, and outright violence to show how one company wreaked havoc
+        in the \"banana republics\" of Central America, and how terrifyingly similar
+        the age of United Fruit is to our age of rapid globalization.--From publisher
+        description.\u000d\u000aN2  - 1. From the Memory of Men -- 2. Lament for a
+        Dying Fruit -- 3. Roots of Empire -- 4. Monopoly -- 5. The Banana Man -- 6.
+        Taming the Enclave -- 7. Banana Republics -- 8. On the Inside -- 9. Coup --
+        10. ''Betrayal'' -- 11. Decline and Fall -- 12. Old and Dark Forces -- Epilogue:
+        United Fruit World.\u000d\u000aKW  - Banana trade -- Central America -- History\u000d\u000aKW  -
+        Bananas -- Social aspects\u000d\u000aKW  - International business enterprises
+        -- Corrupt practices\u000d\u000aKW  - Central America -- History -- 1951-1979\u000d\u000aKW  -
+        United Fruit Company -- History\u000d\u000aKW  - United Fruit Company -- Corrupt
+        practices\u000d\u000aN1  - Accession Number: mit.001492509; Other Notes: Originally
+        published as: Jungle capitalists.; Map on lining papers.; Includes bibliographical
+        references (p. 211-215) and index.; Publication Type: Book; Physical Description:
+        xv, 224 p. : map ; 21 cm.; Language: English; Other Titles: Jungle capitalists;
+        OCLC: 166367812\u000d\u000aUR  - https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330\u000d\u000aDP  -
+        EBSCOhost\u000d\u000aDB  - cat00916a\u000d\u000aER  - \u000d\u000a"}'
+  recorded_at: Wed, 16 Jun 2021 20:00:47 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CitationStyles?an=mit.001492509&dbid=cat00916a&styles=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:00:47 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Msg-Correlid:
+      - f65e9bbc-cc79-468e-a59e-75fce8a2a1ef
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '4012'
+    body:
+      encoding: UTF-8
+      string: '{"Citations":[{"Id":"abnt","Label":"ABNT","SectionLabel":"References","Data":"CHAPMAN,
+        P. <b>Bananas : how the United Fruit Company shaped the world<\/b>. <i>[s.
+        l.]<\/i>: Edinburgh ; New York : Canongate ; [Berkeley, Calif.?] : Distributed
+        by Publishers Group West, c2007., 2007. ISBN 9781841958811. Disponível em:
+        https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330.
+        Acesso em: 16 jun. 2021.","Caption":"Brazilian National Standards"},{"Id":"ama","Label":"AMA
+        11th Edition","SectionLabel":"Reference List","Data":"Chapman P. <i>Bananas :
+        How the United Fruit Company Shaped the World<\/i>. Edinburgh ; New York :
+        Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group West, c2007.;
+        2007. Accessed June 16, 2021. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330","Caption":"American
+        Medical Assoc."},{"Id":"apa","Label":"APA 7th Edition","SectionLabel":"References","Data":"Chapman,
+        P. (2007). <i>Bananas : how the United Fruit Company shaped the world<\/i>.
+        Edinburgh ; New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers
+        Group West, c2007. ","Caption":"American Psychological Assoc.","Indent":1},{"Id":"chicago","Label":"Chicago
+        17th Edition","SectionLabel":"Reference List","Data":"Chapman, Peter. 2007.
+        <i>Bananas : How the United Fruit Company Shaped the World<\/i>. Edinburgh ;
+        New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group
+        West, c2007. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330.","Caption":"Author-Date","Indent":1},{"Id":"harvard","Label":"Harvard","SectionLabel":"References","Data":"Chapman,
+        P. (2007) <i>Bananas : how the United Fruit Company shaped the world<\/i>.
+        Edinburgh ; New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers
+        Group West, c2007. Available at: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330
+        (Accessed: 16 June 2021)."},{"Id":"harvardaustralian","Label":"Harvard: Australian","SectionLabel":"References","Data":"Chapman,
+        P 2007, <i>Bananas : how the United Fruit Company shaped the world<\/i>, Edinburgh ;
+        New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group
+        West, c2007., viewed 16 June 2021, <https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330>."},{"Id":"mla","Label":"MLA
+        8th Edition","SectionLabel":"Works Cited","Data":"Chapman, Peter. <i>Bananas :
+        How the United Fruit Company Shaped the World<\/i>. Edinburgh ; New York :
+        Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group West, c2007.,
+        2007. <i>EBSCOhost<\/i>, search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330.","Caption":"Modern
+        Language Assoc.","Indent":1},{"Id":"turabian","Label":"Chicago 17th Edition","SectionLabel":"Bibliography","Data":"Chapman,
+        Peter. <i>Bananas : How the United Fruit Company Shaped the World<\/i>. Edinburgh ;
+        New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group
+        West, c2007., 2007. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330.","Caption":"Notes
+        & Bibliography","Indent":1},{"Id":"vancouver","Label":"Vancouver\/ICMJE","SectionLabel":"References","Data":"Chapman
+        P. Bananas : how the United Fruit Company shaped the world [Internet]. Edinburgh ;
+        New York : Canongate ; [Berkeley, Calif.?] : Distributed by Publishers Group
+        West, c2007.; 2007 [cited 2021 Jun 16]. Available from: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.001492509&authtype=sso&custid=s8978330"}]}'
+  recorded_at: Wed, 16 Jun 2021 20:00:48 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=001492509MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="902231F54EA1A3B4678BFA65273F3A64.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=b8a0c1ec2de31237d87845c9a3ab8c22;Path=/;SameSite=None;Secure
+      - urm_se=1623874248577; Path=/; SameSite=None; Secure
+      - urm_st=1623873648577; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - H0CaWgyl4o
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:00:48 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03348cam  2200541Ia 4500</leader>
+                  <controlfield tag="001">990014925090206761</controlfield>
+                  <controlfield tag="005">20210519003556.0</controlfield>
+                  <controlfield tag="008">070728s2007    enkb     b    001 0 eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">1841958816 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)001492509MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)166367812</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">BTCTA</subfield>
+                    <subfield code="c">BTCTA</subfield>
+                    <subfield code="d">BAKER</subfield>
+                    <subfield code="d">YDXCP</subfield>
+                    <subfield code="d">OCO</subfield>
+                    <subfield code="d">CPL</subfield>
+                    <subfield code="d">YBM</subfield>
+                    <subfield code="d">BUR</subfield>
+                    <subfield code="d">TBS</subfield>
+                    <subfield code="d">MYG</subfield>
+                    <subfield code="d">OrLoB-B</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="043">
+                    <subfield code="a">nc-----</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="4" tag="050">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="092">
+                    <subfield code="a">338.1</subfield>
+                    <subfield code="b">C466b</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Chapman, Peter,</subfield>
+                    <subfield code="d">1948-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="240">
+                    <subfield code="a">Jungle capitalists</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Bananas :</subfield>
+                    <subfield code="b">how the United Fruit Company shaped the world /</subfield>
+                    <subfield code="c">Peter Chapman.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="250">
+                    <subfield code="a">1st American ed.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Edinburgh ;</subfield>
+                    <subfield code="a">New York :</subfield>
+                    <subfield code="b">Canongate ;</subfield>
+                    <subfield code="a">[Berkeley, Calif.?] :</subfield>
+                    <subfield code="b">Distributed by Publishers Group West,</subfield>
+                    <subfield code="c">c2007.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">xv, 224 p. :</subfield>
+                    <subfield code="b">map ;</subfield>
+                    <subfield code="c">21 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Originally published as: Jungle capitalists.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Map on lining papers.</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="505">
+                    <subfield code="g">1.</subfield>
+                    <subfield code="t">From the Memory of Men --</subfield>
+                    <subfield code="g">2.</subfield>
+                    <subfield code="t">Lament for a Dying Fruit --</subfield>
+                    <subfield code="g">3.</subfield>
+                    <subfield code="t">Roots of Empire --</subfield>
+                    <subfield code="g">4.</subfield>
+                    <subfield code="t">Monopoly --</subfield>
+                    <subfield code="g">5.</subfield>
+                    <subfield code="t">The Banana Man --</subfield>
+                    <subfield code="g">6.</subfield>
+                    <subfield code="t">Taming the Enclave --</subfield>
+                    <subfield code="g">7.</subfield>
+                    <subfield code="t">Banana Republics --</subfield>
+                    <subfield code="g">8.</subfield>
+                    <subfield code="t">On the Inside --</subfield>
+                    <subfield code="g">9.</subfield>
+                    <subfield code="t">Coup --</subfield>
+                    <subfield code="g">10.</subfield>
+                    <subfield code="t">'Betrayal' --</subfield>
+                    <subfield code="g">11.</subfield>
+                    <subfield code="t">Decline and Fall --</subfield>
+                    <subfield code="g">12.</subfield>
+                    <subfield code="t">Old and Dark Forces --</subfield>
+                    <subfield code="t">Epilogue: United Fruit World.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="504">
+                    <subfield code="a">Includes bibliographical references (p. 211-215) and index.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="520">
+                    <subfield code="a">In this exploration of corporate maneuvering and subterfuge, journalist Chapman shows how the importer United Fruit set the precedent for the institutionalized power and influence of today's multinational companies. This infamous company was arguably the most controversial global corporation ever--from the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from an office on the 44th floor of the Pan Am building in New York City. From the marketing of the banana as the first fast food, to the company's involvement in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala, Chapman weaves a tale of big business, political deceit, and outright violence to show how one company wreaked havoc in the "banana republics" of Central America, and how terrifyingly similar the age of United Fruit is to our age of rapid globalization.--From publisher description.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Banana trade</subfield>
+                    <subfield code="z">Central America</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Bananas</subfield>
+                    <subfield code="x">Social aspects.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">International business enterprises</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="651">
+                    <subfield code="a">Central America</subfield>
+                    <subfield code="x">History</subfield>
+                    <subfield code="y">1951-1979.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="x">IAduringHaydenReno</subfield>
+                    <subfield code="3">Internet Archive</subfield>
+                    <subfield code="u">https://archive.org/details/bananashowunited00chap</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker and Taylor</subfield>
+                    <subfield code="b">BTCP</subfield>
+                    <subfield code="n">BK0007364891</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker &amp; Taylor</subfield>
+                    <subfield code="b">BKTY</subfield>
+                    <subfield code="c">24.00</subfield>
+                    <subfield code="d">18.00</subfield>
+                    <subfield code="i">1841958816</subfield>
+                    <subfield code="n">0007364891</subfield>
+                    <subfield code="s">active</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">YBP Library Services</subfield>
+                    <subfield code="b">YANK</subfield>
+                    <subfield code="n">2734445</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="949">
+                    <subfield code="4">IP</subfield>
+                    <subfield code="a">h</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">STACK</subfield>
+                    <subfield code="o">0</subfield>
+                    <subfield code="p">39080034192929</subfield>
+                    <subfield code="x">01</subfield>
+                    <subfield code="h">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">Edinburgh ; Canongate ;</subfield>
+                    <subfield code="a">2007</subfield>
+                    <subfield code="a">enk</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="a">166367812</subfield>
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="a">1841958816 :</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990014925090206761</subfield>
+                    <subfield code="8">224940810006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">Stacks</subfield>
+                    <subfield code="d">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">1</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">STACK</subfield>
+                    <subfield code="k">0</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Hayden Library</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53404794090006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="t">Internet Archive</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990014925090206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:00:48-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:00:48 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=001492509MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="CCAE3D65D62FDE82B26C448C7B1AF7F6.app02.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=c7d4f8ca7386afa6ced80a46b25687b6;Path=/;SameSite=None;Secure
+      - urm_se=1623874249321; Path=/; SameSite=None; Secure
+      - urm_st=1623873649321; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - GprRrV2yHx
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:00:49 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03348cam  2200541Ia 4500</leader>
+                  <controlfield tag="001">990014925090206761</controlfield>
+                  <controlfield tag="005">20210519003556.0</controlfield>
+                  <controlfield tag="008">070728s2007    enkb     b    001 0 eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">1841958816 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)001492509MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)166367812</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">BTCTA</subfield>
+                    <subfield code="c">BTCTA</subfield>
+                    <subfield code="d">BAKER</subfield>
+                    <subfield code="d">YDXCP</subfield>
+                    <subfield code="d">OCO</subfield>
+                    <subfield code="d">CPL</subfield>
+                    <subfield code="d">YBM</subfield>
+                    <subfield code="d">BUR</subfield>
+                    <subfield code="d">TBS</subfield>
+                    <subfield code="d">MYG</subfield>
+                    <subfield code="d">OrLoB-B</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="043">
+                    <subfield code="a">nc-----</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="4" tag="050">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="092">
+                    <subfield code="a">338.1</subfield>
+                    <subfield code="b">C466b</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Chapman, Peter,</subfield>
+                    <subfield code="d">1948-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="240">
+                    <subfield code="a">Jungle capitalists</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Bananas :</subfield>
+                    <subfield code="b">how the United Fruit Company shaped the world /</subfield>
+                    <subfield code="c">Peter Chapman.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="250">
+                    <subfield code="a">1st American ed.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Edinburgh ;</subfield>
+                    <subfield code="a">New York :</subfield>
+                    <subfield code="b">Canongate ;</subfield>
+                    <subfield code="a">[Berkeley, Calif.?] :</subfield>
+                    <subfield code="b">Distributed by Publishers Group West,</subfield>
+                    <subfield code="c">c2007.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">xv, 224 p. :</subfield>
+                    <subfield code="b">map ;</subfield>
+                    <subfield code="c">21 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Originally published as: Jungle capitalists.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Map on lining papers.</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="505">
+                    <subfield code="g">1.</subfield>
+                    <subfield code="t">From the Memory of Men --</subfield>
+                    <subfield code="g">2.</subfield>
+                    <subfield code="t">Lament for a Dying Fruit --</subfield>
+                    <subfield code="g">3.</subfield>
+                    <subfield code="t">Roots of Empire --</subfield>
+                    <subfield code="g">4.</subfield>
+                    <subfield code="t">Monopoly --</subfield>
+                    <subfield code="g">5.</subfield>
+                    <subfield code="t">The Banana Man --</subfield>
+                    <subfield code="g">6.</subfield>
+                    <subfield code="t">Taming the Enclave --</subfield>
+                    <subfield code="g">7.</subfield>
+                    <subfield code="t">Banana Republics --</subfield>
+                    <subfield code="g">8.</subfield>
+                    <subfield code="t">On the Inside --</subfield>
+                    <subfield code="g">9.</subfield>
+                    <subfield code="t">Coup --</subfield>
+                    <subfield code="g">10.</subfield>
+                    <subfield code="t">'Betrayal' --</subfield>
+                    <subfield code="g">11.</subfield>
+                    <subfield code="t">Decline and Fall --</subfield>
+                    <subfield code="g">12.</subfield>
+                    <subfield code="t">Old and Dark Forces --</subfield>
+                    <subfield code="t">Epilogue: United Fruit World.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="504">
+                    <subfield code="a">Includes bibliographical references (p. 211-215) and index.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="520">
+                    <subfield code="a">In this exploration of corporate maneuvering and subterfuge, journalist Chapman shows how the importer United Fruit set the precedent for the institutionalized power and influence of today's multinational companies. This infamous company was arguably the most controversial global corporation ever--from the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from an office on the 44th floor of the Pan Am building in New York City. From the marketing of the banana as the first fast food, to the company's involvement in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala, Chapman weaves a tale of big business, political deceit, and outright violence to show how one company wreaked havoc in the "banana republics" of Central America, and how terrifyingly similar the age of United Fruit is to our age of rapid globalization.--From publisher description.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Banana trade</subfield>
+                    <subfield code="z">Central America</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Bananas</subfield>
+                    <subfield code="x">Social aspects.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">International business enterprises</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="651">
+                    <subfield code="a">Central America</subfield>
+                    <subfield code="x">History</subfield>
+                    <subfield code="y">1951-1979.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="x">IAduringHaydenReno</subfield>
+                    <subfield code="3">Internet Archive</subfield>
+                    <subfield code="u">https://archive.org/details/bananashowunited00chap</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker and Taylor</subfield>
+                    <subfield code="b">BTCP</subfield>
+                    <subfield code="n">BK0007364891</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker &amp; Taylor</subfield>
+                    <subfield code="b">BKTY</subfield>
+                    <subfield code="c">24.00</subfield>
+                    <subfield code="d">18.00</subfield>
+                    <subfield code="i">1841958816</subfield>
+                    <subfield code="n">0007364891</subfield>
+                    <subfield code="s">active</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">YBP Library Services</subfield>
+                    <subfield code="b">YANK</subfield>
+                    <subfield code="n">2734445</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="949">
+                    <subfield code="4">IP</subfield>
+                    <subfield code="a">h</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">STACK</subfield>
+                    <subfield code="o">0</subfield>
+                    <subfield code="p">39080034192929</subfield>
+                    <subfield code="x">01</subfield>
+                    <subfield code="h">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">Edinburgh ; Canongate ;</subfield>
+                    <subfield code="a">2007</subfield>
+                    <subfield code="a">enk</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="a">166367812</subfield>
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="a">1841958816 :</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990014925090206761</subfield>
+                    <subfield code="8">224940810006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">Stacks</subfield>
+                    <subfield code="d">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">1</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">STACK</subfield>
+                    <subfield code="k">0</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Hayden Library</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53404794090006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="t">Internet Archive</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990014925090206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:00:49-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:00:49 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=001492509MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="8DE1AFB073739A886C4624ED633C75DC.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=a556d7ef198f1c1dd429ddf70584774a;Path=/;SameSite=None;Secure
+      - urm_se=1623874250202; Path=/; SameSite=None; Secure
+      - urm_st=1623873650202; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - G5EEOvTvsf
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:00:49 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03348cam  2200541Ia 4500</leader>
+                  <controlfield tag="001">990014925090206761</controlfield>
+                  <controlfield tag="005">20210519003556.0</controlfield>
+                  <controlfield tag="008">070728s2007    enkb     b    001 0 eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">1841958816 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)001492509MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)166367812</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">BTCTA</subfield>
+                    <subfield code="c">BTCTA</subfield>
+                    <subfield code="d">BAKER</subfield>
+                    <subfield code="d">YDXCP</subfield>
+                    <subfield code="d">OCO</subfield>
+                    <subfield code="d">CPL</subfield>
+                    <subfield code="d">YBM</subfield>
+                    <subfield code="d">BUR</subfield>
+                    <subfield code="d">TBS</subfield>
+                    <subfield code="d">MYG</subfield>
+                    <subfield code="d">OrLoB-B</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="043">
+                    <subfield code="a">nc-----</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="4" tag="050">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="092">
+                    <subfield code="a">338.1</subfield>
+                    <subfield code="b">C466b</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Chapman, Peter,</subfield>
+                    <subfield code="d">1948-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="240">
+                    <subfield code="a">Jungle capitalists</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Bananas :</subfield>
+                    <subfield code="b">how the United Fruit Company shaped the world /</subfield>
+                    <subfield code="c">Peter Chapman.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="250">
+                    <subfield code="a">1st American ed.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Edinburgh ;</subfield>
+                    <subfield code="a">New York :</subfield>
+                    <subfield code="b">Canongate ;</subfield>
+                    <subfield code="a">[Berkeley, Calif.?] :</subfield>
+                    <subfield code="b">Distributed by Publishers Group West,</subfield>
+                    <subfield code="c">c2007.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">xv, 224 p. :</subfield>
+                    <subfield code="b">map ;</subfield>
+                    <subfield code="c">21 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Originally published as: Jungle capitalists.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Map on lining papers.</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="505">
+                    <subfield code="g">1.</subfield>
+                    <subfield code="t">From the Memory of Men --</subfield>
+                    <subfield code="g">2.</subfield>
+                    <subfield code="t">Lament for a Dying Fruit --</subfield>
+                    <subfield code="g">3.</subfield>
+                    <subfield code="t">Roots of Empire --</subfield>
+                    <subfield code="g">4.</subfield>
+                    <subfield code="t">Monopoly --</subfield>
+                    <subfield code="g">5.</subfield>
+                    <subfield code="t">The Banana Man --</subfield>
+                    <subfield code="g">6.</subfield>
+                    <subfield code="t">Taming the Enclave --</subfield>
+                    <subfield code="g">7.</subfield>
+                    <subfield code="t">Banana Republics --</subfield>
+                    <subfield code="g">8.</subfield>
+                    <subfield code="t">On the Inside --</subfield>
+                    <subfield code="g">9.</subfield>
+                    <subfield code="t">Coup --</subfield>
+                    <subfield code="g">10.</subfield>
+                    <subfield code="t">'Betrayal' --</subfield>
+                    <subfield code="g">11.</subfield>
+                    <subfield code="t">Decline and Fall --</subfield>
+                    <subfield code="g">12.</subfield>
+                    <subfield code="t">Old and Dark Forces --</subfield>
+                    <subfield code="t">Epilogue: United Fruit World.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="504">
+                    <subfield code="a">Includes bibliographical references (p. 211-215) and index.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="520">
+                    <subfield code="a">In this exploration of corporate maneuvering and subterfuge, journalist Chapman shows how the importer United Fruit set the precedent for the institutionalized power and influence of today's multinational companies. This infamous company was arguably the most controversial global corporation ever--from the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from an office on the 44th floor of the Pan Am building in New York City. From the marketing of the banana as the first fast food, to the company's involvement in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala, Chapman weaves a tale of big business, political deceit, and outright violence to show how one company wreaked havoc in the "banana republics" of Central America, and how terrifyingly similar the age of United Fruit is to our age of rapid globalization.--From publisher description.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Banana trade</subfield>
+                    <subfield code="z">Central America</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Bananas</subfield>
+                    <subfield code="x">Social aspects.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">International business enterprises</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="651">
+                    <subfield code="a">Central America</subfield>
+                    <subfield code="x">History</subfield>
+                    <subfield code="y">1951-1979.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="x">IAduringHaydenReno</subfield>
+                    <subfield code="3">Internet Archive</subfield>
+                    <subfield code="u">https://archive.org/details/bananashowunited00chap</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker and Taylor</subfield>
+                    <subfield code="b">BTCP</subfield>
+                    <subfield code="n">BK0007364891</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker &amp; Taylor</subfield>
+                    <subfield code="b">BKTY</subfield>
+                    <subfield code="c">24.00</subfield>
+                    <subfield code="d">18.00</subfield>
+                    <subfield code="i">1841958816</subfield>
+                    <subfield code="n">0007364891</subfield>
+                    <subfield code="s">active</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">YBP Library Services</subfield>
+                    <subfield code="b">YANK</subfield>
+                    <subfield code="n">2734445</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="949">
+                    <subfield code="4">IP</subfield>
+                    <subfield code="a">h</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">STACK</subfield>
+                    <subfield code="o">0</subfield>
+                    <subfield code="p">39080034192929</subfield>
+                    <subfield code="x">01</subfield>
+                    <subfield code="h">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">Edinburgh ; Canongate ;</subfield>
+                    <subfield code="a">2007</subfield>
+                    <subfield code="a">enk</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="a">166367812</subfield>
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="a">1841958816 :</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990014925090206761</subfield>
+                    <subfield code="8">224940810006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">Stacks</subfield>
+                    <subfield code="d">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">1</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">STACK</subfield>
+                    <subfield code="k">0</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Hayden Library</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53404794090006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="t">Internet Archive</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990014925090206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:00:50-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:00:50 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=001492509MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="737DD493D3DB5C656CBB45634458BF74.app02.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=c7d4f8ca7386afa6ced80a46b25687b6;Path=/;SameSite=None;Secure
+      - urm_se=1623874251206; Path=/; SameSite=None; Secure
+      - urm_st=1623873651206; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - oKeC6fIuHJ
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:00:51 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03348cam  2200541Ia 4500</leader>
+                  <controlfield tag="001">990014925090206761</controlfield>
+                  <controlfield tag="005">20210519003556.0</controlfield>
+                  <controlfield tag="008">070728s2007    enkb     b    001 0 eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="020">
+                    <subfield code="a">1841958816 :</subfield>
+                    <subfield code="c">$24.00</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)001492509MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)166367812</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">BTCTA</subfield>
+                    <subfield code="c">BTCTA</subfield>
+                    <subfield code="d">BAKER</subfield>
+                    <subfield code="d">YDXCP</subfield>
+                    <subfield code="d">OCO</subfield>
+                    <subfield code="d">CPL</subfield>
+                    <subfield code="d">YBM</subfield>
+                    <subfield code="d">BUR</subfield>
+                    <subfield code="d">TBS</subfield>
+                    <subfield code="d">MYG</subfield>
+                    <subfield code="d">OrLoB-B</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="043">
+                    <subfield code="a">nc-----</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="4" tag="050">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="092">
+                    <subfield code="a">338.1</subfield>
+                    <subfield code="b">C466b</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="100">
+                    <subfield code="a">Chapman, Peter,</subfield>
+                    <subfield code="d">1948-</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="240">
+                    <subfield code="a">Jungle capitalists</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2="0" tag="245">
+                    <subfield code="a">Bananas :</subfield>
+                    <subfield code="b">how the United Fruit Company shaped the world /</subfield>
+                    <subfield code="c">Peter Chapman.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="250">
+                    <subfield code="a">1st American ed.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">Edinburgh ;</subfield>
+                    <subfield code="a">New York :</subfield>
+                    <subfield code="b">Canongate ;</subfield>
+                    <subfield code="a">[Berkeley, Calif.?] :</subfield>
+                    <subfield code="b">Distributed by Publishers Group West,</subfield>
+                    <subfield code="c">c2007.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">xv, 224 p. :</subfield>
+                    <subfield code="b">map ;</subfield>
+                    <subfield code="c">21 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Originally published as: Jungle capitalists.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Map on lining papers.</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="505">
+                    <subfield code="g">1.</subfield>
+                    <subfield code="t">From the Memory of Men --</subfield>
+                    <subfield code="g">2.</subfield>
+                    <subfield code="t">Lament for a Dying Fruit --</subfield>
+                    <subfield code="g">3.</subfield>
+                    <subfield code="t">Roots of Empire --</subfield>
+                    <subfield code="g">4.</subfield>
+                    <subfield code="t">Monopoly --</subfield>
+                    <subfield code="g">5.</subfield>
+                    <subfield code="t">The Banana Man --</subfield>
+                    <subfield code="g">6.</subfield>
+                    <subfield code="t">Taming the Enclave --</subfield>
+                    <subfield code="g">7.</subfield>
+                    <subfield code="t">Banana Republics --</subfield>
+                    <subfield code="g">8.</subfield>
+                    <subfield code="t">On the Inside --</subfield>
+                    <subfield code="g">9.</subfield>
+                    <subfield code="t">Coup --</subfield>
+                    <subfield code="g">10.</subfield>
+                    <subfield code="t">'Betrayal' --</subfield>
+                    <subfield code="g">11.</subfield>
+                    <subfield code="t">Decline and Fall --</subfield>
+                    <subfield code="g">12.</subfield>
+                    <subfield code="t">Old and Dark Forces --</subfield>
+                    <subfield code="t">Epilogue: United Fruit World.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="504">
+                    <subfield code="a">Includes bibliographical references (p. 211-215) and index.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="520">
+                    <subfield code="a">In this exploration of corporate maneuvering and subterfuge, journalist Chapman shows how the importer United Fruit set the precedent for the institutionalized power and influence of today's multinational companies. This infamous company was arguably the most controversial global corporation ever--from the jungles of Costa Rica to the dramatic suicide of its CEO, who leapt from an office on the 44th floor of the Pan Am building in New York City. From the marketing of the banana as the first fast food, to the company's involvement in an invasion of Honduras, the Bay of Pigs crisis, and a bloody coup in Guatemala, Chapman weaves a tale of big business, political deceit, and outright violence to show how one company wreaked havoc in the "banana republics" of Central America, and how terrifyingly similar the age of United Fruit is to our age of rapid globalization.--From publisher description.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2="0" tag="610">
+                    <subfield code="a">United Fruit Company</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Banana trade</subfield>
+                    <subfield code="z">Central America</subfield>
+                    <subfield code="x">History.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Bananas</subfield>
+                    <subfield code="x">Social aspects.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">International business enterprises</subfield>
+                    <subfield code="x">Corrupt practices.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="651">
+                    <subfield code="a">Central America</subfield>
+                    <subfield code="x">History</subfield>
+                    <subfield code="y">1951-1979.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="x">IAduringHaydenReno</subfield>
+                    <subfield code="3">Internet Archive</subfield>
+                    <subfield code="u">https://archive.org/details/bananashowunited00chap</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">jm080520</subfield>
+                    <subfield code="i">jm</subfield>
+                    <subfield code="d">080520</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker and Taylor</subfield>
+                    <subfield code="b">BTCP</subfield>
+                    <subfield code="n">BK0007364891</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">Baker &amp; Taylor</subfield>
+                    <subfield code="b">BKTY</subfield>
+                    <subfield code="c">24.00</subfield>
+                    <subfield code="d">18.00</subfield>
+                    <subfield code="i">1841958816</subfield>
+                    <subfield code="n">0007364891</subfield>
+                    <subfield code="s">active</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="938">
+                    <subfield code="a">YBP Library Services</subfield>
+                    <subfield code="b">YANK</subfield>
+                    <subfield code="n">2734445</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="949">
+                    <subfield code="4">IP</subfield>
+                    <subfield code="a">h</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">STACK</subfield>
+                    <subfield code="o">0</subfield>
+                    <subfield code="p">39080034192929</subfield>
+                    <subfield code="x">01</subfield>
+                    <subfield code="h">HD9259.B3.U523 2007b</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">Edinburgh ; Canongate ;</subfield>
+                    <subfield code="a">2007</subfield>
+                    <subfield code="a">enk</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="a">166367812</subfield>
+                    <subfield code="a">9781841958811 :</subfield>
+                    <subfield code="a">1841958816 :</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990014925090206761</subfield>
+                    <subfield code="8">224940810006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">HUM</subfield>
+                    <subfield code="c">Stacks</subfield>
+                    <subfield code="d">HD9259.B3.U523 2007b</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">1</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">STACK</subfield>
+                    <subfield code="k">0</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Hayden Library</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53404794090006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="t">Internet Archive</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990014925090206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:00:51-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:00:51 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/sru_journal.yml
+++ b/test/vcr_cassettes/sru_journal.yml
@@ -1,0 +1,2021 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/authservice/rest/uidauth
+    body:
+      encoding: UTF-8
+      string: '{"UserId":"FAKE_EDS_USER_ID","Password":"FAKE_EDS_PASSWORD","InterfaceId":"edsapi_ruby_gem"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - ''
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:01 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '128'
+    body:
+      encoding: UTF-8
+      string: '{"AuthToken":"FakeAuthenticationtoken","AuthTimeout":"1800"}'
+  recorded_at: Wed, 16 Jun 2021 20:24:01 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=y&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - ''
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:01 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - ebcb5fb9-8fb4-4f9b-8d04-dc6277e08ea2
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '389770294'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '102'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"bf00e3a5-22ff-45a5-a149-4bbba790c7c7.2RjRRF6VfzpM\/cH0MCRirEt+43QDl4X14iighr\/KY5U="}'
+  recorded_at: Wed, 16 Jun 2021 20:24:01 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CreateSession?displaydatabasename=y&guest=n&profile=FAKE_EDS_PROFILE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:01 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - fb35c687-d135-4a42-83a2-3c7a7606e122
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-296810165"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '101'
+    body:
+      encoding: UTF-8
+      string: '{"SessionToken":"32469886-c6a2-4faf-8c38-717937cb83ad.fwCaMkKYAqbLT8bawaFK\/FxeDcyZJKN6fEdzDapRAnA="}'
+  recorded_at: Wed, 16 Jun 2021 20:24:01 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:02 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 471fcf22-b39d-4ea9-84fe-8fdf37830da5
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '389770294'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '26533'
+    body:
+      encoding: UTF-8
+      string: '{"AvailableSearchCriteria":{"AvailableSorts":[{"Id":"relevance","Label":"Relevance","AddAction":"setsort(relevance)"},{"Id":"date","Label":"Date
+        Newest","AddAction":"setsort(date)"},{"Id":"date2","Label":"Date Oldest","AddAction":"setsort(date2)"}],"AvailableSearchFields":[{"FieldCode":"TX","Label":"All
+        Text"},{"FieldCode":"AU","Label":"Author"},{"FieldCode":"TI","Label":"Title"},{"FieldCode":"SU","Label":"Subject
+        Terms"},{"FieldCode":"SO","Label":"Source"},{"FieldCode":"AB","Label":"Abstract"},{"FieldCode":"IS","Label":"ISSN"},{"FieldCode":"IB","Label":"ISBN"}],"AvailableExpanders":[{"Id":"thesaurus","Label":"Apply
+        related words","AddAction":"addexpander(thesaurus)","DefaultOn":"n"},{"Id":"fulltext","Label":"Also
+        search within the full text of the articles","AddAction":"addexpander(fulltext)","DefaultOn":"y"},{"Id":"relatedsubjects","Label":"Apply
+        equivalent subjects","AddAction":"addexpander(relatedsubjects)","DefaultOn":"n"}],"AvailableLimiters":[{"Id":"FT","Label":"Full
+        Text","Type":"select","AddAction":"addlimiter(FT:value)","DefaultOn":"n","Order":"1"},{"Id":"TI","Label":"Reviewed
+        Book Title","Type":"text","AddAction":"addlimiter(TI:value)","DefaultOn":"n","Order":"2"},{"Id":"FR","Label":"References
+        Available","Type":"select","AddAction":"addlimiter(FR:value)","DefaultOn":"n","Order":"3"},{"Id":"RV","Label":"Peer
+        Reviewed","Type":"select","AddAction":"addlimiter(RV:value)","DefaultOn":"n","Order":"4"},{"Id":"AU","Label":"Author","Type":"text","AddAction":"addlimiter(AU:value)","DefaultOn":"n","Order":"5"},{"Id":"SO","Label":"Journal
+        Name","Type":"text","AddAction":"addlimiter(SO:value)","DefaultOn":"n","Order":"6"},{"Id":"DT1","Label":"Date
+        Published","Type":"ymrange","AddAction":"addlimiter(DT1:value)","DefaultOn":"n","Order":"7"},{"Id":"LB","Label":"Location","Type":"multiselectvalue","LimiterValues":[{"Value":"MIT
+        Barton Catalog","AddAction":"addlimiter(LB:MIT Barton Catalog)","LimiterValues":[{"Value":"Barker
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Barker Library)"},{"Value":"Dewey
+        Library","AddAction":"addlimiter(LB:MIT Barton Catalog-Dewey Library)"},{"Value":"Hayden
+        Library - Humanities","AddAction":"addlimiter(LB:MIT Barton Catalog-Hayden
+        Library - Humanities)"},{"Value":"Hayden Library - Science","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Library - Science)"},{"Value":"Hayden Reserves","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Hayden Reserves)"},{"Value":"Institute Archives","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Institute Archives)"},{"Value":"Internet Resource","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Internet Resource)"},{"Value":"Lewis Music Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Lewis Music Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Barton Catalog-Rotch Visual Collections)"}]},{"Value":"MIT Course Reserves","AddAction":"addlimiter(LB:MIT
+        Course Reserves)","LimiterValues":[{"Value":"Barker Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Barker Library)"},{"Value":"Dewey Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Dewey Library)"},{"Value":"Hayden Library - Humanities","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Hayden Library - Humanities)"},{"Value":"Hayden Library -
+        Science","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Library - Science)"},{"Value":"Hayden
+        Reserves","AddAction":"addlimiter(LB:MIT Course Reserves-Hayden Reserves)"},{"Value":"Institute
+        Archives","AddAction":"addlimiter(LB:MIT Course Reserves-Institute Archives)"},{"Value":"Internet
+        Resource","AddAction":"addlimiter(LB:MIT Course Reserves-Internet Resource)"},{"Value":"Lewis
+        Music Library","AddAction":"addlimiter(LB:MIT Course Reserves-Lewis Music
+        Library)"},{"Value":"Library Storage Annex","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Library Storage Annex)"},{"Value":"Physics Dept. Reading Room","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Physics Dept. Reading Room)"},{"Value":"Rotch Library","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Library)"},{"Value":"Rotch Visual Collections","AddAction":"addlimiter(LB:MIT
+        Course Reserves-Rotch Visual Collections)"}]}],"DefaultOn":"n","Order":"8"},{"Id":"FT1","Label":"Available
+        in Library Collection","Type":"select","AddAction":"addlimiter(FT1:value)","DefaultOn":"n","Order":"9"},{"Id":"FC","Label":"Catalog
+        Only","Type":"select","AddAction":"addlimiter(FC:value)","DefaultOn":"n","Order":"10"},{"Id":"LA99","Label":"Language","Type":"multiselectvalue","LimiterValues":[{"Value":"Afrikaans","AddAction":"addlimiter(LA99:Afrikaans)"},{"Value":"Albanian","AddAction":"addlimiter(LA99:Albanian)"},{"Value":"Aleut","AddAction":"addlimiter(LA99:Aleut)"},{"Value":"Arabic","AddAction":"addlimiter(LA99:Arabic)"},{"Value":"Chinese","AddAction":"addlimiter(LA99:Chinese)"},{"Value":"Czech","AddAction":"addlimiter(LA99:Czech)"},{"Value":"Danish","AddAction":"addlimiter(LA99:Danish)"},{"Value":"Dutch;
+        Flemish","AddAction":"addlimiter(LA99:Dutch; Flemish)"},{"Value":"English","AddAction":"addlimiter(LA99:English)"},{"Value":"Finnish","AddAction":"addlimiter(LA99:Finnish)"},{"Value":"French","AddAction":"addlimiter(LA99:French)"},{"Value":"German","AddAction":"addlimiter(LA99:German)"},{"Value":"Haitian;
+        Haitian Creole","AddAction":"addlimiter(LA99:Haitian; Haitian Creole)"},{"Value":"Hebrew","AddAction":"addlimiter(LA99:Hebrew)"},{"Value":"Hmong;
+        Mong","AddAction":"addlimiter(LA99:Hmong; Mong)"},{"Value":"Indonesian","AddAction":"addlimiter(LA99:Indonesian)"},{"Value":"Inupiaq","AddAction":"addlimiter(LA99:Inupiaq)"},{"Value":"Italian","AddAction":"addlimiter(LA99:Italian)"},{"Value":"Japanese","AddAction":"addlimiter(LA99:Japanese)"},{"Value":"Korean","AddAction":"addlimiter(LA99:Korean)"},{"Value":"Lao","AddAction":"addlimiter(LA99:Lao)"},{"Value":"Latin","AddAction":"addlimiter(LA99:Latin)"},{"Value":"Lithuanian","AddAction":"addlimiter(LA99:Lithuanian)"},{"Value":"Navajo;
+        Navaho","AddAction":"addlimiter(LA99:Navajo; Navaho)"},{"Value":"Persian","AddAction":"addlimiter(LA99:Persian)"},{"Value":"Polish","AddAction":"addlimiter(LA99:Polish)"},{"Value":"Portuguese","AddAction":"addlimiter(LA99:Portuguese)"},{"Value":"Pushto;
+        Pashto","AddAction":"addlimiter(LA99:Pushto; Pashto)"},{"Value":"Romanian;
+        Moldavian; Moldovan","AddAction":"addlimiter(LA99:Romanian; Moldavian; Moldovan)"},{"Value":"Russian","AddAction":"addlimiter(LA99:Russian)"},{"Value":"Spanish;
+        Castilian","AddAction":"addlimiter(LA99:Spanish; Castilian)"},{"Value":"Swedish","AddAction":"addlimiter(LA99:Swedish)"},{"Value":"Tagalog","AddAction":"addlimiter(LA99:Tagalog)"},{"Value":"Thai","AddAction":"addlimiter(LA99:Thai)"},{"Value":"Turkish","AddAction":"addlimiter(LA99:Turkish)"},{"Value":"Ukrainian","AddAction":"addlimiter(LA99:Ukrainian)"},{"Value":"Vietnamese","AddAction":"addlimiter(LA99:Vietnamese)"},{"Value":"Croatian","AddAction":"addlimiter(LA99:Croatian)"},{"Value":"Dutch\/Flemish","AddAction":"addlimiter(LA99:Dutch\/Flemish)"},{"Value":"Hungarian","AddAction":"addlimiter(LA99:Hungarian)"},{"Value":"Norwegian","AddAction":"addlimiter(LA99:Norwegian)"},{"Value":"Romanian","AddAction":"addlimiter(LA99:Romanian)"},{"Value":"Serbian","AddAction":"addlimiter(LA99:Serbian)"},{"Value":"Slovak","AddAction":"addlimiter(LA99:Slovak)"},{"Value":"Slovenian","AddAction":"addlimiter(LA99:Slovenian)"},{"Value":"Spanish","AddAction":"addlimiter(LA99:Spanish)"},{"Value":"Swahili","AddAction":"addlimiter(LA99:Swahili)"},{"Value":"Bosnian","AddAction":"addlimiter(LA99:Bosnian)"},{"Value":"Latvian","AddAction":"addlimiter(LA99:Latvian)"},{"Value":"Catalan","AddAction":"addlimiter(LA99:Catalan)"},{"Value":"Abkhazian","AddAction":"addlimiter(LA99:Abkhazian)"},{"Value":"Amharic","AddAction":"addlimiter(LA99:Amharic)"},{"Value":"Armenian","AddAction":"addlimiter(LA99:Armenian)"},{"Value":"Mapudungun;
+        Mapuche","AddAction":"addlimiter(LA99:Mapudungun; Mapuche)"},{"Value":"Asturian;
+        Bable; Leonese; Asturleonese","AddAction":"addlimiter(LA99:Asturian; Bable;
+        Leonese; Asturleonese)"},{"Value":"Australian languages","AddAction":"addlimiter(LA99:Australian
+        languages)"},{"Value":"Basque","AddAction":"addlimiter(LA99:Basque)"},{"Value":"Bengali","AddAction":"addlimiter(LA99:Bengali)"},{"Value":"Breton","AddAction":"addlimiter(LA99:Breton)"},{"Value":"Burmese","AddAction":"addlimiter(LA99:Burmese)"},{"Value":"Central
+        American Indian languages","AddAction":"addlimiter(LA99:Central American Indian
+        languages)"},{"Value":"Catalan; Valencian","AddAction":"addlimiter(LA99:Catalan;
+        Valencian)"},{"Value":"Chechen","AddAction":"addlimiter(LA99:Chechen)"},{"Value":"Coptic","AddAction":"addlimiter(LA99:Coptic)"},{"Value":"English,
+        Middle (1100-1500)","AddAction":"addlimiter(LA99:English\\, Middle \\(1100-1500\\))"},{"Value":"Esperanto","AddAction":"addlimiter(LA99:Esperanto)"},{"Value":"Estonian","AddAction":"addlimiter(LA99:Estonian)"},{"Value":"Faroese","AddAction":"addlimiter(LA99:Faroese)"},{"Value":"Fijian","AddAction":"addlimiter(LA99:Fijian)"},{"Value":"Germanic
+        languages","AddAction":"addlimiter(LA99:Germanic languages)"},{"Value":"Geez","AddAction":"addlimiter(LA99:Geez)"},{"Value":"Irish","AddAction":"addlimiter(LA99:Irish)"},{"Value":"Galician","AddAction":"addlimiter(LA99:Galician)"},{"Value":"Greek,
+        Ancient (to 1453)","AddAction":"addlimiter(LA99:Greek\\, Ancient \\(to 1453\\))"},{"Value":"Greek,
+        Modern (1453-)","AddAction":"addlimiter(LA99:Greek\\, Modern \\(1453-\\))"},{"Value":"Hindi","AddAction":"addlimiter(LA99:Hindi)"},{"Value":"Icelandic","AddAction":"addlimiter(LA99:Icelandic)"},{"Value":"Ido","AddAction":"addlimiter(LA99:Ido)"},{"Value":"Interlingua
+        (International Auxiliary Language Association)","AddAction":"addlimiter(LA99:Interlingua
+        \\(International Auxiliary Language Association\\))"},{"Value":"Javanese","AddAction":"addlimiter(LA99:Javanese)"},{"Value":"Judeo-Arabic","AddAction":"addlimiter(LA99:Judeo-Arabic)"},{"Value":"Kannada","AddAction":"addlimiter(LA99:Kannada)"},{"Value":"Luxembourgish;
+        Letzeburgesch","AddAction":"addlimiter(LA99:Luxembourgish; Letzeburgesch)"},{"Value":"Malayalam","AddAction":"addlimiter(LA99:Malayalam)"},{"Value":"Austronesian
+        languages","AddAction":"addlimiter(LA99:Austronesian languages)"},{"Value":"Malay","AddAction":"addlimiter(LA99:Malay)"},{"Value":"Maltese","AddAction":"addlimiter(LA99:Maltese)"},{"Value":"Mongolian","AddAction":"addlimiter(LA99:Mongolian)"},{"Value":"Nahuatl
+        languages","AddAction":"addlimiter(LA99:Nahuatl languages)"},{"Value":"Neapolitan","AddAction":"addlimiter(LA99:Neapolitan)"},{"Value":"Bokmål,
+        Norwegian; Norwegian Bokmål","AddAction":"addlimiter(LA99:Bokmål\\, Norwegian;
+        Norwegian Bokmål)"},{"Value":"Norse, Old","AddAction":"addlimiter(LA99:Norse\\,
+        Old)"},{"Value":"Occitan (post 1500)","AddAction":"addlimiter(LA99:Occitan
+        \\(post 1500\\))"},{"Value":"Ojibwa","AddAction":"addlimiter(LA99:Ojibwa)"},{"Value":"Philippine
+        languages","AddAction":"addlimiter(LA99:Philippine languages)"},{"Value":"Romany","AddAction":"addlimiter(LA99:Romany)"},{"Value":"Samaritan
+        Aramaic","AddAction":"addlimiter(LA99:Samaritan Aramaic)"},{"Value":"Sanskrit","AddAction":"addlimiter(LA99:Sanskrit)"},{"Value":"Sinhala;
+        Sinhalese","AddAction":"addlimiter(LA99:Sinhala; Sinhalese)"},{"Value":"Sundanese","AddAction":"addlimiter(LA99:Sundanese)"},{"Value":"Sumerian","AddAction":"addlimiter(LA99:Sumerian)"},{"Value":"Classical
+        Syriac","AddAction":"addlimiter(LA99:Classical Syriac)"},{"Value":"Tibetan","AddAction":"addlimiter(LA99:Tibetan)"},{"Value":"Ugaritic","AddAction":"addlimiter(LA99:Ugaritic)"},{"Value":"Welsh","AddAction":"addlimiter(LA99:Welsh)"},{"Value":"Yiddish","AddAction":"addlimiter(LA99:Yiddish)"},{"Value":"Zapotec","AddAction":"addlimiter(LA99:Zapotec)"},{"Value":"Azerbaijani","AddAction":"addlimiter(LA99:Azerbaijani)"},{"Value":"Bulgarian","AddAction":"addlimiter(LA99:Bulgarian)"},{"Value":"Greek","AddAction":"addlimiter(LA99:Greek)"},{"Value":"Serbo-Croatian","AddAction":"addlimiter(LA99:Serbo-Croatian)"},{"Value":"Urdu","AddAction":"addlimiter(LA99:Urdu)"},{"Value":"Belorussian","AddAction":"addlimiter(LA99:Belorussian)"},{"Value":"Dutch","AddAction":"addlimiter(LA99:Dutch)"},{"Value":"Georgian","AddAction":"addlimiter(LA99:Georgian)"},{"Value":"Kazakh","AddAction":"addlimiter(LA99:Kazakh)"},{"Value":"Malayan","AddAction":"addlimiter(LA99:Malayan)"},{"Value":"Moldavian","AddAction":"addlimiter(LA99:Moldavian)"},{"Value":"Ukranian","AddAction":"addlimiter(LA99:Ukranian)"},{"Value":"Uzbek","AddAction":"addlimiter(LA99:Uzbek)"},{"Value":"English,
+        Old (ca.450-1100)","AddAction":"addlimiter(LA99:English\\, Old \\(ca.450-1100\\))"},{"Value":"Belarusian","AddAction":"addlimiter(LA99:Belarusian)"},{"Value":"Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic","AddAction":"addlimiter(LA99:Church
+        Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic)"},{"Value":"Creoles
+        and pidgins, English based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        English based)"},{"Value":"French, Middle (ca.1400-1600)","AddAction":"addlimiter(LA99:French\\,
+        Middle \\(ca.1400-1600\\))"},{"Value":"French, Old (842-ca.1400)","AddAction":"addlimiter(LA99:French\\,
+        Old \\(842-ca.1400\\))"},{"Value":"Gaelic; Scottish Gaelic","AddAction":"addlimiter(LA99:Gaelic;
+        Scottish Gaelic)"},{"Value":"Manx","AddAction":"addlimiter(LA99:Manx)"},{"Value":"German,
+        Middle High (ca.1050-1500)","AddAction":"addlimiter(LA99:German\\, Middle
+        High \\(ca.1050-1500\\))"},{"Value":"Gujarati","AddAction":"addlimiter(LA99:Gujarati)"},{"Value":"Hawaiian","AddAction":"addlimiter(LA99:Hawaiian)"},{"Value":"Iloko","AddAction":"addlimiter(LA99:Iloko)"},{"Value":"Uncoded
+        languages","AddAction":"addlimiter(LA99:Uncoded languages)"},{"Value":"Multiple
+        languages","AddAction":"addlimiter(LA99:Multiple languages)"},{"Value":"Turkish,
+        Ottoman (1500-1928)","AddAction":"addlimiter(LA99:Turkish\\, Ottoman \\(1500-1928\\))"},{"Value":"Pangasinan","AddAction":"addlimiter(LA99:Pangasinan)"},{"Value":"Pali","AddAction":"addlimiter(LA99:Pali)"},{"Value":"Prakrit
+        languages","AddAction":"addlimiter(LA99:Prakrit languages)"},{"Value":"Romance
+        languages","AddAction":"addlimiter(LA99:Romance languages)"},{"Value":"Romansh","AddAction":"addlimiter(LA99:Romansh)"},{"Value":"Scots","AddAction":"addlimiter(LA99:Scots)"},{"Value":"Slavic
+        languages","AddAction":"addlimiter(LA99:Slavic languages)"},{"Value":"Samoan","AddAction":"addlimiter(LA99:Samoan)"},{"Value":"Tahitian","AddAction":"addlimiter(LA99:Tahitian)"},{"Value":"Undetermined","AddAction":"addlimiter(LA99:Undetermined)"},{"Value":"Volapük","AddAction":"addlimiter(LA99:Volapük)"},{"Value":"No
+        linguistic content; Not applicable","AddAction":"addlimiter(LA99:No linguistic
+        content; Not applicable)"},{"Value":"FRENCH","AddAction":"addlimiter(LA99:FRENCH)"},{"Value":"PORTUGUESE","AddAction":"addlimiter(LA99:PORTUGUESE)"},{"Value":"RUSSIAN","AddAction":"addlimiter(LA99:RUSSIAN)"},{"Value":"SPANISH","AddAction":"addlimiter(LA99:SPANISH)"},{"Value":"GERMAN","AddAction":"addlimiter(LA99:GERMAN)"},{"Value":"ENGLISH","AddAction":"addlimiter(LA99:ENGLISH)"},{"Value":"CHINESE","AddAction":"addlimiter(LA99:CHINESE)"},{"Value":"Macedonian","AddAction":"addlimiter(LA99:Macedonian)"},{"Value":"Iranian
+        languages","AddAction":"addlimiter(LA99:Iranian languages)"},{"Value":"Marshallese","AddAction":"addlimiter(LA99:Marshallese)"},{"Value":"Nepali","AddAction":"addlimiter(LA99:Nepali)"},{"Value":"Nepal
+        Bhasa; Newari","AddAction":"addlimiter(LA99:Nepal Bhasa; Newari)"},{"Value":"Greek,
+        Modern","AddAction":"addlimiter(LA99:Greek\\, Modern)"},{"Value":"Acoli","AddAction":"addlimiter(LA99:Acoli)"},{"Value":"Afro-Asiatic
+        languages","AddAction":"addlimiter(LA99:Afro-Asiatic languages)"},{"Value":"Ainu","AddAction":"addlimiter(LA99:Ainu)"},{"Value":"Akan","AddAction":"addlimiter(LA99:Akan)"},{"Value":"Algonquian
+        languages","AddAction":"addlimiter(LA99:Algonquian languages)"},{"Value":"Southern
+        Altai","AddAction":"addlimiter(LA99:Southern Altai)"},{"Value":"Apache languages","AddAction":"addlimiter(LA99:Apache
+        languages)"},{"Value":"Avaric","AddAction":"addlimiter(LA99:Avaric)"},{"Value":"Aymara","AddAction":"addlimiter(LA99:Aymara)"},{"Value":"Banda
+        languages","AddAction":"addlimiter(LA99:Banda languages)"},{"Value":"Bamileke
+        languages","AddAction":"addlimiter(LA99:Bamileke languages)"},{"Value":"Baluchi","AddAction":"addlimiter(LA99:Baluchi)"},{"Value":"Bambara","AddAction":"addlimiter(LA99:Bambara)"},{"Value":"Balinese","AddAction":"addlimiter(LA99:Balinese)"},{"Value":"Bemba","AddAction":"addlimiter(LA99:Bemba)"},{"Value":"Berber
+        languages","AddAction":"addlimiter(LA99:Berber languages)"},{"Value":"Bhojpuri","AddAction":"addlimiter(LA99:Bhojpuri)"},{"Value":"Bislama","AddAction":"addlimiter(LA99:Bislama)"},{"Value":"Bantu
+        languages","AddAction":"addlimiter(LA99:Bantu languages)"},{"Value":"Braj","AddAction":"addlimiter(LA99:Braj)"},{"Value":"Batak
+        languages","AddAction":"addlimiter(LA99:Batak languages)"},{"Value":"Buriat","AddAction":"addlimiter(LA99:Buriat)"},{"Value":"Galibi
+        Carib","AddAction":"addlimiter(LA99:Galibi Carib)"},{"Value":"Caucasian languages","AddAction":"addlimiter(LA99:Caucasian
+        languages)"},{"Value":"Chibcha","AddAction":"addlimiter(LA99:Chibcha)"},{"Value":"Corsican","AddAction":"addlimiter(LA99:Corsican)"},{"Value":"Creoles
+        and pidgins, French-based","AddAction":"addlimiter(LA99:Creoles and pidgins\\,
+        French-based)"},{"Value":"Creoles and pidgins, Portuguese-based","AddAction":"addlimiter(LA99:Creoles
+        and pidgins\\, Portuguese-based)"},{"Value":"Creoles and pidgins","AddAction":"addlimiter(LA99:Creoles
+        and pidgins)"},{"Value":"Slave (Athapascan)","AddAction":"addlimiter(LA99:Slave
+        \\(Athapascan\\))"},{"Value":"Duala","AddAction":"addlimiter(LA99:Duala)"},{"Value":"Dutch,
+        Middle (ca.1050-1350)","AddAction":"addlimiter(LA99:Dutch\\, Middle \\(ca.1050-1350\\))"},{"Value":"Dzongkha","AddAction":"addlimiter(LA99:Dzongkha)"},{"Value":"Efik","AddAction":"addlimiter(LA99:Efik)"},{"Value":"Egyptian
+        (Ancient)","AddAction":"addlimiter(LA99:Egyptian \\(Ancient\\))"},{"Value":"Ewe","AddAction":"addlimiter(LA99:Ewe)"},{"Value":"Fang","AddAction":"addlimiter(LA99:Fang)"},{"Value":"Filipino;
+        Pilipino","AddAction":"addlimiter(LA99:Filipino; Pilipino)"},{"Value":"Finno-Ugrian
+        languages","AddAction":"addlimiter(LA99:Finno-Ugrian languages)"},{"Value":"Fulah","AddAction":"addlimiter(LA99:Fulah)"},{"Value":"Ga","AddAction":"addlimiter(LA99:Ga)"},{"Value":"Gilbertese","AddAction":"addlimiter(LA99:Gilbertese)"},{"Value":"German,
+        Old High (ca.750-1050)","AddAction":"addlimiter(LA99:German\\, Old High \\(ca.750-1050\\))"},{"Value":"Gondi","AddAction":"addlimiter(LA99:Gondi)"},{"Value":"Swiss
+        German; Alemannic; Alsatian","AddAction":"addlimiter(LA99:Swiss German; Alemannic;
+        Alsatian)"},{"Value":"Haida","AddAction":"addlimiter(LA99:Haida)"},{"Value":"Hausa","AddAction":"addlimiter(LA99:Hausa)"},{"Value":"Igbo","AddAction":"addlimiter(LA99:Igbo)"},{"Value":"Inuktitut","AddAction":"addlimiter(LA99:Inuktitut)"},{"Value":"Indic
+        languages","AddAction":"addlimiter(LA99:Indic languages)"},{"Value":"Indo-European
+        languages","AddAction":"addlimiter(LA99:Indo-European languages)"},{"Value":"Iroquoian
+        languages","AddAction":"addlimiter(LA99:Iroquoian languages)"},{"Value":"Kabyle","AddAction":"addlimiter(LA99:Kabyle)"},{"Value":"Kalaallisut;
+        Greenlandic","AddAction":"addlimiter(LA99:Kalaallisut; Greenlandic)"},{"Value":"Kamba","AddAction":"addlimiter(LA99:Kamba)"},{"Value":"Karen
+        languages","AddAction":"addlimiter(LA99:Karen languages)"},{"Value":"Khoisan
+        languages","AddAction":"addlimiter(LA99:Khoisan languages)"},{"Value":"Central
+        Khmer","AddAction":"addlimiter(LA99:Central Khmer)"},{"Value":"Kinyarwanda","AddAction":"addlimiter(LA99:Kinyarwanda)"},{"Value":"Kirghiz;
+        Kyrgyz","AddAction":"addlimiter(LA99:Kirghiz; Kyrgyz)"},{"Value":"Kpelle","AddAction":"addlimiter(LA99:Kpelle)"},{"Value":"Kurdish","AddAction":"addlimiter(LA99:Kurdish)"},{"Value":"Ladino","AddAction":"addlimiter(LA99:Ladino)"},{"Value":"Lingala","AddAction":"addlimiter(LA99:Lingala)"},{"Value":"Luba-Katanga","AddAction":"addlimiter(LA99:Luba-Katanga)"},{"Value":"Ganda","AddAction":"addlimiter(LA99:Ganda)"},{"Value":"Lunda","AddAction":"addlimiter(LA99:Lunda)"},{"Value":"Madurese","AddAction":"addlimiter(LA99:Madurese)"},{"Value":"Mandingo","AddAction":"addlimiter(LA99:Mandingo)"},{"Value":"Maori","AddAction":"addlimiter(LA99:Maori)"},{"Value":"Marathi","AddAction":"addlimiter(LA99:Marathi)"},{"Value":"Masai","AddAction":"addlimiter(LA99:Masai)"},{"Value":"Mende","AddAction":"addlimiter(LA99:Mende)"},{"Value":"Mon-Khmer
+        languages","AddAction":"addlimiter(LA99:Mon-Khmer languages)"},{"Value":"Malagasy","AddAction":"addlimiter(LA99:Malagasy)"},{"Value":"Mayan
+        languages","AddAction":"addlimiter(LA99:Mayan languages)"},{"Value":"North
+        American Indian languages","AddAction":"addlimiter(LA99:North American Indian
+        languages)"},{"Value":"Ndebele, North; North Ndebele","AddAction":"addlimiter(LA99:Ndebele\\,
+        North; North Ndebele)"},{"Value":"Niger-Kordofanian languages","AddAction":"addlimiter(LA99:Niger-Kordofanian
+        languages)"},{"Value":"Chichewa; Chewa; Nyanja","AddAction":"addlimiter(LA99:Chichewa;
+        Chewa; Nyanja)"},{"Value":"Nyankole","AddAction":"addlimiter(LA99:Nyankole)"},{"Value":"Papuan
+        languages","AddAction":"addlimiter(LA99:Papuan languages)"},{"Value":"Pampanga;
+        Kapampangan","AddAction":"addlimiter(LA99:Pampanga; Kapampangan)"},{"Value":"Panjabi;
+        Punjabi","AddAction":"addlimiter(LA99:Panjabi; Punjabi)"},{"Value":"Papiamento","AddAction":"addlimiter(LA99:Papiamento)"},{"Value":"Provençal,
+        Old (to 1500);Occitan, Old (to 1500)","AddAction":"addlimiter(LA99:Provençal\\,
+        Old \\(to 1500\\);Occitan\\, Old \\(to 1500\\))"},{"Value":"Quechua","AddAction":"addlimiter(LA99:Quechua)"},{"Value":"Rajasthani","AddAction":"addlimiter(LA99:Rajasthani)"},{"Value":"Rarotongan;
+        Cook Islands Maori","AddAction":"addlimiter(LA99:Rarotongan; Cook Islands
+        Maori)"},{"Value":"Rundi","AddAction":"addlimiter(LA99:Rundi)"},{"Value":"South
+        American Indian languages","AddAction":"addlimiter(LA99:South American Indian
+        languages)"},{"Value":"Salishan languages","AddAction":"addlimiter(LA99:Salishan
+        languages)"},{"Value":"Sino-Tibetan languages","AddAction":"addlimiter(LA99:Sino-Tibetan
+        languages)"},{"Value":"Sami languages","AddAction":"addlimiter(LA99:Sami languages)"},{"Value":"Shona","AddAction":"addlimiter(LA99:Shona)"},{"Value":"Somali","AddAction":"addlimiter(LA99:Somali)"},{"Value":"Sotho,
+        Southern","AddAction":"addlimiter(LA99:Sotho\\, Southern)"},{"Value":"Sardinian","AddAction":"addlimiter(LA99:Sardinian)"},{"Value":"Nilo-Saharan
+        languages","AddAction":"addlimiter(LA99:Nilo-Saharan languages)"},{"Value":"Swati","AddAction":"addlimiter(LA99:Swati)"},{"Value":"Susu","AddAction":"addlimiter(LA99:Susu)"},{"Value":"Syriac","AddAction":"addlimiter(LA99:Syriac)"},{"Value":"Tamil","AddAction":"addlimiter(LA99:Tamil)"},{"Value":"Tatar","AddAction":"addlimiter(LA99:Tatar)"},{"Value":"Telugu","AddAction":"addlimiter(LA99:Telugu)"},{"Value":"Tajik","AddAction":"addlimiter(LA99:Tajik)"},{"Value":"Tigrinya","AddAction":"addlimiter(LA99:Tigrinya)"},{"Value":"Tamashek","AddAction":"addlimiter(LA99:Tamashek)"},{"Value":"Tonga
+        (Nyasa)","AddAction":"addlimiter(LA99:Tonga \\(Nyasa\\))"},{"Value":"Tonga
+        (Tonga Islands)","AddAction":"addlimiter(LA99:Tonga \\(Tonga Islands\\))"},{"Value":"Tok
+        Pisin","AddAction":"addlimiter(LA99:Tok Pisin)"},{"Value":"Tswana","AddAction":"addlimiter(LA99:Tswana)"},{"Value":"Turkmen","AddAction":"addlimiter(LA99:Turkmen)"},{"Value":"Tumbuka","AddAction":"addlimiter(LA99:Tumbuka)"},{"Value":"Altaic
+        languages","AddAction":"addlimiter(LA99:Altaic languages)"},{"Value":"Twi","AddAction":"addlimiter(LA99:Twi)"},{"Value":"Tuvinian","AddAction":"addlimiter(LA99:Tuvinian)"},{"Value":"Uighur;
+        Uyghur","AddAction":"addlimiter(LA99:Uighur; Uyghur)"},{"Value":"Umbundu","AddAction":"addlimiter(LA99:Umbundu)"},{"Value":"Wakashan
+        languages","AddAction":"addlimiter(LA99:Wakashan languages)"},{"Value":"Wolof","AddAction":"addlimiter(LA99:Wolof)"},{"Value":"Xhosa","AddAction":"addlimiter(LA99:Xhosa)"},{"Value":"Yao","AddAction":"addlimiter(LA99:Yao)"},{"Value":"Yoruba","AddAction":"addlimiter(LA99:Yoruba)"},{"Value":"Yupik
+        languages","AddAction":"addlimiter(LA99:Yupik languages)"},{"Value":"Zulu","AddAction":"addlimiter(LA99:Zulu)"},{"Value":"Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki","AddAction":"addlimiter(LA99:Zaza;
+        Dimili; Dimli; Kirdki; Kirmanjki; Zazaki)"},{"Value":"Venda","AddAction":"addlimiter(LA99:Venda)"},{"Value":"Aragonese","AddAction":"addlimiter(LA99:Aragonese)"}],"DefaultOn":"n","Order":"11"}],"AvailableSearchModes":[{"Mode":"bool","Label":"Boolean\/Phrase","DefaultOn":"n","AddAction":"setsearchmode(bool)"},{"Mode":"all","Label":"Find
+        all my search terms","DefaultOn":"y","AddAction":"setsearchmode(all)"},{"Mode":"any","Label":"Find
+        any of my search terms","DefaultOn":"n","AddAction":"setsearchmode(any)"},{"Mode":"smart","Label":"SmartText
+        Searching","DefaultOn":"n","AddAction":"setsearchmode(smart)"}],"AvailableRelatedContent":[{"Type":"emp","Label":"Exact
+        Match Publication","DefaultOn":"y","AddAction":"includerelatedcontent(emp)"},{"Type":"rs","Label":"Research
+        Starters","DefaultOn":"n","AddAction":"includerelatedcontent(rs)"}],"AvailableDidYouMeanOptions":[{"Id":"AutoSuggest","Label":"Did
+        You Mean","DefaultOn":"y"},{"Id":"AutoCorrect","Label":"Auto Correct","DefaultOn":"n"}]},"ViewResultSettings":{"ResultsPerPage":"20","ResultListView":"brief","IncludeImageQuickView":{"Id":"ImageQuickViewResults","Label":"Image
+        Quick View Results","DefaultOn":"n"}},"ApplicationSettings":{"SessionTimeout":"900"},"ApiSettings":{"MaxRecordJumpAhead":"250"},"ExportFormatSettings":{"AvailableFormats":[{"Id":"RIS","Label":"RIS
+        Format"}]},"CitationStyleSettings":{"AvailableStyles":[{"Id":"abnt","Label":"ABNT"},{"Id":"ama","Label":"AMA
+        11th Edition"},{"Id":"apa","Label":"APA 7th Edition"},{"Id":"chicago","Label":"Chicago
+        17th Edition"},{"Id":"harvard","Label":"Harvard"},{"Id":"harvardaustralian","Label":"Harvard:
+        Australian"},{"Id":"mla","Label":"MLA 8th Edition"},{"Id":"turabian","Label":"Chicago
+        17th Edition"},{"Id":"vancouver","Label":"Vancouver\/ICMJE"}]}}'
+  recorded_at: Wed, 16 Jun 2021 20:24:02 GMT
+- request:
+    method: post
+    uri: https://eds-api.ebscohost.com/edsapi/rest/Retrieve
+    body:
+      encoding: UTF-8
+      string: '{"DbId":"cat00916a","An":"mit.000292123","HighlightTerms":null,"EbookPreferredFormat":"ebook-pdf"}'
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:01 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - 6a6abaef-a29f-42a2-b80d-afeb96cefe9c
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - '389770294'
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '4459'
+    body:
+      encoding: UTF-8
+      string: '{"Record":{"ResultId":1,"Header":{"DbId":"cat00916a","DbLabel":"MIT
+        Barton Catalog","An":"mit.000292123","RelevancyScore":"910","AccessLevel":"3","PubType":"Periodical","PubTypeId":"serialPeriodical"},"PLink":"https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330","CustomLinks":[{"Url":"https:\/\/library.mit.edu\/item\/000292123","Name":"MIT
+        Barton Catalog Full Record (cat00916a)","Category":"libCatalog","Text":"View
+        catalog record","MouseOverText":"Go to Barton catalog to find this at the
+        MIT Libraries"},{"Url":"https:\/\/mit.on.worldcat.org\/oclc\/01536582","Name":"WorldCat
+        customlink","Category":"ill","Text":"Get it in the library","MouseOverText":"Get
+        items from MIT & non-MIT Libraries"}],"FullText":{"Text":{"Availability":"0"}},"Items":[{"Name":"Title","Label":"Title","Group":"Ti","Data":"Blood."},{"Name":"Language","Label":"Language","Group":"Lang","Data":"English"},{"Name":"PubInfo","Label":"Publication
+        Information","Group":"PubInfo","Data":"[Philadelphia, PA, etc. W.B. Saunders
+        Co., etc.]"},{"Name":"DatePub","Label":"Publication Date","Group":"Date","Data":"1946"},{"Name":"PhysDesc","Label":"Physical
+        Description","Group":"PhysDesc","Data":"v. ill., ports. 26 cm."},{"Name":"TypePub","Label":"Publication
+        Type","Group":"TypPub","Data":"Periodical"},{"Name":"TypeDocument","Label":"Document
+        Type","Group":"TypDoc","Data":"Periodical"},{"Name":"Subject","Label":"Subject
+        Terms","Group":"Su","Data":"&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Blood+--+Periodicals%22&quot;&gt;Blood
+        -- Periodicals&lt;\/searchLink&gt;&lt;br \/&gt;&lt;searchLink fieldCode=&quot;DE&quot;
+        term=&quot;%22Hematology+--+Periodicals%22&quot;&gt;Hematology -- Periodicals&lt;\/searchLink&gt;&lt;br
+        \/&gt;&lt;searchLink fieldCode=&quot;DE&quot; term=&quot;%22Periodicals%22&quot;&gt;Periodicals&lt;\/searchLink&gt;"},{"Name":"TOC","Label":"Content
+        Notes","Group":"TOC","Data":"Library Storage Annex - Off Campus Collection
+        | RB.B655 | v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete"},{"Name":"Note","Label":"Notes","Group":"Note","Data":"&quot;The
+        journal of hematology.&quot;&lt;br \/&gt;Vol. 2 has two special issues, no.
+        1: Morphologic hematology, and no. 2: The Rh factor in the clinic and the
+        laboratory.&lt;br \/&gt;Excerpta medica&lt;br \/&gt;Index medicus 0019-3879&lt;br
+        \/&gt;Biological abstracts 0006-3169&lt;br \/&gt;Chemical abstracts 0009-2258&lt;br
+        \/&gt;Energy research abstracts 0160-3604&lt;br \/&gt;International aerospace
+        abstracts 0020-5842&lt;br \/&gt;Life sciences collection&lt;br \/&gt;RINGDOC&lt;br
+        \/&gt;Also available via the World Wide Web.&lt;br \/&gt;Some summaries also
+        in Interlingua.&lt;br \/&gt;Journal of the American Society of Hematology,
+        1976-"},{"Name":"Author","Label":"Other Authors","Group":"Au","Data":"&lt;searchLink
+        fieldCode=&quot;AR&quot; term=&quot;%22American+Society+of+Hematology%2E%22&quot;&gt;American
+        Society of Hematology.&lt;\/searchLink&gt;"},{"Name":"TitleAlt","Label":"Title
+        Abbreviation","Group":"TiAlt","Data":"Blood"},{"Name":"TitleAlt","Label":"Other
+        Titles","Group":"TiAlt","Data":"Blood"},{"Name":"ISSN","Label":"ISSN","Group":"ISSN","Data":"0006-4971"},{"Name":"NumberControlLC","Label":"LCCN","Group":"ID","Data":"a  50001900"},{"Name":"NumberOther","Label":"OCLC","Group":"ID","Data":"01536582&lt;br
+        \/&gt;02302157"},{"Name":"NoteSerial","Label":"Serial Publication Dates","Group":"Note","Data":"v.
+        1-   Jan. 1946-&lt;br \/&gt;[s_h] Library Storage Annex Off Campus Collection
+        RB.B655 v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete"},{"Name":"PubInfo","Label":"Publication
+        Frequency","Group":"PubInfo","Data":"Semimonthly, 1990-"},{"Name":"AN","Label":"Accession
+        Number","Group":"ID","Data":"mit.000292123"}],"RecordInfo":{"BibRecord":{"BibEntity":{"Languages":[{"Text":"English"}],"Subjects":[{"SubjectFull":"Blood
+        -- Periodicals","Type":"general"},{"SubjectFull":"Hematology -- Periodicals","Type":"general"},{"SubjectFull":"Periodicals","Type":"general"}],"Titles":[{"TitleFull":"Blood.","Type":"main"}]},"BibRelationships":{"IsPartOfRelationships":[{"BibEntity":{"Dates":[{"D":"01","M":"01","Type":"published","Y":"1946"}],"Identifiers":[{"Type":"issn-print","Value":"00064971"}],"Titles":[{"TitleFull":"Blood.","Type":"main"}]}}]}}},"Holdings":[{"HoldingSimple":{"CopyInformationList":[{"Sublocation":"Library
+        Storage Annex - Off Campus Collection","ShelfLocator":"RB.B655"}]}}],"IllustrationInfo":{}}}'
+  recorded_at: Wed, 16 Jun 2021 20:24:02 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/ExportFormat?an=mit.000292123&dbid=cat00916a&format=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:02 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      X-Msg-Correlid:
+      - a380d27e-c557-44ac-b685-694476ee0c67
+      X-Powered-By:
+      - ASP.NET
+      X-Sessionno:
+      - "-296810165"
+      X-Sessiontoken:
+      - FakeSessiontoken
+      Content-Length:
+      - '1623'
+    body:
+      encoding: UTF-8
+      string: '{"Format":"RIS","Label":"RIS Format","Data":"TY  - Book\u000d\u000aID  -
+        mit.000292123\u000d\u000aT1  - Blood.\u000d\u000aY1  - 1946\/\/\/\u000d\u000aM3  -
+        Periodical\u000d\u000aPB  - [Philadelphia, PA, etc. W.B. Saunders Co., etc.]\u000d\u000aAV  -
+        Library Storage Annex - Off Campus Collection RB.B655\u000d\u000aSN  - 0006-4971\u000d\u000aN2  -
+        Library Storage Annex - Off Campus Collection | RB.B655 | v.1 (1946)- v.115:p.1315-2560
+        (2010) Incomplete\u000d\u000aKW  - Blood -- Periodicals\u000d\u000aKW  - Hematology
+        -- Periodicals\u000d\u000aKW  - Periodicals\u000d\u000aN1  - Accession Number:
+        mit.000292123; Corporate Authors: American Society of Hematology.; Other Notes:
+        \"The journal of hematology.\"; Vol. 2 has two special issues, no. 1: Morphologic
+        hematology, and no. 2: The Rh factor in the clinic and the laboratory.; Excerpta
+        medica; Index medicus 0019-3879; Biological abstracts 0006-3169; Chemical
+        abstracts 0009-2258; Energy research abstracts 0160-3604; International aerospace
+        abstracts 0020-5842; Life sciences collection; RINGDOC; Also available via
+        the World Wide Web.; Some summaries also in Interlingua.; Journal of the American
+        Society of Hematology, 1976-; Publication Type: Periodical; Physical Description:
+        v. ill., ports. 26 cm.; Language: English; Title Abbreviation: Blood; Other
+        Titles: Blood; LCCN: a  50001900; OCLC: 01536582; Frequency: Semimonthly,
+        1990-\u000d\u000aUR  - https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330\u000d\u000aDP  -
+        EBSCOhost\u000d\u000aDB  - cat00916a\u000d\u000aER  - \u000d\u000a"}'
+  recorded_at: Wed, 16 Jun 2021 20:24:03 GMT
+- request:
+    method: get
+    uri: https://eds-api.ebscohost.com/edsapi/rest/CitationStyles?an=mit.000292123&dbid=cat00916a&styles=all
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json;charset=UTF-8
+      Accept:
+      - application/json
+      X-Sessiontoken:
+      - FakeSessiontoken
+      X-Authenticationtoken:
+      - FakeAuthenticationtoken
+      User-Agent:
+      - EBSCO EDS GEM v0.0.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 16 Jun 2021 20:24:03 GMT
+      Server:
+      - Microsoft-IIS/10.0
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Msg-Correlid:
+      - b952be0e-6681-45ad-9c0b-bbf1d54e3d8a
+      X-Powered-By:
+      - ASP.NET
+      Content-Length:
+      - '2876'
+    body:
+      encoding: UTF-8
+      string: '{"Citations":[{"Id":"abnt","Label":"ABNT","SectionLabel":"References","Data":"<b>Blood<\/b>.
+        <i>[s. l.]<\/i>: [Philadelphia, PA, etc. W.B. Saunders Co., etc.], 1946. ISBN
+        0006-4971. Disponível em: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330.
+        Acesso em: 16 jun. 2021.","Caption":"Brazilian National Standards"},{"Id":"ama","Label":"AMA
+        11th Edition","SectionLabel":"Reference List","Data":"<i>Blood<\/i>. [Philadelphia,
+        PA, etc. W.B. Saunders Co., etc.]; 1946. Accessed June 16, 2021. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330","Caption":"American
+        Medical Assoc."},{"Id":"apa","Label":"APA 7th Edition","SectionLabel":"References","Data":"<i>Blood<\/i>.
+        (1946). [Philadelphia, PA, etc. W.B. Saunders Co., etc.]. ","Caption":"American
+        Psychological Assoc.","Indent":1},{"Id":"chicago","Label":"Chicago 17th Edition","SectionLabel":"Reference
+        List","Data":"<i>Blood<\/i>. 1946. [Philadelphia, PA, etc. W.B. Saunders Co.,
+        etc.]. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330.","Caption":"Author-Date","Indent":1},{"Id":"harvard","Label":"Harvard","SectionLabel":"References","Data":"<i>Blood<\/i>
+        (1946). [Philadelphia, PA, etc. W.B. Saunders Co., etc.]. Available at: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330
+        (Accessed: 16 June 2021)."},{"Id":"harvardaustralian","Label":"Harvard: Australian","SectionLabel":"References","Data":"<i>Blood<\/i>
+        1946, [Philadelphia, PA, etc. W.B. Saunders Co., etc.], viewed 16 June 2021,
+        <https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330>."},{"Id":"mla","Label":"MLA
+        8th Edition","SectionLabel":"Works Cited","Data":"<i>Blood<\/i>. [Philadelphia,
+        PA, etc. W.B. Saunders Co., etc.], 1946. <i>EBSCOhost<\/i>, search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330.","Caption":"Modern
+        Language Assoc.","Indent":1},{"Id":"turabian","Label":"Chicago 17th Edition","SectionLabel":"Bibliography","Data":"<i>Blood<\/i>.
+        [Philadelphia, PA, etc. W.B. Saunders Co., etc.], 1946. https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330.","Caption":"Notes
+        & Bibliography","Indent":1},{"Id":"vancouver","Label":"Vancouver\/ICMJE","SectionLabel":"References","Data":"Blood
+        [Internet]. [Philadelphia, PA, etc. W.B. Saunders Co., etc.]; 1946 [cited
+        2021 Jun 16]. Available from: https:\/\/search.ebscohost.com\/login.aspx?direct=true&site=eds-live&db=cat00916a&AN=mit.000292123&authtype=sso&custid=s8978330"}]}'
+  recorded_at: Wed, 16 Jun 2021 20:24:03 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=000292123MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="09FFCACEC415B19ED1249B67ED8E0D4D.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=a556d7ef198f1c1dd429ddf70584774a;Path=/;SameSite=None;Secure
+      - urm_se=1623875644018; Path=/; SameSite=None; Secure
+      - urm_st=1623875044018; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - p4CsSuDVRs
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:24:05 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03129cas  2200817   4500</leader>
+                  <controlfield tag="001">990002921230206761</controlfield>
+                  <controlfield tag="005">20210518192645.0</controlfield>
+                  <controlfield tag="008">750812c19469999pausr1p       0   a0eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">a  50001900</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="016">
+                    <subfield code="a">B21220000</subfield>
+                    <subfield code="2">DNLM</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="022">
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="030">
+                    <subfield code="a">BLOOAW</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="032">
+                    <subfield code="a">058200</subfield>
+                    <subfield code="b">USPS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(SFX)954925385125</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">MITb10292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01536582</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)02302157</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(VERA)4468</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="037">
+                    <subfield code="b">W.B. Saunders Co., Curtis Center, Independence Sqr. West, Philadelphia, PA 19106-3399</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">MUL</subfield>
+                    <subfield code="c">MUL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">HUL</subfield>
+                    <subfield code="d">IUL</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">RCS</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">NST</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">MYG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="041">
+                    <subfield code="a">eng</subfield>
+                    <subfield code="b">ina</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="042">
+                    <subfield code="a">nsdp</subfield>
+                    <subfield code="a">lcd</subfield>
+                    <subfield code="a">premarc</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="b">.B56</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="060">
+                    <subfield code="a">W1 BL661</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="082">
+                    <subfield code="a">616</subfield>
+                    <subfield code="2">11</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">RB</subfield>
+                    <subfield code="a">.B655</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">**See URL(s)</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="210">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="222">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="245">
+                    <subfield code="a">Blood.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">[Philadelphia, PA, etc.</subfield>
+                    <subfield code="b">W.B. Saunders Co., etc.]</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">v.</subfield>
+                    <subfield code="b">ill., ports.</subfield>
+                    <subfield code="c">26 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="310">
+                    <subfield code="a">Semimonthly,</subfield>
+                    <subfield code="b">1990-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="321">
+                    <subfield code="a">Monthly</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="362">
+                    <subfield code="a">v. 1-   Jan. 1946-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">"The journal of hematology."</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Vol. 2 has two special issues, no. 1: Morphologic hematology, and no. 2: The Rh factor in the clinic and the laboratory.</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Excerpta medica</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Index medicus</subfield>
+                    <subfield code="x">0019-3879</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Biological abstracts</subfield>
+                    <subfield code="x">0006-3169</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Chemical abstracts</subfield>
+                    <subfield code="x">0009-2258</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy research abstracts</subfield>
+                    <subfield code="x">0160-3604</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">International aerospace abstracts</subfield>
+                    <subfield code="x">0020-5842</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Life sciences collection</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">RINGDOC</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="530">
+                    <subfield code="a">Also available via the World Wide Web.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="546">
+                    <subfield code="a">Some summaries also in Interlingua.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="550">
+                    <subfield code="a">Journal of the American Society of Hematology, 1976-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Blood</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Hematology</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="770">
+                    <subfield code="t">Blood. Special issue</subfield>
+                    <subfield code="w">(OCoLC)6881222</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="776">
+                    <subfield code="t">Blood (Online)</subfield>
+                    <subfield code="x">1528-0020</subfield>
+                    <subfield code="w">(DLC) 00211046</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="793">
+                    <subfield code="a">Blood.</subfield>
+                    <subfield code="g">S06550 960007888</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="710">
+                    <subfield code="a">American Society of Hematology.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">http://catalog.hathitrust.org/api/volumes/oclc/1536582.html</subfield>
+                    <subfield code="3">Hathi Trust</subfield>
+                    <subfield code="x">HathiETAS</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">https://ashpublications.org/blood</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u"><![CDATA[https://sfx.mit.edu/sfx%5Flocal?rft.object%5Fid=954925385125&url%5Fver=Z39.88-2004&ctx%5Fver=Z39.88-2004&ctx%5Fenc=info:ofi/enc:UTF-8&rfr%5Fid=info:sid/sfxit.com:opac%5F856&url%5Fctx%5Ffmt=info:ofi/fmt:kev:mtx:ctx&sfx.ignore%5Fdate%5Fthreshold=1&svc%5Fval%5Ffmt=info:ofi/fmt:kev:mtx:sch%5Fsvc&]]></subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="936">
+                    <subfield code="a">Unknown</subfield>
+                    <subfield code="a">Nov. 1, 1992 (surrogate)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">[Philadelphia, PA, etc. W.B. Saunders Co., etc.]</subfield>
+                    <subfield code="a">1946</subfield>
+                    <subfield code="a">pau</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">616</subfield>
+                    <subfield code="a">W1 BL661</subfield>
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="a">BLOOAW</subfield>
+                    <subfield code="a">01536582</subfield>
+                    <subfield code="a">02302157</subfield>
+                    <subfield code="a">a  50001900</subfield>
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002921230206761</subfield>
+                    <subfield code="8">2231386110006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">Off Campus Collection</subfield>
+                    <subfield code="d">RB.B655</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">348</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">OCC</subfield>
+                    <subfield code="k">Hfcl</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Library Storage Annex</subfield>
+                    <subfield code="t">v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425360006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425320006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425340006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990002921230206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:24:05-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:24:05 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=000292123MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="62C4E0381833C04B94DDA03CD3A5FDCA.app03.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=b8a0c1ec2de31237d87845c9a3ab8c22;Path=/;SameSite=None;Secure
+      - urm_se=1623875645537; Path=/; SameSite=None; Secure
+      - urm_st=1623875045537; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - hZRqbWRqPX
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:24:05 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03129cas  2200817   4500</leader>
+                  <controlfield tag="001">990002921230206761</controlfield>
+                  <controlfield tag="005">20210518192645.0</controlfield>
+                  <controlfield tag="008">750812c19469999pausr1p       0   a0eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">a  50001900</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="016">
+                    <subfield code="a">B21220000</subfield>
+                    <subfield code="2">DNLM</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="022">
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="030">
+                    <subfield code="a">BLOOAW</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="032">
+                    <subfield code="a">058200</subfield>
+                    <subfield code="b">USPS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(SFX)954925385125</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">MITb10292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01536582</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)02302157</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(VERA)4468</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="037">
+                    <subfield code="b">W.B. Saunders Co., Curtis Center, Independence Sqr. West, Philadelphia, PA 19106-3399</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">MUL</subfield>
+                    <subfield code="c">MUL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">HUL</subfield>
+                    <subfield code="d">IUL</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">RCS</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">NST</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">MYG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="041">
+                    <subfield code="a">eng</subfield>
+                    <subfield code="b">ina</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="042">
+                    <subfield code="a">nsdp</subfield>
+                    <subfield code="a">lcd</subfield>
+                    <subfield code="a">premarc</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="b">.B56</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="060">
+                    <subfield code="a">W1 BL661</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="082">
+                    <subfield code="a">616</subfield>
+                    <subfield code="2">11</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">RB</subfield>
+                    <subfield code="a">.B655</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">**See URL(s)</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="210">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="222">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="245">
+                    <subfield code="a">Blood.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">[Philadelphia, PA, etc.</subfield>
+                    <subfield code="b">W.B. Saunders Co., etc.]</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">v.</subfield>
+                    <subfield code="b">ill., ports.</subfield>
+                    <subfield code="c">26 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="310">
+                    <subfield code="a">Semimonthly,</subfield>
+                    <subfield code="b">1990-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="321">
+                    <subfield code="a">Monthly</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="362">
+                    <subfield code="a">v. 1-   Jan. 1946-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">"The journal of hematology."</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Vol. 2 has two special issues, no. 1: Morphologic hematology, and no. 2: The Rh factor in the clinic and the laboratory.</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Excerpta medica</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Index medicus</subfield>
+                    <subfield code="x">0019-3879</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Biological abstracts</subfield>
+                    <subfield code="x">0006-3169</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Chemical abstracts</subfield>
+                    <subfield code="x">0009-2258</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy research abstracts</subfield>
+                    <subfield code="x">0160-3604</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">International aerospace abstracts</subfield>
+                    <subfield code="x">0020-5842</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Life sciences collection</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">RINGDOC</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="530">
+                    <subfield code="a">Also available via the World Wide Web.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="546">
+                    <subfield code="a">Some summaries also in Interlingua.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="550">
+                    <subfield code="a">Journal of the American Society of Hematology, 1976-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Blood</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Hematology</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="770">
+                    <subfield code="t">Blood. Special issue</subfield>
+                    <subfield code="w">(OCoLC)6881222</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="776">
+                    <subfield code="t">Blood (Online)</subfield>
+                    <subfield code="x">1528-0020</subfield>
+                    <subfield code="w">(DLC) 00211046</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="793">
+                    <subfield code="a">Blood.</subfield>
+                    <subfield code="g">S06550 960007888</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="710">
+                    <subfield code="a">American Society of Hematology.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">http://catalog.hathitrust.org/api/volumes/oclc/1536582.html</subfield>
+                    <subfield code="3">Hathi Trust</subfield>
+                    <subfield code="x">HathiETAS</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">https://ashpublications.org/blood</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u"><![CDATA[https://sfx.mit.edu/sfx%5Flocal?rft.object%5Fid=954925385125&url%5Fver=Z39.88-2004&ctx%5Fver=Z39.88-2004&ctx%5Fenc=info:ofi/enc:UTF-8&rfr%5Fid=info:sid/sfxit.com:opac%5F856&url%5Fctx%5Ffmt=info:ofi/fmt:kev:mtx:ctx&sfx.ignore%5Fdate%5Fthreshold=1&svc%5Fval%5Ffmt=info:ofi/fmt:kev:mtx:sch%5Fsvc&]]></subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="936">
+                    <subfield code="a">Unknown</subfield>
+                    <subfield code="a">Nov. 1, 1992 (surrogate)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">[Philadelphia, PA, etc. W.B. Saunders Co., etc.]</subfield>
+                    <subfield code="a">1946</subfield>
+                    <subfield code="a">pau</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">616</subfield>
+                    <subfield code="a">W1 BL661</subfield>
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="a">BLOOAW</subfield>
+                    <subfield code="a">01536582</subfield>
+                    <subfield code="a">02302157</subfield>
+                    <subfield code="a">a  50001900</subfield>
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002921230206761</subfield>
+                    <subfield code="8">2231386110006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">Off Campus Collection</subfield>
+                    <subfield code="d">RB.B655</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">348</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">OCC</subfield>
+                    <subfield code="k">Hfcl</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Library Storage Annex</subfield>
+                    <subfield code="t">v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425360006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425320006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425340006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990002921230206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:24:06-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:24:06 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=000292123MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="538AE12FDC8B809258B9DDF1C679D629.app02.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=c7d4f8ca7386afa6ced80a46b25687b6;Path=/;SameSite=None;Secure
+      - urm_se=1623875646512; Path=/; SameSite=None; Secure
+      - urm_st=1623875046512; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - cOuCaw4S3n
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:24:06 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03129cas  2200817   4500</leader>
+                  <controlfield tag="001">990002921230206761</controlfield>
+                  <controlfield tag="005">20210518192645.0</controlfield>
+                  <controlfield tag="008">750812c19469999pausr1p       0   a0eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">a  50001900</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="016">
+                    <subfield code="a">B21220000</subfield>
+                    <subfield code="2">DNLM</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="022">
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="030">
+                    <subfield code="a">BLOOAW</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="032">
+                    <subfield code="a">058200</subfield>
+                    <subfield code="b">USPS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(SFX)954925385125</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">MITb10292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01536582</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)02302157</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(VERA)4468</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="037">
+                    <subfield code="b">W.B. Saunders Co., Curtis Center, Independence Sqr. West, Philadelphia, PA 19106-3399</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">MUL</subfield>
+                    <subfield code="c">MUL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">HUL</subfield>
+                    <subfield code="d">IUL</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">RCS</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">NST</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">MYG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="041">
+                    <subfield code="a">eng</subfield>
+                    <subfield code="b">ina</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="042">
+                    <subfield code="a">nsdp</subfield>
+                    <subfield code="a">lcd</subfield>
+                    <subfield code="a">premarc</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="b">.B56</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="060">
+                    <subfield code="a">W1 BL661</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="082">
+                    <subfield code="a">616</subfield>
+                    <subfield code="2">11</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">RB</subfield>
+                    <subfield code="a">.B655</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">**See URL(s)</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="210">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="222">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="245">
+                    <subfield code="a">Blood.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">[Philadelphia, PA, etc.</subfield>
+                    <subfield code="b">W.B. Saunders Co., etc.]</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">v.</subfield>
+                    <subfield code="b">ill., ports.</subfield>
+                    <subfield code="c">26 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="310">
+                    <subfield code="a">Semimonthly,</subfield>
+                    <subfield code="b">1990-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="321">
+                    <subfield code="a">Monthly</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="362">
+                    <subfield code="a">v. 1-   Jan. 1946-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">"The journal of hematology."</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Vol. 2 has two special issues, no. 1: Morphologic hematology, and no. 2: The Rh factor in the clinic and the laboratory.</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Excerpta medica</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Index medicus</subfield>
+                    <subfield code="x">0019-3879</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Biological abstracts</subfield>
+                    <subfield code="x">0006-3169</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Chemical abstracts</subfield>
+                    <subfield code="x">0009-2258</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy research abstracts</subfield>
+                    <subfield code="x">0160-3604</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">International aerospace abstracts</subfield>
+                    <subfield code="x">0020-5842</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Life sciences collection</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">RINGDOC</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="530">
+                    <subfield code="a">Also available via the World Wide Web.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="546">
+                    <subfield code="a">Some summaries also in Interlingua.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="550">
+                    <subfield code="a">Journal of the American Society of Hematology, 1976-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Blood</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Hematology</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="770">
+                    <subfield code="t">Blood. Special issue</subfield>
+                    <subfield code="w">(OCoLC)6881222</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="776">
+                    <subfield code="t">Blood (Online)</subfield>
+                    <subfield code="x">1528-0020</subfield>
+                    <subfield code="w">(DLC) 00211046</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="793">
+                    <subfield code="a">Blood.</subfield>
+                    <subfield code="g">S06550 960007888</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="710">
+                    <subfield code="a">American Society of Hematology.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">http://catalog.hathitrust.org/api/volumes/oclc/1536582.html</subfield>
+                    <subfield code="3">Hathi Trust</subfield>
+                    <subfield code="x">HathiETAS</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">https://ashpublications.org/blood</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u"><![CDATA[https://sfx.mit.edu/sfx%5Flocal?rft.object%5Fid=954925385125&url%5Fver=Z39.88-2004&ctx%5Fver=Z39.88-2004&ctx%5Fenc=info:ofi/enc:UTF-8&rfr%5Fid=info:sid/sfxit.com:opac%5F856&url%5Fctx%5Ffmt=info:ofi/fmt:kev:mtx:ctx&sfx.ignore%5Fdate%5Fthreshold=1&svc%5Fval%5Ffmt=info:ofi/fmt:kev:mtx:sch%5Fsvc&]]></subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="936">
+                    <subfield code="a">Unknown</subfield>
+                    <subfield code="a">Nov. 1, 1992 (surrogate)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">[Philadelphia, PA, etc. W.B. Saunders Co., etc.]</subfield>
+                    <subfield code="a">1946</subfield>
+                    <subfield code="a">pau</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">616</subfield>
+                    <subfield code="a">W1 BL661</subfield>
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="a">BLOOAW</subfield>
+                    <subfield code="a">01536582</subfield>
+                    <subfield code="a">02302157</subfield>
+                    <subfield code="a">a  50001900</subfield>
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002921230206761</subfield>
+                    <subfield code="8">2231386110006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">Off Campus Collection</subfield>
+                    <subfield code="d">RB.B655</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">348</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">OCC</subfield>
+                    <subfield code="k">Hfcl</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Library Storage Annex</subfield>
+                    <subfield code="t">v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425360006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425320006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425340006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990002921230206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:24:06-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:24:06 GMT
+- request:
+    method: get
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?operation=searchRetrieve&query=alma.all_for_ui=000292123MIT01&recordSchema=marcxml&version=1.2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - mit.alma.exlibrisgroup.com
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      P3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      Set-Cookie:
+      - JSESSIONID="7E2CB6689514B252EB9CF8F64C20FA06.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - X-Persist=a556d7ef198f1c1dd429ddf70584774a;Path=/;SameSite=None;Secure
+      - urm_se=1623875647334; Path=/; SameSite=None; Secure
+      - urm_st=1623875047334; Path=/; SameSite=None; Secure
+      X-Request-Id:
+      - 8fMmMV4VRk
+      Vary:
+      - accept-encoding
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 16 Jun 2021 20:24:07 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?><searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+          <version>1.2</version>
+          <numberOfRecords>1</numberOfRecords>
+          <records>
+            <record>
+              <recordSchema>marcxml</recordSchema>
+              <recordPacking>xml</recordPacking>
+              <recordData>
+                <record xmlns="http://www.loc.gov/MARC21/slim">
+                  <leader>03129cas  2200817   4500</leader>
+                  <controlfield tag="001">990002921230206761</controlfield>
+                  <controlfield tag="005">20210518192645.0</controlfield>
+                  <controlfield tag="008">750812c19469999pausr1p       0   a0eng d</controlfield>
+                  <datafield ind1=" " ind2=" " tag="010">
+                    <subfield code="a">a  50001900</subfield>
+                  </datafield>
+                  <datafield ind1="7" ind2=" " tag="016">
+                    <subfield code="a">B21220000</subfield>
+                    <subfield code="2">DNLM</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="022">
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="030">
+                    <subfield code="a">BLOOAW</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="032">
+                    <subfield code="a">058200</subfield>
+                    <subfield code="b">USPS</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(MCM)000292123MIT01</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(SFX)954925385125</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">MITb10292123</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)01536582</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(OCoLC)02302157</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="035">
+                    <subfield code="a">(VERA)4468</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="037">
+                    <subfield code="b">W.B. Saunders Co., Curtis Center, Independence Sqr. West, Philadelphia, PA 19106-3399</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">MUL</subfield>
+                    <subfield code="c">MUL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">HUL</subfield>
+                    <subfield code="d">IUL</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">RCS</subfield>
+                    <subfield code="d">SER</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">AIP</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">NST</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">OCL</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">DLC</subfield>
+                    <subfield code="d">NSD</subfield>
+                    <subfield code="d">MYG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="041">
+                    <subfield code="a">eng</subfield>
+                    <subfield code="b">ina</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="042">
+                    <subfield code="a">nsdp</subfield>
+                    <subfield code="a">lcd</subfield>
+                    <subfield code="a">premarc</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="049">
+                    <subfield code="a">MYGG</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="050">
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="b">.B56</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="060">
+                    <subfield code="a">W1 BL661</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="082">
+                    <subfield code="a">616</subfield>
+                    <subfield code="2">11</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">RB</subfield>
+                    <subfield code="a">.B655</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="099">
+                    <subfield code="a">**See URL(s)</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="210">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="222">
+                    <subfield code="a">Blood</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2="0" tag="245">
+                    <subfield code="a">Blood.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="260">
+                    <subfield code="a">[Philadelphia, PA, etc.</subfield>
+                    <subfield code="b">W.B. Saunders Co., etc.]</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">v.</subfield>
+                    <subfield code="b">ill., ports.</subfield>
+                    <subfield code="c">26 cm.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="310">
+                    <subfield code="a">Semimonthly,</subfield>
+                    <subfield code="b">1990-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="321">
+                    <subfield code="a">Monthly</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="336">
+                    <subfield code="a">text</subfield>
+                    <subfield code="b">txt</subfield>
+                    <subfield code="2">rdacontent</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="337">
+                    <subfield code="a">unmediated</subfield>
+                    <subfield code="b">n</subfield>
+                    <subfield code="2">rdamedia</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="338">
+                    <subfield code="a">volume</subfield>
+                    <subfield code="b">nc</subfield>
+                    <subfield code="2">rdacarrier</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="362">
+                    <subfield code="a">v. 1-   Jan. 1946-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">"The journal of hematology."</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="500">
+                    <subfield code="a">Vol. 2 has two special issues, no. 1: Morphologic hematology, and no. 2: The Rh factor in the clinic and the laboratory.</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Excerpta medica</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="510">
+                    <subfield code="a">Index medicus</subfield>
+                    <subfield code="x">0019-3879</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Biological abstracts</subfield>
+                    <subfield code="x">0006-3169</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Chemical abstracts</subfield>
+                    <subfield code="x">0009-2258</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Energy research abstracts</subfield>
+                    <subfield code="x">0160-3604</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">International aerospace abstracts</subfield>
+                    <subfield code="x">0020-5842</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">Life sciences collection</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="510">
+                    <subfield code="a">RINGDOC</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="530">
+                    <subfield code="a">Also available via the World Wide Web.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="546">
+                    <subfield code="a">Some summaries also in Interlingua.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="550">
+                    <subfield code="a">Journal of the American Society of Hematology, 1976-</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Blood</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="0" tag="650">
+                    <subfield code="a">Hematology</subfield>
+                    <subfield code="v">Periodicals.</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2="7" tag="655">
+                    <subfield code="a">Periodicals.</subfield>
+                    <subfield code="2">lcgft</subfield>
+                  </datafield>
+                  <datafield ind1="0" ind2=" " tag="770">
+                    <subfield code="t">Blood. Special issue</subfield>
+                    <subfield code="w">(OCoLC)6881222</subfield>
+                  </datafield>
+                  <datafield ind1="1" ind2=" " tag="776">
+                    <subfield code="t">Blood (Online)</subfield>
+                    <subfield code="x">1528-0020</subfield>
+                    <subfield code="w">(DLC) 00211046</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="793">
+                    <subfield code="a">Blood.</subfield>
+                    <subfield code="g">S06550 960007888</subfield>
+                  </datafield>
+                  <datafield ind1="2" ind2=" " tag="710">
+                    <subfield code="a">American Society of Hematology.</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">http://catalog.hathitrust.org/api/volumes/oclc/1536582.html</subfield>
+                    <subfield code="3">Hathi Trust</subfield>
+                    <subfield code="x">HathiETAS</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u">https://ashpublications.org/blood</subfield>
+                  </datafield>
+                  <datafield ind1="4" ind2="0" tag="856">
+                    <subfield code="u"><![CDATA[https://sfx.mit.edu/sfx%5Flocal?rft.object%5Fid=954925385125&url%5Fver=Z39.88-2004&ctx%5Fver=Z39.88-2004&ctx%5Fenc=info:ofi/enc:UTF-8&rfr%5Fid=info:sid/sfxit.com:opac%5F856&url%5Fctx%5Ffmt=info:ofi/fmt:kev:mtx:ctx&sfx.ignore%5Fdate%5Fthreshold=1&svc%5Fval%5Ffmt=info:ofi/fmt:kev:mtx:sch%5Fsvc&]]></subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">MARCIVEAUT</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="910">
+                    <subfield code="a">lem010501/1</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="936">
+                    <subfield code="a">Unknown</subfield>
+                    <subfield code="a">Nov. 1, 1992 (surrogate)</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="961">
+                    <subfield code="a">[Philadelphia, PA, etc. W.B. Saunders Co., etc.]</subfield>
+                    <subfield code="a">1946</subfield>
+                    <subfield code="a">pau</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="969">
+                    <subfield code="a">616</subfield>
+                    <subfield code="a">W1 BL661</subfield>
+                    <subfield code="a">RB145</subfield>
+                    <subfield code="a">BLOOAW</subfield>
+                    <subfield code="a">01536582</subfield>
+                    <subfield code="a">02302157</subfield>
+                    <subfield code="a">a  50001900</subfield>
+                    <subfield code="a">0006-4971</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="994">
+                    <subfield code="a">02</subfield>
+                    <subfield code="b">MYG</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVA">
+                    <subfield code="0">990002921230206761</subfield>
+                    <subfield code="8">2231386110006761</subfield>
+                    <subfield code="a">01MIT_INST</subfield>
+                    <subfield code="b">LSA</subfield>
+                    <subfield code="c">Off Campus Collection</subfield>
+                    <subfield code="d">RB.B655</subfield>
+                    <subfield code="e">available</subfield>
+                    <subfield code="f">348</subfield>
+                    <subfield code="g">0</subfield>
+                    <subfield code="j">OCC</subfield>
+                    <subfield code="k">Hfcl</subfield>
+                    <subfield code="p">1</subfield>
+                    <subfield code="q">Library Storage Annex</subfield>
+                    <subfield code="t">v.1 (1946)- v.115:p.1315-2560 (2010) Incomplete</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425360006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425320006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                  <datafield ind1=" " ind2=" " tag="AVE">
+                    <subfield code="8">53399425340006761</subfield>
+                    <subfield code="e">Available</subfield>
+                    <subfield code="l">NET</subfield>
+                    <subfield code="t">Hathi Trust</subfield>
+                  </datafield>
+                </record>
+              </recordData>
+              <recordIdentifier>990002921230206761</recordIdentifier>
+              <recordPosition>1</recordPosition>
+            </record>
+          </records>
+          <extraResponseData xmlns:xb="http://www.exlibris.com/repository/search/xmlbeans/">
+            <xb:exact>true</xb:exact>
+            <xb:responseDate>2021-06-16T16:24:07-0400</xb:responseDate>
+          </extraResponseData>
+        </searchRetrieveResponse>
+  recorded_at: Wed, 16 Jun 2021 20:24:07 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
#### Why these changes are being introduced:

Bento full record links are occasionally used as permalinks, but we will
be turning them off once we launch Primo.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2007

#### How this addresses that need:

This adds logic to the record controller, toggled by a feature flag,
that makes an Alma SRU query for Aleph record and determines whether we
can unambiguously link to a corresponding record in Primo (i.e., the SRU
returns one and only one record). If we can, we redirect users to that
Primo record, and if not, we redirect them to a generic splash page that
describes the switch from EDS to Primo.

#### Side effects of this change:

We now toggle feature flags in the test environment using Flipflop's
built-in :test strategy.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
