### PR TITLE
IMP-2358 Bugfix for 'Details and requests' links

### DIFF
--- a/app/models/normalize_primo_common.rb
+++ b/app/models/normalize_primo_common.rb
@@ -69,11 +69,30 @@ class NormalizePrimoCommon
     end
   end
 
+  # We've altered this method slightly to address bugs introduced in the Primo VE November 2021 release. The search_scope
+  # param is now required for CDI fulldisplay links, and the context param is now required for local (catalog)
+  # fulldisplay links.
+  #
+  # In order to avoid more surprises, we're adding all of the params included in the fulldisplay exmaple links provided
+  # here, even though not all of them are actually required at present:
+  # https://developers.exlibrisgroup.com/primo/apis/deep-links-new-ui/
+  #
+  # We should keep an eye on this over subsequent Primo reeleases and revert it to something more minimalist/sensible
+  # when Ex Libris fixes this issue.
   def link
     return unless @record['pnx']['control']['recordid']
+    return unless @record['context']
     record_id = @record['pnx']['control']['recordid'].join('')
-    [ENV['MIT_PRIMO_URL'], '/discovery/fulldisplay?docid=', record_id, 
-     '&vid=', ENV['PRIMO_VID']].join('')
+    base = [ENV.fetch('MIT_PRIMO_URL'), '/discovery/fulldisplay?'].join('')
+    query = {
+      docid: record_id,
+      vid: ENV.fetch('PRIMO_VID'),
+      context: @record['context'],
+      search_scope: 'all',
+      lang: 'en',
+      tab: ENV.fetch('PRIMO_MAIN_VIEW_TAB')
+    }.to_query
+    [base, query].join('')
   end
 
   def type


### PR DESCRIPTION
 #### Why these changes are being introduced:

The November release of Primo VE unexpectedly broke our 'Details
and requests' links, which are constructed as Primo fulldisplay
'deep links'. In the latest release, Ex Libris made two params
(`context` and `search_scope`) required for fulldisplay links.

This was most likely accidental as the change is not mentioned in
the release notes, and the params are not required consistently:
i.e., `context` is required only for local records, and
`search_scope` is required only for CDI records.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/IMP-2358

#### How this addresses that need:

This adds to our 'Details and requests' links all of the params
included in the Ex Libris docs' fulldisplay example link:
https://developers.exlibrisgroup.com/primo/apis/deep-links-new-ui/

In reality, not all of these params are required, but hopefully
including them now will prevent more surprises later.

#### Side effects of this change:

I refactored the link method to use `to_query`, which is a bit more
readable to me..

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
