### PR TITLE
Update theme gem and document PLATFORM_NAME variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'ipaddr_range_set'
 gem 'jquery-rails'
 gem 'jquery-validation-rails'
 gem 'lograge'
-gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.1'
+gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.2'
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/mitlibraries/mitlibraries-theme
-  revision: 93b931b802485f9e35a6878f957b3fd88ae3b294
-  tag: v1.1
+  revision: bcbe5d3de36a92d275085a045c5c4d8f30f33e62
+  tag: v1.2
   specs:
     mitlibraries-theme (1.0.2)
       rails (>= 6, < 8)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ to construct thumbnail URLs.
   - Hints will only be displayed to the user if they are in `HINT_SOURCES`.
 - `LOG_LEVEL`: set log level for development, default is `:debug`
 - `LOG_LIKE_PROD`: uses prod-like logging in development if set
+- `PLATFORM_NAME`: The value set is added to the header after the MIT Libraries logo. The logic and CSS for this comes from our theme gem.
 - `PRIMO_TIMEOUT`: value to override the 6 second default for Primo timeout.
 - `REQUESTS_PER_PERIOD`: number of requests per time period we allow from a
   single non-MIT IP address. Defaults to 100. Example: "100".


### PR DESCRIPTION
#### Why these changes are being introduced:

The GDT project added a feature to the theme gem to conditionally include the platform name in the header if the `PLATFORM_NAME` environment variable is supplied.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/GDT-124

#### How this addresses that need:

This updates the theme gem to the v1.2 tag, which includes the new feature, and documents the PLATFORM_NAME variable.

#### Side effects of this change:

None. The app will continue to use the standard header if PLATFORM_NAME is not supplied.

#### Developer

- [x] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod **(Intentionally not setting the variable at this time, so we can choose when to make the change.)**
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
