### PR TITLE
IMP-2239 Use search instead of browse for subject links

### DIFF
--- a/app/models/normalize_primo_books.rb
+++ b/app/models/normalize_primo_books.rb
@@ -40,8 +40,9 @@ class NormalizePrimoBooks
   def subject_link(subj)
     # We need to remove hyphens to accommodate Primo's subject browse
     subj = subj.split('--').map { |el| el.strip }.join(' ') if subj.include?('--')
-    [ENV['MIT_PRIMO_URL'], '/discovery/browse?browseQuery=', 
-     subj, '&browseScope=subject.1&vid=', ENV['PRIMO_VID']].join('')
+    [ENV['MIT_PRIMO_URL'], '/discovery/search?query=subject,exact,', 
+     subj, '&tab=', ENV['PRIMO_MAIN_VIEW_TAB'], '&search_scope=all&vid=', 
+     ENV['PRIMO_VID']].join('')
   end
 
   # Since we are displaying RTA based on the best location, this is the 

--- a/test/models/normalize_primo_books_test.rb
+++ b/test/models/normalize_primo_books_test.rb
@@ -91,7 +91,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
   test 'constructs subjects with links' do
     result = popcorn_books['results'].first
     assert_equal ["Geography",
-                  "https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Geography&browseScope=subject.1&vid=FAKE_PRIMO_VID"],
+                  "https://mit.primo.exlibrisgroup.com/discovery/search?query=subject,exact,Geography&tab=all&search_scope=all&vid=FAKE_PRIMO_VID"],
                   result.subjects.first
   end
 
@@ -104,7 +104,7 @@ class NormalizePrimoBooksTest < ActiveSupport::TestCase
   test 'removes hyphens from subject links' do
     result = physical_book['results'].first
     assert_equal ['Linguists -- United States',
-                  'https://mit.primo.exlibrisgroup.com/discovery/browse?browseQuery=Linguists United States&browseScope=subject.1&vid=FAKE_PRIMO_VID'],
+                  'https://mit.primo.exlibrisgroup.com/discovery/search?query=subject,exact,Linguists United States&tab=all&search_scope=all&vid=FAKE_PRIMO_VID'],
                  result.subjects.second
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

The subject browse feature in Primo is ineffectual.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2239

#### How this addresses that need:

Subject links are now Primo searches with the `subject,exact` operators
rather than the subject browse.

#### Side effects of this change:

None, although the search term highlighting in Primo is a bit misleading.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
