### PR TITLE
Adds .codeclimate.yml to update rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-1-23-0


### PR DESCRIPTION
#### Why are these changes being introduced:

* CodeClimate uses an older version of Rubocop internally by default,
  but this can be updated using a .codeclimate.yml file.

#### Relevant ticket(s):

* n/a

#### How does this address that need:

* This adds the needed configuration file, using the same version that
  we are using for the Timdex* projects.

#### Document any side effects to this change:

* This version will need to be updated down the road, ideally in sync
  with our other repos and as new versions of Rubocop become available.
  There is no mechanism to detect how out of date this is, however...
* As with our other updates to this channel, any changes to the codebase itself are out of scope for this PR.

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO (not this codebase, just a configuration to an associated platform)
