### PR TITLE
Confirm that new proof-of-concept theme works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'ipaddr_range_set'
 gem 'jquery-rails'
 gem 'jquery-validation-rails'
 gem 'lograge'
+gem 'mitlibraries-theme', '1.0.0', path: "~/git/blorgh/mitlibraries-theme"
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false
@@ -24,7 +25,6 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'skylight'
 gem 'stringex'
-gem 'tesseract', tag: '0.5.0', git: 'https://github.com/matt-bernhardt/tesseract.git'
 gem 'uglifier'
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'ipaddr_range_set'
 gem 'jquery-rails'
 gem 'jquery-validation-rails'
 gem 'lograge'
-gem 'mitlibraries-theme'
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false
@@ -25,6 +24,7 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'skylight'
 gem 'stringex'
+gem 'tesseract', tag: '0.5.0', git: 'https://github.com/matt-bernhardt/tesseract.git'
 gem 'uglifier'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,17 @@
 GIT
-  remote: https://github.com/matt-bernhardt/tesseract.git
-  revision: 3554f275290f565b98ad1306db8c24fabbc04f30
-  tag: 0.5.0
-  specs:
-    tesseract (0.5.0)
-      debug (~> 1)
-      rails (>= 6, < 8)
-      sassc-rails (~> 2)
-
-GIT
   remote: https://github.com/rails/actionpack-action_caching.git
   revision: 05c821ec84eb79760e95b0a57ae72919eefb0257
   branch: master
   specs:
     actionpack-action_caching (1.2.2)
       actionpack (>= 4.0.0)
+
+PATH
+  remote: ../blorgh/mitlibraries-theme
+  specs:
+    mitlibraries-theme (1.0.0)
+      rails (>= 6, < 8)
+      sassc-rails (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -103,9 +100,6 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.2)
-    debug (1.6.2)
-      irb (>= 1.3.6)
-      reline (>= 0.3.1)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     docile (1.4.0)
@@ -171,10 +165,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
     ipaddr_range_set (1.0.0)
-    irb (1.4.2)
-      reline (>= 0.3.0)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -271,8 +262,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.6.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -391,6 +380,7 @@ DEPENDENCIES
   listen
   lograge
   minitest-rails
+  mitlibraries-theme (= 1.0.0)!
   mocha
   net-imap
   net-pop
@@ -411,7 +401,6 @@ DEPENDENCIES
   skylight
   sqlite3
   stringex
-  tesseract!
   uglifier
   vcr
   web-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/matt-bernhardt/tesseract.git
+  revision: 3554f275290f565b98ad1306db8c24fabbc04f30
+  tag: 0.5.0
+  specs:
+    tesseract (0.5.0)
+      debug (~> 1)
+      rails (>= 6, < 8)
+      sassc-rails (~> 2)
+
+GIT
   remote: https://github.com/rails/actionpack-action_caching.git
   revision: 05c821ec84eb79760e95b0a57ae72919eefb0257
   branch: master
@@ -93,6 +103,9 @@ GEM
       rexml
     crass (1.0.6)
     dalli (3.2.2)
+    debug (1.6.2)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     debug_inspector (1.1.0)
     declarative (0.0.20)
     docile (1.4.0)
@@ -158,7 +171,10 @@ GEM
     httpclient (2.8.3)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
     ipaddr_range_set (1.0.0)
+    irb (1.4.2)
+      reline (>= 0.3.0)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -186,14 +202,10 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
     minitest (5.16.3)
     minitest-rails (6.1.0)
       minitest (~> 5.10)
       railties (~> 6.1.0)
-    mitlibraries-theme (0.8.0)
-      rails (>= 5, < 8)
-      sassc (~> 2)
     mocha (1.16.0)
     msgpack (1.6.0)
     multi_json (1.15.0)
@@ -206,8 +218,7 @@ GEM
     net-smtp (0.3.2)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.9)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     os (1.1.4)
     parallel (1.22.1)
@@ -260,6 +271,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.6.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -322,8 +335,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.3)
-      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.5.3-x86_64-darwin)
     statsd-ruby (1.5.0)
     stringex (2.8.5)
     terminal-table (3.0.2)
@@ -358,7 +370,7 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   actionpack-action_caching!
@@ -379,7 +391,6 @@ DEPENDENCIES
   listen
   lograge
   minitest-rails
-  mitlibraries-theme
   mocha
   net-imap
   net-pop
@@ -400,6 +411,7 @@ DEPENDENCIES
   skylight
   sqlite3
   stringex
+  tesseract!
   uglifier
   vcr
   web-console

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  helper Tesseract::Engine.helpers
+  helper Mitlibraries::Theme::Engine.helpers
 
   def flipflop_access_control
     return if session[:flipflop_user]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  helper Tesseract::Engine.helpers
+
   def flipflop_access_control
     return if session[:flipflop_user]
 


### PR DESCRIPTION
** Why are these changes being introduced:

* As part of ENGX-175, I've set up a separate theme gem starting from a
  blank slate, named Tesseract. I need to confirm that this can function
  as a drop-in replacement for our current theme gem.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/engx-175

** How does this address that need:

* This removes the current theme gem from the application, replacing it
  with loading the Tesseract gem directly from Github (avoiding the need
  to publish through RubyGems for this proof of concept).
* Because the new gem implements helpers differently, this also adds a
  line to the application controller to load the new gem's helpers.

** Document any side effects to this change:

* See above note about there being one additional implementation step
  for the new gem, a line that needs to be added to the application
  controller.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
