### PR TITLE
IMP-2241 Remove borders from cover images

### DIFF
--- a/app/assets/stylesheets/_results.scss
+++ b/app/assets/stylesheets/_results.scss
@@ -31,7 +31,6 @@
     float: right;
     max-width: 150px;
     margin-left: 3%;
-    border: 1px solid #ccc;
   }
 
   .result-title {


### PR DESCRIPTION
#### Why these changes are being introduced:

When it can't find a cover image, Syndetics returns a 1x1 pixel JPEG. We
look for cover images for anything with an ISBN, so the app will often
incorrectly render a 'cover image' (i.e., a 1x1 dot) for books that
don't have one. This results in a weird-looking border surrounding
seemingly nothing.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2241

#### How this addresses that need:

Removes the border from cover images.

#### Side effects of this change:

Cover images no longer have border, so they are very slightly less
prominent.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
