### PR TITLE
IMP-2240 Fix 'view more results' URLs when Primo searches are enabled

### DIFF
--- a/app/views/search/_view_all_link.html.erb
+++ b/app/views/search/_view_all_link.html.erb
@@ -3,7 +3,7 @@
   <% if @results['total'] > 0 %>
     <% if Flipflop.enabled?(:local_browse) && @results['local_view_more'] %>
       <% view_more_url = @results['local_view_more'] %>
-    <% elsif Flipflop.enabled?(:primo_search) %>
+    <% elsif Flipflop.enabled?(:primo_search) && (params[:target] == ENV.fetch('PRIMO_BOOK_SCOPE') || params[:target] == ENV.fetch('PRIMO_ARTICLE_SCOPE')) %>
       <% view_more_url = @results['primo_ui_view_more'] %>
     <% else %>
       <% view_more_url = @results['eds_ui_view_more'] %>


### PR DESCRIPTION
#### Why these changes are being introduced:

The 'view more' links for website/Google and ArchivesSpace searches break
when the Primo feature flag is toggled due to a flawed conditional in
the view_all_links partial.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2240

#### How this addresses that need:

This adjusts the aforementioned conditional to check if the Primo feature
flag is enabled AND if the target param is equal to one of the two Primo
targets.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
