### PR TITLE
Better error handling for dates

### DIFF
--- a/app/models/normalize_timdex.rb
+++ b/app/models/normalize_timdex.rb
@@ -38,17 +38,18 @@ class NormalizeTimdex
   end
 
   def extract_dates(dates)
-    # It is unlikely for a record to have more than one creation date, but just in case...
-    relevant_dates = dates.select { |date| date['kind'] == 'creation' }
+    # It is unlikely for a record to have more than one creation or publication date, but just in case...
+    relevant_dates = dates.select { |date| date['kind'] == 'creation' || date['kind'] == 'publication' }
 
-    # If the record *does* have more than one creation date, it's probably not worth determining which to display.
-    return if relevant_dates.count > 1
+    # If the record has no creation or publication date, stop here.
+    return if relevant_dates.empty?
 
+    # If the record *does* have more than one creation/pub date, just take the first one.
     relevant_date = relevant_dates.first
 
-    # We are only concerned with creation dates that are ranges, since we harvest ASpace metadata at the collection
+    # We are only concerned with creation/pub dates that are ranges, since we harvest ASpace metadata at the collection
     # level.
-    return unless relevant_date['kind'] == 'creation' && relevant_date['range'].present?
+    return unless relevant_date['range'].present?
 
     "#{relevant_date['range']['gte']}-#{relevant_date['range']['lte']}"
   end

--- a/test/models/normalize_timdex_test.rb
+++ b/test/models/normalize_timdex_test.rb
@@ -36,4 +36,46 @@ class NormalizeTimdexTest < ActiveSupport::TestCase
     assert_match 'The Paul Earls archives contains a large number of music manuscript',
                  aspace_records['results'][0].blurb
   end
+
+  # Some ASpace records have a publication date range rather than a creation date range. The following regression test
+  # ensures that the NormalizeTimdex model does not error for such records.
+  test 'records with no creation date do not error' do
+    VCR.use_cassette('aspace publication date',
+                     allow_playback_repeats: true) do
+      raw_query = SearchTimdex.new.search('SOVEREIGN INTIMACY: PRIVATE MEDIA AND THE TRACES OF COLONIAL VIOLENCE')
+      assert_not raw_query['data']['search']['records'].first['dates'].first['kind'] == 'creation'
+      assert_nothing_raised do
+        NormalizeTimdex.new.to_result(raw_query, 'SOVEREIGN INTIMACY: PRIVATE MEDIA AND THE TRACES OF COLONIAL VIOLENCE')
+      end
+    end
+  end
+
+  # This is another regression test. Now that we know that records with no creation date will not error, we also want
+  # to ensure that records with a publication date will be normalized accordingly.
+  test 'publication dates are normalized' do
+    VCR.use_cassette('aspace publication date',
+                     allow_playback_repeats: true) do
+      raw_query = SearchTimdex.new.search('SOVEREIGN INTIMACY: PRIVATE MEDIA AND THE TRACES OF COLONIAL VIOLENCE')
+      normalized = NormalizeTimdex.new.to_result(raw_query, 'SOVEREIGN INTIMACY: PRIVATE MEDIA AND THE TRACES OF COLONIAL VIOLENCE')
+
+      assert_equal 'publication', raw_query['data']['search']['records'].first['dates'].first['kind']
+      assert_equal '1940', raw_query['data']['search']['records'].first['dates'].first['range']['gte']
+      assert_equal '1983', raw_query['data']['search']['records'].first['dates'].first['range']['lte']
+      assert_equal '1940-1983', normalized['results'][0].year
+    end
+  end
+
+  test 'normalizer selects the first of two relevant dates' do
+    VCR.use_cassette('aspace multiple creation dates') do
+      raw_query = SearchTimdex.new.search('Timurid Architecture Research Archive')
+      assert raw_query['data']['search']['records'].first['dates'].count > 1
+      assert_not_equal raw_query['data']['search']['records'].first['dates'].first,
+                       raw_query['data']['search']['records'].first['dates'].second
+
+      start_date = raw_query['data']['search']['records'].first['dates'].first['range']['gte']
+      end_date = raw_query['data']['search']['records'].first['dates'].first['range']['lte']
+      normalized = NormalizeTimdex.new.to_result(raw_query, 'Timurid Architecture Research Archive')
+      assert_equal "#{start_date}-#{end_date}", normalized['results'][0].year
+    end
+  end
 end

