### PR TITLE
IMP-2236 Add timeouts to TIMDEX search model

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ to construct thumbnail URLs.
 - `ALEPH_HOLD_TYPE`: Switches between links to Aleph `item-hold-request` and
   `item-global`. Defaults to `item-hold-request`.
 - `EDS_TIMEOUT`: value to override the 6 second default for EDS timeout
+- `TIMDEX_TIMEOUT`: value to override the 6 second default for TIMDEX timeout.
 - `EDS_GEM_HOSTS_LIST`: override list of hosts to use for our full record views
   defaults to the (theoretically) load balanced EDS API endpoint. The protocol
   is not included, so use `example.com` instead of `https://example.com`

--- a/app/models/search_eds.rb
+++ b/app/models/search_eds.rb
@@ -80,11 +80,6 @@ class SearchEds
       json_result.dig('ErrorDescription') == 'Session Token Invalid'
   end
 
-  # The timeout value is multiplied by 3 in http.rb so we divide by 3
-  # here to end up with the timeout value we actually want.
-  # This is because we are using a global (per request) timeout. It
-  # is possible to instead separate out each phase of the request for
-  # distinct timeouts if we find that is better.
   # https://github.com/httprb/http/wiki/Timeouts
   def http_timeout
     t = if ENV['EDS_TIMEOUT'].present?

--- a/app/models/search_timdex.rb
+++ b/app/models/search_timdex.rb
@@ -25,11 +25,24 @@ class SearchTimdex
   # @return [Hash] A Hash with search metadata and an Array of {Result}s
   def search(term)
     @query = '{"query":"{search(searchterm: \"' + clean_term(term) + '\", source: \"MIT ArchivesSpace\") {hits records {sourceLink title identifier publicationDate physicalDescription summary contributors { value } } } }"}'
-    results = @timdex_http.post(TIMDEX_URL, :body => @query)
+    results = @timdex_http.timeout(http_timeout)
+                          .post(TIMDEX_URL, :body => @query)
     json_result = JSON.parse(results.to_s)
   end
 
   def clean_term(term)
     term.gsub('"', '\'')
+  end
+
+  private
+
+  # https://github.com/httprb/http/wiki/Timeouts
+  def http_timeout
+    t = if ENV['TIMDEX_TIMEOUT'].present?
+          ENV['TIMDEX_TIMEOUT'].to_f
+        else
+          6
+        end
+    t
   end
 end

--- a/test/models/search_timdex_test.rb
+++ b/test/models/search_timdex_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 class SearchTimdexTest < ActiveSupport::TestCase
+  def setup
+    ENV['TIMDEX_TIMEOUT'] = nil
+  end
+
+  def after
+    ENV['TIMDEX_TIMEOUT'] = nil
+  end
+
   test 'can search timdex' do
     VCR.use_cassette('popcorn timdex',
                      allow_playback_repeats: true) do
@@ -15,5 +23,15 @@ class SearchTimdexTest < ActiveSupport::TestCase
         query = SearchTimdex.new.search('"kevin lynch"')
         refute(query['status'] == 400)
       end
+  end
+
+  test 'can change timeout value' do
+    assert_equal(6, SearchTimdex.new.send(:http_timeout))
+
+    ENV['TIMDEX_TIMEOUT'] = '0.1'
+    assert_equal(0.1, SearchTimdex.new.send(:http_timeout))
+
+    ENV['TIMDEX_TIMEOUT'] = '3'
+    assert_equal(3, SearchTimdex.new.send(:http_timeout))
   end
 end


### PR DESCRIPTION
Why these changes are being introduced:

Currently only EDS searches time out. We want to make sure we catch
timeouts on the other search models as well.

Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2236

How this addresses that need:

Adds a timeout to the TIMDEX search model.

Side effects of this change:

TIMDEX timeouts should now raise an HTTP::TimeoutError, which should
in turn get caught by Sentry. If this becomes troublesome, we can adjust
Sentry's settings to make these alerts less noisy.

#### Developer

- [x] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
