### PR TITLE
IMP-2235 Add timeouts to Primo search model

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ to construct thumbnail URLs.
   `item-global`. Defaults to `item-hold-request`.
 - `EDS_TIMEOUT`: value to override the 6 second default for EDS timeout
 - `TIMDEX_TIMEOUT`: value to override the 6 second default for TIMDEX timeout.
+- `PRIMO_TIMEOUT`: value to override the 6 second default for Primo timeout
 - `EDS_GEM_HOSTS_LIST`: override list of hosts to use for our full record views
   defaults to the (theoretically) load balanced EDS API endpoint. The protocol
   is not included, so use `example.com` instead of `https://example.com`

--- a/app/models/search_primo.rb
+++ b/app/models/search_primo.rb
@@ -21,7 +21,8 @@ class SearchPrimo
   end
 
   def search(term, scope, per_page)
-    result = @primo_http.headers(accept: 'application/json')
+    result = @primo_http.timeout(http_timeout)
+                        .headers(accept: 'application/json')
                         .get(search_url(term, scope, per_page))
 
     raise "Primo Error Detected: #{result.status}" unless result.status == 200
@@ -42,5 +43,15 @@ class SearchPrimo
     [PRIMO_API_URL, '/search?q=any,contains,', clean_term(term), '&vid=', 
       PRIMO_VID, '&tab=', PRIMO_TAB, '&scope=', scope, '&limit=', 
       per_page, '&apikey=', PRIMO_API_KEY].join('')
+  end
+
+  # https://github.com/httprb/http/wiki/Timeouts
+  def http_timeout
+    t = if ENV['PRIMO_TIMEOUT'].present?
+          ENV['PRIMO_TIMEOUT'].to_f
+        else
+          6
+        end
+    t
   end
 end

--- a/test/models/search_primo_test.rb
+++ b/test/models/search_primo_test.rb
@@ -1,6 +1,14 @@
 require 'test_helper'
 
 class SearchPrimoTest < ActiveSupport::TestCase
+  def setup
+    ENV['PRIMO_TIMEOUT'] = nil
+  end
+
+  def after
+    ENV['PRIMO_TIMEOUT'] = nil
+  end
+
   test 'can call Primo API' do
     VCR.use_cassette('popcorn primo books', allow_playback_repeats: true) do
       query = SearchPrimo.new.search('popcorn', ENV['PRIMO_BOOK_SCOPE'], 5)
@@ -46,5 +54,15 @@ class SearchPrimoTest < ActiveSupport::TestCase
         SearchPrimo.new.search('popcorn', ENV['PRIMO_BOOK_SCOPE'], 5)
       end
     end
+  end
+
+  test 'can change timeout value' do
+    assert_equal(6, SearchPrimo.new.send(:http_timeout))
+
+    ENV['PRIMO_TIMEOUT'] = '0.1'
+    assert_equal(0.1, SearchPrimo.new.send(:http_timeout))
+
+    ENV['PRIMO_TIMEOUT'] = '3'
+    assert_equal(3, SearchPrimo.new.send(:http_timeout))
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Currently only EDS searches time out. We want to make sure we catch
timeouts on the other search models as well.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2235

#### How this addresses that need:

Adds a configurable timeout to the Primo search model.

#### Side effects of this change:

Primo timeouts should now raise an HTTP::TimeoutError, which should
in turn get caught by Sentry. If this becomes troublesome, we can adjust
Sentry's settings to make these alerts less noisy.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