--- a/test/vcr_cassettes/aspace_multiple_creation_dates.yml
+++ b/test/vcr_cassettes/aspace_multiple_creation_dates.yml
@@ -1,0 +1,252 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://timdex.mit.edu/graphql
+    body:
+      encoding: UTF-8
+      string: '{ "query": "{ search(searchterm: \"Timurid Architecture Research Archive\",
+        sourceFilter: \"MIT ArchivesSpace\") { hits records { sourceLink title identifiers
+        { kind value } dates { kind value range { gte lte } } physicalDescription
+        summary contributors { value } } } }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Thu, 16 Mar 2023 15:16:39 GMT
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      - Origin
+      Etag:
+      - W/"c90476b23343da3650eb2eb488e616d7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5389c817-1e7e-47e5-a97a-3fd58024cf80
+      X-Runtime:
+      - '0.108109'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '17402'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"search":{"hits":630,"records":[{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1227","title":"Timurid
+        Architecture Research Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0005"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1966","lte":"1981"}},{"kind":"creation","value":null,"range":{"gte":"1966","lte":"1967"}}],"physicalDescription":"18
+        box(es) Document boxes: three 5\" letter size; nine 2.5\" letter size; one
+        5\" legal size; one 5\" Tall legal size; and, two single drawer card file
+        boxes; one small CD size box; and one triangular tube for architectural drawings
+        (which measure 63 x 14 x 12 centimetres); 9 Linear Feet; 2 folder(s) 2 extra
+        large files for architectural drawings/maps","summary":["Materials in this
+        collection are the creations of Lisa Golombek and Donald Wilber.  The collection
+        consists of extensive field notes, photographs, architectural drawings, and
+        slides.  Sites featured in the materials are found in a number of Middle Eastern
+        and Central Asian countries, both within modern cities and in rural areas.  Sites
+        featured include a wide array of building types such as mosques, madrassas,
+        khanaqahs, and palaces.  Some sites are associated with Timurid rulers, while
+        others are associated with religious figures.  The majority of the materials
+        in the collection were created during field expeditions in 1966.  Images and
+        notes contributed to Golombek and Wilber''s two-volume work on the Timurid
+        architecture of Iran and Central Asia."],"contributors":[{"value":"Wilber,
+        Donald Newton"},{"value":"Golombek, Lisa"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1226","title":"Isfahan
+        Urban History Project","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0004"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"11.5
+        Linear Feet; 11 box(es) 5 record cartons (boxes 1-5); \n1 legal-size documents
+        box, 2.5\" width (box 6); \n1 portfolio box (box 7); \n2 triangular tubes
+        (tubes 1-2); \n2 extra-large flat files (xl ff A \u0026 B)","summary":["The
+        contents of the Isfahan Urban History Project Archive are the culminating
+        efforts of Lisa Golombek, Renata Holod, Claus Breede, and Juliette Yaghubi-Nassab,
+        which document the research team''s fieldwork and subsequent projects related
+        to the study of Isfahan''s pre-modern urban development. Comprising the fieldwork
+        are notebooks, sketchbooks, research indexes and files, maps, drawings, photography
+        and color slides depicting the city''s street patterns, service nodes, monuments
+        and domestic architecture. Also included are unpublished writings, articles,
+        and speeches authored by Golombek and Holod, as well as the foundational work
+        for a computer program designed to organize and analyze project findings.
+        Several districts of Isfahan are represented in the studies, including Jubareh,
+        Dar-Dasht, and Kara''an. Specific locations of interest include the Ali Quli
+        Agha complex, Masjid-i Kirmani, and Old Maydan. The majority of the Archive''s
+        contents were created during two seasons of field work in 1974 and 1976."],"contributors":[{"value":"Golombek,
+        Lisa"},{"value":"Yaghubi-Nassab, Juliette"},{"value":"Holod, Renata"},{"value":"Breede,
+        Claus, 1944-"},{"value":"Royal Ontario Museum"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1224","title":"Hisham
+        Munir Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2014.0001"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":".41
+        Linear Feet (two 2.5 inch document boxes)","summary":null,"contributors":[{"value":"Munir,
+        Hisham"},{"value":"Munir, Hisham"},{"value":"Hisham Munir \u0026 Associates"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1225","title":"Yasser
+        Tabbaa Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0002"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"5
+        Linear Feet Five table top, 5-drawer, metal slide cabinets. 5-Drawer, Metal,
+        Table-Top, Slide Cabinet, extent measured by width. Depth 12.25, height 13,
+        width 15.5 inches.; 25,000 item(s) estimated quantity Color, or black and
+        white. 35mm slides; 2 item(s) 2 journals; 50 folder(s) estimated quantity,
+        will revise Folders of photographs, notes, textual documents. Folders are
+        circa 9 x 12 inches.; 10 Linear Feet","summary":null,"contributors":[{"value":"Yasser,
+        Tabbaa"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1247","title":"Aga
+        Khan Visual Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.1980.001"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"209
+        box(es) Document boxes containing slides in sleeve pages with related documentation
+        209 Boxes, various sizes. Some have been combined to save space, but retain
+        their numbers both on the joint box. Document boxes vary in size from 14 inch
+        legal or 12 inch letter (depth), and 2.5 or 5 inches (width), and are 10.5
+        inches in height","summary":null,"contributors":null},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1260","title":"Bing
+        and Harrington Balkan Archives","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2013.0001"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"10  box(es)
+        Boxes I - VIII (1 - 8) are photographs enclosed in glass plates.\nBox IX (9)
+        is a triangular tube of drawings by Jonathan Harrington\nBox X (10) encloses
+        the reference volume from Sarajevo AKDC.2013.0001.0001rf (rf = reference material)\n10
+        boxes of files of slides arranged by the donors","summary":null,"contributors":[{"value":"Bing,
+        Judith"},{"value":"Bing, Judith"},{"value":"Bing, Judith"},{"value":"Harrington,
+        J. Brooke"},{"value":"Harrington, J. Brooke"},{"value":"Harrington, J. Brooke"},{"value":"Harrington,
+        J. Brooke"},{"value":"Bing, Judith"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1258","title":"Besim
+        Hakim Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2017.0005"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1930","lte":"2015"}}],"physicalDescription":"26
+        box(es) 26 containers housing rolls of drawings and maps, including 25 long
+        boxes, and one cylinder. unknown; 7 volume(s) ca. 7 printed texts in 1 legal
+        size 5\" document box","summary":null,"contributors":[{"value":"Hakim, Besim
+        S."},{"value":"Hakim, Besim S."}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1323","title":"Melanie
+        Michailidis Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2013.0003"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1995","lte":"2013"}}],"physicalDescription":"5
+        box(es)","summary":["The Melanie Michailidis Archive covers a range of Michailidis''s
+        scholarly writing and curatorial work concerning Islamic art and architecture,
+        with particular strengths in her areas of expertise including Iranian and
+        Central Asian mausolea to transcultural ceramics, metalwork, and textiles.
+        This archive encompasses Melanie''s essays, articles, dissertation, thesis,
+        and other materials, which Melanie gathered during her Fulbright fieldwork
+        in Iran and Central Asia in 2003 and 2005, and in Russia and India in 2012.
+        It further covers didactics, press and publications for her installations
+        and exhibitions at St. Louis Art Museum and Harvard Art Museums, respectively,
+        with additional notes from collections research in Spain."],"contributors":[{"value":"Michailidis,
+        Melanie"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/721","title":"Albert
+        G. Ingalls pseudoscience collection","identifiers":[{"kind":"Collection Identifier","value":"MC.0187"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1900","lte":"1990"}}],"physicalDescription":"8.91
+        Cubic Feet (15 legal manuscript boxes, 6 manuscript boxes)","summary":null,"contributors":[{"value":"Ingalls,
+        Albert G. (Albert Graham)"},{"value":"Ingalls, Albert G. (Albert Graham)"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1244","title":"Ali
+        Tayar Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2017.0003"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1983","lte":"2016"}},{"kind":"creation","value":null,"range":{"gte":"1994","lte":"2014"}}],"physicalDescription":"44
+        Linear Feet Currently, there are a single 5-drawer flat file cabinet; 28 tubes
+        of rolled oversize material and drawings; 15 flat boxes; 2 record cartons;
+        71 document boxes.  The majority will stay in this configuration, some of
+        the large drawings may eventually be rehoused following removal from the Center
+        in March of 2020, to be housed with other archival collections in the Department
+        of Distinctive Collections'' storage spaces.; Most of the contents of this
+        archive (drawings, printed matter, photographs, mixed materials, publications,
+        photocopies, and original documents) arrived in very good condition. However,
+        there were many documents throughout the project files which were on fax paper
+        and fading. Most of these have been reformatted on photocopy paper for preservation
+        purposes.","summary":["The Ali Tayar Archive covers many of the works of the
+        late architect and designer Ali Tayar. Present in the collection are records
+        concerning works of architecture, interior design, and furniture/product design.
+        Also included are works from design competitions, special projects, publicity
+        materials, ephemera, and photographic materials."],"contributors":[{"value":"Tayar,
+        Ali"},{"value":"Parallel Design Partnership"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1228","title":"Adrienne
+        Minassian Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0009"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1920","lte":"1960"}}],"physicalDescription":"3
+        box(es) 16 folders Toxic negatives kept a separate box, photographs taken
+        to preserve what was possible of the content of these.; 2 Linear Feet contained
+        in 3 archival document boxes, one of which is stored horizontally.","summary":null,"contributors":[{"value":"Jenkins,
+        Marilyn (Marilyn Jenkins-Madina)"},{"value":"Minassian, Adrienne"},{"value":"Minassian,
+        Kirkor"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1317","title":"Unlocking
+        History Research Group archives","identifiers":[{"kind":"Collection Identifier","value":"MC.0760"}],"dates":[{"kind":"creation","value":null,"range":null},{"kind":"creation","value":null,"range":{"gte":"2000","lte":"2021"}}],"physicalDescription":"55
+        box(es)","summary":["The Unlocking History Research Group archives document
+        the development of the field of letterlocking,including related document security
+        techniques used on archival bindings and other manuscripts. Materials include
+        documentation of the process and evolution of this novel field of study dating
+        from 2000 to 2020. Materials in the collection include archival research materials,
+        original historical manuscripts from 1490s to 2021, notes, drawings, models,
+        teaching materials, and digital assets."],"contributors":[{"value":"Unlocking
+        History Research Group"},{"value":"Dambrogio, Jana"},{"value":"Smith, Daniel
+        Starza"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1314","title":"Collection
+        on Community Activism at MIT","identifiers":[{"kind":"Collection Identifier","value":"MC.0758"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"2016","lte":"2020"}}],"physicalDescription":"3
+        Cubic Feet (6 oversize boxes, 1 oversize folder, 1 legal half manuscript box);
+        1.95 Gigabytes (163 digital files); 1 item(s) (1 website)","summary":["The
+        Collection on Community Activism is an artificial collection created to include
+        records from multiple activist events and organizations in the MIT community.
+        The records consist of posters, digital photographs, digital videos, and social
+        media and document a range of political and social issues, including sexual
+        assault, gender equality, and immigration. Events are related to the 2016
+        Presidential Election, the March for Science, Executive Order 13769, the Stephen
+        A. Schwarzman College of Computing, and MIT''s involvement with Jeffrey Epstein
+        and Charles and David Koch."],"contributors":[{"value":"Massachusetts Institute
+        of Technology. Libraries. Department of Distinctive Collections"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/84","title":"Architecture
+        Education Study records","identifiers":[{"kind":"Collection Identifier","value":"AC.0108"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1972","lte":"1982"}}],"physicalDescription":"6
+        Cubic Feet (6 record cartons)","summary":null,"contributors":[{"value":"Architecture
+        Education Study"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1230","title":"Rifat
+        Chadirji Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2016.0001"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"40
+        Linear Feet Architectural drawings and prints, and maps make up the vast majority
+        of this archive.  Well over a half of this resource is not in final housing
+        or containers.  Some materials are currently in flat boxes, other materials
+        are in variously sized files, or in various types and sizes of tubes or boxes
+        for rolled materials.  Therefore, total linear feet can only be estimated,
+        currently. Circa 1500 original and/or copies of architectural and urban planning
+        drawings, maps, photographs, prints, and Boxed numbered limited edition sets
+        of etchings of drawings (12) and photographs (8).  7 mounted photographs,
+        and circa 5 large loose photographic prints. Graphic material dimensions vary
+        from letter size or smaller, to a 2-piece map, 12 x 8 feet. Boxed sets are
+        circa 1 x 22 x 24 inches. Photographs are circa 8 x 10 inches and mounted
+        on board.  Large loose unmounted photographs are circa 16 x 20 inches.","summary":null,"contributors":[{"value":"Chadirji,
+        Rifat"},{"value":"Chadirji, Rifat"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/206","title":"Massachusetts
+        Institute of Technology, Aga Khan Program for Islamic Architecture records","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0245"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1979","lte":"2000"}},{"kind":"creation","value":null,"range":null}],"physicalDescription":"18
+        Cubic Feet (11 record cartons, 22 manuscript boxes, 1 half manuscript box,
+        1 folio); 1 item(s) (1 archived website); .155 Megabytes (11 digital files)","summary":null,"contributors":[{"value":"Aga
+        Khan Program for Islamic Architecture"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1113","title":"George
+        Charles Manning papers","identifiers":[{"kind":"Collection Identifier","value":"MC.0621"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1889","lte":"1942"}}],"physicalDescription":"4
+        Cubic Feet (4 record cartons)","summary":null,"contributors":[{"value":"Manning,
+        George Charles, 1892-1964"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1229","title":"Marilyn
+        Jenkins-Madina Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0010"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"1.5
+        Linear Feet 7 metal slide boxes with slides; 1 green cloth bag with CD and
+        4 small plastic boxes that housed additional slides (now empty).  Box 8: record
+        carton 8 boxes and one cloth bag:  7 metal slide boxes with slides, 1 cloth
+        bag with a CD and small empty slide boxes.  Those slides were moved, and given
+        labelled dividers in with the slides which arrived in box 7.  Box 8 contains
+        envelopes of developed negatives and prints, 7 more small slide boxes, and
+        a folder of negatives. Slides are all 35mm.  Metal boxes: depth 20.5 x width
+        36.8 x height 5.5 centimetres; bag, circa depth 20 x width 13 x height 25
+        centimetres.  Record carton depth15.5, height 10, width 12.5 inches. Photographs
+        are 4 x 6 inches, negatives are 35mm.","summary":null,"contributors":[{"value":"Jenkins,
+        Marilyn (Marilyn Jenkins-Madina)"},{"value":"Jenkins, Marilyn (Marilyn Jenkins-Madina)"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/324","title":"Massachusetts
+        Institute of Technology, Department of Urban Studies and Planning student
+        records","identifiers":[{"kind":"Collection Identifier","value":"AC.0376"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1967","lte":"2003"}}],"physicalDescription":"73.3
+        Cubic Feet (73 record cartons, 1 manuscript box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Department of Urban Studies and Planning"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/323","title":"Massachusetts
+        Institute of Technology, Department of Urban Studies and Planning faculty
+        and staff personnel records","identifiers":[{"kind":"Collection Identifier","value":"AC.0375"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1973","lte":"1990"}}],"physicalDescription":"3.6
+        Cubic Feet (3 record cartons, 2 manuscript boxes)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Department of Urban Studies and Planning"}]}]}}}'
+  recorded_at: Thu, 16 Mar 2023 15:16:40 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/aspace_publication_date.yml
+++ b/test/vcr_cassettes/aspace_publication_date.yml
@@ -1,0 +1,252 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://timdex.mit.edu/graphql
+    body:
+      encoding: UTF-8
+      string: '{ "query": "{ search(searchterm: \"SOVEREIGN INTIMACY: PRIVATE MEDIA
+        AND THE TRACES OF COLONIAL VIOLENCE\", sourceFilter: \"MIT ArchivesSpace\")
+        { hits records { sourceLink title identifiers { kind value } dates { kind
+        value range { gte lte } } physicalDescription summary contributors { value
+        } } } }"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Content-Type:
+      - application/json
+      Origin:
+      - https://lib.mit.edu
+      Connection:
+      - Keep-Alive
+      Host:
+      - timdex.mit.edu
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Tue, 14 Mar 2023 20:52:10 GMT
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - POST
+      Access-Control-Expose-Headers:
+      - ''
+      Access-Control-Max-Age:
+      - '7200'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      - Origin
+      Etag:
+      - W/"ee8af17355f179d71eed5fd6399c5ca1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1a80b7dd-e5c7-482f-8af4-6e1321494a79
+      X-Runtime:
+      - '0.232255'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '17095'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"data":{"search":{"hits":1282,"records":[{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1253","title":"Iraqi
+        engineering and art journals collection","identifiers":[{"kind":"Collection
+        Identifier","value":"AKDC.2017.0004"}],"dates":[{"kind":"publication","value":null,"range":{"gte":"1940","lte":"1983"}}],"physicalDescription":".418
+        Linear Feet Two 2.5 inch width document boxes, legal size. 22 journals Each
+        box is 15.25 x 2.5 x 10.25 inches.","summary":null,"contributors":[{"value":"Private
+        Collector"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/531","title":"Massachusetts
+        Institute of Technology, Comparative Media Studies records","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0592"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1989","lte":"2008"}},{"kind":"creation","value":null,"range":null}],"physicalDescription":"2.3
+        Cubic Feet (2 record cartons, 1 manuscript box); 2 item(s) (2 archived websites)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Department of Comparative Media Studies"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/594","title":"Records
+        of Howe, Manning \u0026 Almy, Inc. and the papers of Lois Lilley Howe, Eleanor
+        Manning O''Connor, and Mary Almy","identifiers":[{"kind":"Collection Identifier","value":"MC.0009"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1883","lte":"1972"}}],"physicalDescription":"25
+        Cubic Feet (21 record cartons, 4 manuscript boxes, 1 half manuscript box,  6
+        flat storage boxes, 1 small box, 1 roll, 54 oversize folders)","summary":["The
+        firm of Howe, Manning \u0026 Almy is believed to be the first architectural
+        firm in Boston founded by women and the second in the United States. Lois
+        Lilley Howe (Massachusetts Institute of Technology, SB 1890), whose commissions
+        began in 1894, established her own firm in 1900 and asked Eleanor Manning
+        (Massachusetts Institute of Technology, SB 1906), one of her draftsmen, to
+        be her partner in 1913, creating the firm of Lois Lilley Howe \u0026 Manning.
+        In 1926, another draftsman from the office, Mary Almy (Radcliffe College,
+        1905, and Massachusetts Institute of Technology, SB 1922) became a partner,
+        assuming responsibility for the business aspects of the firm. Manning focused
+        on the technical architectural work and design problems, and Howe continued
+        to concentrate on design. The firm dissolved in 1937 when Howe retired, and
+        Manning and Almy started separate practices.\n\nThe emphasis of the firm was
+        on domestic architecture and the partners did both building and remodeling.
+        They were interested in urban housing problems and worked with the Architects''
+        Small House Service Bureau of Massachusetts and the Boston Housing Association
+        throughout the 1920s and 1930s. They submitted small house designs to the
+        Department of the Interior for the Subsistence Homestead Communities, remodeled
+        apartments for the Lynn Slum Clearance Project, and developed housing in Mariemont,
+        Ohio. Materials of the firm include correspondence, financial data, reports,
+        specifications, photographs, blueprints, drawings, and research materials
+        that document the firm''s projects and commissions.\n\nThe collection also
+        includes personal papers of the three architects including illustrated travel
+        diaries, watercolors, sketchbooks, and architecural scrapbooks. Records from
+        Eleanor Manning O''Connor''s  private architectural work after 1937 and material
+        from the Seventeen Associated Architects are included. There are a number
+        of documents about the Howe family in the personal papers of Lois Lilley Howe."],"contributors":[{"value":"Howe,
+        Manning \u0026 Almy"},{"value":"Howe, Lois Lilley, 1864-1964"},{"value":"Manning,
+        Eleanor, 1884-1973"},{"value":"Almy, Mary, 1883-1953"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/196","title":"Massachusetts
+        Institute of Technology, Communications Forum records","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0235"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1985","lte":"1996"}}],"physicalDescription":"5.95
+        Cubic Feet (3 record cartons, 8 manuscript boxes, 1 large flat box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Communications Forum"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/244","title":"Muriel
+        Cooper personal archives","identifiers":[{"kind":"Collection Identifier","value":"MC.0739"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"78
+        Cubic Feet (78 record cartons)","summary":null,"contributors":[{"value":"Cooper,
+        Muriel"},{"value":"Visible Language Workshop (Massachusetts Institute of Technology)"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/457","title":"Massachusetts
+        Institute of Technology, News in the Future Research Group, records of Fishwrap
+        Ask Joe!","identifiers":[{"kind":"Collection Identifier","value":"AC.0518"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1994","lte":"1995"}}],"physicalDescription":"0.3
+        Cubic Feet (1 manuscript box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Media Laboratory"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1197","title":"Pauline
+        Maier papers","identifiers":[{"kind":"Collection Identifier","value":"MC.0705"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1960","lte":"2013"}}],"physicalDescription":"15
+        Cubic Feet (15 record cartons)","summary":null,"contributors":[{"value":"Maier,
+        Pauline, 1938-2013"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1043","title":"Paul
+        Earls archives","identifiers":[{"kind":"Collection Identifier","value":"MC.0552"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1914","lte":"1998"}}],"physicalDescription":"16.3
+        Cubic Feet (16 record cartons, 1 manuscript box)","summary":["The Paul Earls
+        archives contains a large number of music manuscripts and recordings of his
+        compositions, as well as slides of multi-media laser and sound works he created
+        in venues in the United States and Europe.\n\nfrom: \"What''s the Score: Spring
+        2000,\"  MIT Music Library newsletter\nPaul Earls was a fellow at the Massachusetts
+        Institute of Technology Center for Advanced Visual Studies (CAVS) from 1970
+        until his death in 1998. He was a composer known mostly for theatrical and
+        multi-media works that included his laser art such as The Death of King Phillip,
+        Icarus: a Sky Opera (with Otto Piene, Ian Strasfogel and Guenther Schneider-Siemssen),
+        and Mozart and Cosmology (with Beth Soll). He also wrote symphonic, choral,
+        chamber and electronic music. Examples include Brevis Mass, And On the Seventh
+        Day for full orchestra, Nun Danket Fantasy for organ, and Five Notables for
+        solo violin."],"contributors":[{"value":"Earls, Paul, 1934-1998"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/1356","title":"Massachusetts
+        Institute of Technology, Visible Language Workshop records","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0665"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1973","lte":"1994"}}],"physicalDescription":"8
+        Linear Feet 8 boxes","summary":["The Massachusetts Institute of Technology,
+        Visible Language Workshop records is a collection of materials pertaining
+        to the subject of design within the framework of MIT''s arts-science-technology
+        academics. The collection focuses primarily on the work of Muriel Cooper at
+        MIT. \n\nThe materials include a binder of collected materials demonstrating
+        the activities, practice, and published output of the Visible Language Workshop,
+        as well as teaching slides, audio and videotape, and presentation materials
+        from a 1994 TED5 conference talk given by Muriel Cooper."],"contributors":[{"value":"Cooper,
+        Muriel"},{"value":"Massachusetts Institute of Technology. Media Laboratory"},{"value":"Visible
+        Language Workshop (Massachusetts Institute of Technology)"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/157","title":"Massachusetts
+        Institute of Technology, Department of Humanities, Writing Program student
+        records","identifiers":[{"kind":"Collection Identifier","value":"AC.0187"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1980","lte":"1987"}}],"physicalDescription":"1
+        Cubic Feet (2 manuscript boxes, 1 half manuscript box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Program in Comparative Media Studies/Writing"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/211","title":"Massachusetts
+        Institute of Technology, Office of the Assistant to the Chair of the Corporation
+        and to the President, records of Walter L. Milne","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0250"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1962","lte":"1990"}}],"physicalDescription":"145.8
+        Cubic Feet (145 record cartons, 2 manuscript boxes, 1 half manuscript box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the Assistant to the Chairman of the Corporation
+        and to the President"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1226","title":"Isfahan
+        Urban History Project","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2015.0004"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"11.5
+        Linear Feet; 11 box(es) 5 record cartons (boxes 1-5); \n1 legal-size documents
+        box, 2.5\" width (box 6); \n1 portfolio box (box 7); \n2 triangular tubes
+        (tubes 1-2); \n2 extra-large flat files (xl ff A \u0026 B)","summary":["The
+        contents of the Isfahan Urban History Project Archive are the culminating
+        efforts of Lisa Golombek, Renata Holod, Claus Breede, and Juliette Yaghubi-Nassab,
+        which document the research team''s fieldwork and subsequent projects related
+        to the study of Isfahan''s pre-modern urban development. Comprising the fieldwork
+        are notebooks, sketchbooks, research indexes and files, maps, drawings, photography
+        and color slides depicting the city''s street patterns, service nodes, monuments
+        and domestic architecture. Also included are unpublished writings, articles,
+        and speeches authored by Golombek and Holod, as well as the foundational work
+        for a computer program designed to organize and analyze project findings.
+        Several districts of Isfahan are represented in the studies, including Jubareh,
+        Dar-Dasht, and Kara''an. Specific locations of interest include the Ali Quli
+        Agha complex, Masjid-i Kirmani, and Old Maydan. The majority of the Archive''s
+        contents were created during two seasons of field work in 1974 and 1976."],"contributors":[{"value":"Golombek,
+        Lisa"},{"value":"Yaghubi-Nassab, Juliette"},{"value":"Holod, Renata"},{"value":"Breede,
+        Claus, 1944-"},{"value":"Royal Ontario Museum"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/480","title":"Massachusetts
+        Institute of Technology, Student Art Association records","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0541"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1960","lte":"2000"}}],"physicalDescription":"1
+        Cubic Feet (1 record carton)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Student Art Association"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/326","title":"Massachusetts
+        Institute of Technology, Office of the Vice President and Dean of the Graduate
+        School, records of Kenneth R. Wadleigh","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0378"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1950","lte":"1983"}}],"physicalDescription":"29.3
+        Cubic Feet (29 record cartons, 1 manuscript box)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the Vice President and Dean of the Graduate
+        School"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/352","title":"Massachusetts
+        Institute of Technology, Office of the Assistant to the President for Government
+        and Community Relations records","identifiers":[{"kind":"Collection Identifier","value":"AC.0408"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1968","lte":"1994"}}],"physicalDescription":"16
+        Cubic Feet (16 record cartons)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the Assistant to the President for Government
+        and Community Relations"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/9","title":"Massachusetts
+        Institute of Technology, Office of the President and Chancellor, records of
+        Jerome B. Wiesner","identifiers":[{"kind":"Collection Identifier","value":"AC.0008"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1960","lte":"1984"}}],"physicalDescription":"84.6
+        Cubic Feet (254 manuscript boxes)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the President and Chancellor"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/498","title":"Massachusetts
+        Institute of Technology, Office of the President and Chancellor, Records of
+        the Assistant to the President and Provost, Norman C. Dahl","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0559"}],"dates":[{"kind":"creation","value":null,"range":null}],"physicalDescription":"6
+        Cubic Feet (6 record cartons)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the President and Chancellor"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/334","title":"Massachusetts
+        Institute of Technology, Office of the President and Chancellor, records of
+        Barbara Scott Nelson, assistant to the president and chancellor","identifiers":[{"kind":"Collection
+        Identifier","value":"AC.0387"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1972","lte":"1979"}}],"physicalDescription":"18
+        Cubic Feet (18 record cartons)","summary":["Barbara Scott Nelson was assistant
+        to Massachusetts Institute of Technology President Jerome B. Wiesner and Chancellor
+        Paul E. Gray between 1972 and 1978. Wiesner and Gray served as president and
+        chancellor from 1971 to 1980.  The collection contains notes, reports, printed
+        material, and other files on administrative issues including affirmative action;
+        the Institute''s involvement in outside professional associations such as
+        the American Association of University Administrators and the National Association
+        of State Land Grant Colleges, and relations with government and other universities;
+        and educational programs at MIT. There are also records about faculty committees,
+        budget and finance, fund raising, the MIT Corporation Development Committee,
+        and the Whitehead Institute for Biomedical Research."],"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the President and Chancellor"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/2/resources/342","title":"Massachusetts
+        Institute of Technology, Office of the President and Chancellor, records of
+        Chancellor Paul E. Gray","identifiers":[{"kind":"Collection Identifier","value":"AC.0397"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1965","lte":"1981"}}],"physicalDescription":"63
+        Cubic Feet (189 manuscript boxes)","summary":null,"contributors":[{"value":"Massachusetts
+        Institute of Technology. Office of the President and Chancellor"}]},{"sourceLink":"https://archivesspace.mit.edu/repositories/5/resources/1244","title":"Ali
+        Tayar Archive","identifiers":[{"kind":"Collection Identifier","value":"AKDC.2017.0003"}],"dates":[{"kind":"creation","value":null,"range":{"gte":"1983","lte":"2016"}},{"kind":"creation","value":null,"range":{"gte":"1994","lte":"2014"}}],"physicalDescription":"44
+        Linear Feet Currently, there are a single 5-drawer flat file cabinet; 28 tubes
+        of rolled oversize material and drawings; 15 flat boxes; 2 record cartons;
+        71 document boxes.  The majority will stay in this configuration, some of
+        the large drawings may eventually be rehoused following removal from the Center
+        in March of 2020, to be housed with other archival collections in the Department
+        of Distinctive Collections'' storage spaces.; Most of the contents of this
+        archive (drawings, printed matter, photographs, mixed materials, publications,
+        photocopies, and original documents) arrived in very good condition. However,
+        there were many documents throughout the project files which were on fax paper
+        and fading. Most of these have been reformatted on photocopy paper for preservation
+        purposes.","summary":["The Ali Tayar Archive covers many of the works of the
+        late architect and designer Ali Tayar. Present in the collection are records
+        concerning works of architecture, interior design, and furniture/product design.
+        Also included are works from design competitions, special projects, publicity
+        materials, ephemera, and photographic materials."],"contributors":[{"value":"Tayar,
+        Ali"},{"value":"Parallel Design Partnership"}]}]}}}'
+  recorded_at: Tue, 14 Mar 2023 20:52:11 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
#### Why these changes are being introduced:

We encountered a bug after V2 launch in the normalization process, during which Bento hits an unhandled nil value that breaks the search results. This is because we are assuming every ASpace record has a creation date, when in fact some of them have publication dates instead.

Somewhat related to this is a transmogrifier bug that causes a `kind` to be associated with a date even when there is no date.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/TIMX-211
* https://mitlibraries.atlassian.net/browse/TIMX-212

#### How this addresses that need:

This updates `NormalizeTimdex#extract_dates` to select as relevant dates of either the 'creation' _or_ 'publication' date kind. It also adds a guard clause to return if the `relevant_dates` array is empty (a precaution that would have prevented this error).

#### Side effects of this change:

I removed a superfluous check for `date['kind'] == 'creation'` in the guard clause in the `extract_dates` method that checks for a date range. At this point in the method, we have already confirmed that the relevant date is either a creation or publication date.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
