### PR TITLE
IMP-2283 Remove target validation from Search Controller

### DIFF
--- a/test/integration/search_test.rb
+++ b/test/integration/search_test.rb
@@ -98,10 +98,9 @@ class SearchTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'invalid target' do
+  test 'raise 404 on invalid target' do
     get '/search/search_boxed?q=popcorn&target=hackor'
-    follow_redirect!
-    assert_response :success
+    assert_response :not_found
   end
 
   test 'pagination' do


### PR DESCRIPTION
#### Why these changes are being introduced:

The Search Controller contains some confusing logic with regard to
validating the target param. The controller checks the target param
against an array of 'valid' targets; if the target is not
considered valid, the controller returns a redirect to the root URL.

This is problematic for a few reasons:

1. It's not very maintainable. We will have to modify the hardcoded
array of valid targets whenever the value of the param, which is stored
in ENV, changes. We've already encountered this with faked param values
in our test suite.
2. It's not very usable. If a user enters a bad param, redirecting
them to the root URL doesn't tell them anything useful about what
went wrong.
3. It's not very intuitive. We already have a method that checks for
which type of search to run based on the target provided. This seems
like the logical place to check for bad targets, rather than three
separate places as we do now.
4. It's not very necessary. This is what 404 errors are for!

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2283

#### How this addresses that need:

This removes the aforementioned target validation logic from the
Search Controller, and instead returns a 404 error (and renders our
custom 404 template) when it gets a bad target param. Note that this
only occurs from the search_boxed view. The bento view continues to
ignore additional params, target or otherwise.

#### Side effects of this change:

A custom error is used here to avoid a DoubleRenderError.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
