### PR TITLE
ES-572 Primo openurl bugfix

### DIFF
--- a/app/models/normalize_primo_articles.rb
+++ b/app/models/normalize_primo_articles.rb
@@ -37,10 +37,6 @@ class NormalizePrimoArticles
     "#{@record['pnx']['addata']['date'].join('')}, pp. #{@record['pnx']['addata']['pages'].join('')}"
   end
 
-  # Here we are converting the Alma link resolver URL provided by the Primo 
-  # Search API to redirect to the Primo UI. This is done for UX purposes, 
-  # as the regular Alma link resolver URLs redirect to a plaintext 
-  # disambiguation page.
   def openurl
     return unless @record['delivery']['almaOpenurl']
 
@@ -50,9 +46,7 @@ class NormalizePrimoArticles
     openurl_server = ENV['ALMA_OPENURL'][8,4]
     record_openurl_server = @record['delivery']['almaOpenurl'][8,4]
     if openurl_server == record_openurl_server
-      primo_openurl = [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=',
-                       ENV['EXL_INST_ID'], '&vid=', ENV['PRIMO_VID'], '&'].join('')
-      @record['delivery']['almaOpenurl'].gsub(ENV['ALMA_OPENURL'], primo_openurl)
+      construct_primo_openurl
     else
       Rails.logger.warn 'Alma openurl server mismatch. Expected ' +
                          openurl_server + ', but received ' + 
@@ -60,5 +54,22 @@ class NormalizePrimoArticles
                          @record['pnx']['control']['recordid'].join('') + ')'
       @record['delivery']['almaOpenurl']
     end
+  end
+
+  # Here we are converting the Alma link resolver URL provided by the Primo 
+  # Search API to redirect to the Primo UI. This is done for UX purposes, 
+  # as the regular Alma link resolver URLs redirect to a plaintext 
+  # disambiguation page.
+  def construct_primo_openurl
+    return unless @record['delivery']['almaOpenurl']
+
+    primo_openurl_base = [ENV['MIT_PRIMO_URL'], '/discovery/openurl?institution=', ENV['EXL_INST_ID'], '&vid=',
+                          ENV['PRIMO_VID'], '&'].join('')
+    primo_openurl = @record['delivery']['almaOpenurl'].gsub(ENV['ALMA_OPENURL'], primo_openurl_base)
+
+    # The ctx params appear to break Primo openurls, so we need to remove them.
+    params = Rack::Utils.parse_nested_query(primo_openurl)
+    filtered = params.delete_if { |key, value| key.starts_with?('ctx') }
+    URI.decode(filtered.to_param)
   end
 end

--- a/test/models/normalize_primo_articles_test.rb
+++ b/test/models/normalize_primo_articles_test.rb
@@ -99,7 +99,7 @@ class NormalizePrimoArticlesTest < ActiveSupport::TestCase
   # call and will change with each API call.
   test 'constructs full-text links as expected' do
     regular_result = popcorn_articles['results'].first
-    assert_equal 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&vid=FAKE_PRIMO_VID&ctx_enc=info:ofi/enc:UTF-8&ctx_id=10_1&ctx_tim=2021-05-19 10:51:07&ctx_ver=Z39.88-2004&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&rft.genre=article&rft.atitle=Popcorn&rft.jtitle=Physics+world&rft.date=2016-11&rft.volume=29&rft.issue=11&rft.spage=42&rft.epage=42&rft.pages=42-42&rft.issn=0953-8585&rft.eissn=2058-7058&rft_id=info:doi/10.1088%2F2058-7058%2F29%2F11%2F46&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&svc_dat=viewit',
+    assert_equal 'https://mit.primo.exlibrisgroup.com/discovery/openurl?institution=01MIT_INST&rfr_id=info:sid/primo.exlibrisgroup.com-crossref&rft.atitle=Popcorn&rft.date=2016-11&rft.eissn=2058-7058&rft.epage=42&rft.genre=article&rft.issn=0953-8585&rft.issue=11&rft.jtitle=Physics+world&rft.pages=42-42&rft.spage=42&rft.volume=29&rft_dat=<crossref>10_1088_2058_7058_29_11_46</crossref>&rft_id=info:doi/10.1088/2058-7058/29/11/46&rft_val_fmt=info:ofi/fmt:kev:mtx:journal&svc_dat=viewit&url_ctx_fmt=info:ofi/fmt:kev:mtx:ctx&url_ver=Z39.88-2004&vid=FAKE_PRIMO_VID',
                  regular_result.openurl
 
     irregular_result = missing_fields_articles['results'].last


### PR DESCRIPTION
Why these changes are being introduced:

Some Primo openurls do not resolve correctly. The Alma/Primo team
suspects that the cause is the ctx params in the URL.

Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ES-572

How this addresses that need:

This removes the ctx params from the Primo openurls.

Side effects of this change:

I have some reservations about how much we're manipulating URL
strings here. If this fixes the problem, we should have a
conversation about this in code review.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
