### PR TITLE
ENGX-102 Guard against nil :an param in record controller

### DIFF
--- a/app/controllers/record_controller.rb
+++ b/app/controllers/record_controller.rb
@@ -9,6 +9,7 @@ class RecordController < ApplicationController
   private
 
   def alma_sru
+    return unless params[:an]
     return unless params[:an].start_with?('mit')
     alma_system_id = params[:an].split('.').last.concat('MIT01')
     url = ENV.fetch('ALMA_SRU') + alma_system_id


### PR DESCRIPTION
#### Why these changes are being introduced:

We currently only guard against :an params that don't start with 'mit',
which means the application throws a NoMethodError if that param is nil.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-102

#### How this addresses that need:

This adds a guard clause to RecordController#alma_sru to check if
params[:an] is present.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
