### PR TITLE
Update hints view to render libguides URLs

### DIFF
--- a/app/views/hint/hint.html.erb
+++ b/app/views/hint/hint.html.erb
@@ -4,7 +4,7 @@
       <p class="type"><%= display_type %></p>
       <h3 class="title"><%= hint_link(@hint.title) %></h3>
 
-      <% if @hint.url.include?('libraries.mit.edu/get') %>
+      <% if @hint.url.include?('libguides.mit.edu') %>
         <p class="desc">
           <%= hint_link(@hint.url) %>
         </p>


### PR DESCRIPTION
Why these changes are being introduced:

We are moving from GetURLs to LibGuides for our friendly URLs.

Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1371

How this addresses that need:

This updates the hint partial to render URLs that include
'libguides.mit.edu'.

Side effects of this change:

GetURLs will no longer render in the hints panel.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
