### PR TITLE
Initial TACOS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ to construct thumbnail URLs.
 - `RESULTS_PER_BOX`: defaults to 3
 - `SENTRY_DSN`: logs exceptions to Sentry
 - `SENTRY_ENV`: Sentry environment for the application. Defaults to 'unknown' if unset.
+- `TACOS_URL`: The GraphQL endpoint for the [TACOS](https://github.com/mitlibraries/tacos/) application.
 - `TIMDEX_TIMEOUT`: value to override the 6 second default for TIMDEX timeout.
 
 ## Confirming functionality after updating dependencies
@@ -94,4 +95,5 @@ bin/rails test
 
 The following additional manual testing should be performed in the PR build on Heroku.
 
-- search for a few different terms and confirm results return and are displayed in each of the boxes as appropriate. Not all boxes should return results for all searches, but comparing to production should lead to the same results (although there is a cache in production so if results don't match you might want to first clear the production cache before being overly concerned)
+- Search for a few different terms and confirm results return and are displayed in each of the boxes as appropriate. Not all boxes should return results for all searches, but comparing to production should lead to the same results (although there is a cache in production so if results don't match you might want to first clear the production cache before being overly concerned)
+- If the app is integrated with TACOS, the browser console should include a response from that system confirming the search string and source system.

--- a/app/views/search/_trigger_tacos.html.erb
+++ b/app/views/search/_trigger_tacos.html.erb
@@ -1,0 +1,12 @@
+$.ajax({
+  type: "POST",
+  url: "<%= ENV.fetch('TACOS_URL', '') %>",
+  contentType: 'application/json',
+  data: '{ "query": "{ logSearchEvent( searchTerm: \\"<%= params[:q] %>\\" sourceSystem: \\"bento\\" ) { phrase source } }" }',
+  dataType: 'json'
+}).success(function (msg) {
+  console.log(msg.data.logSearchEvent);
+}).fail(function (xhr, textStatus ) {
+  console.log('Failure looking up search in Tacos:');
+  console.log(xhr);
+});

--- a/app/views/search/_trigger_tacos.html.erb
+++ b/app/views/search/_trigger_tacos.html.erb
@@ -2,11 +2,8 @@ $.ajax({
   type: "POST",
   url: "<%= ENV.fetch('TACOS_URL', '') %>",
   contentType: 'application/json',
-  data: '{ "query": "{ logSearchEvent( searchTerm: \\"<%= params[:q] %>\\" sourceSystem: \\"bento\\" ) { phrase source } }" }',
+  data: '{ "query": "{ logSearchEvent( searchTerm: \\"<%= params[:q] %>\\" sourceSystem: \\"bento\\" ) { phrase } }" }',
   dataType: 'json'
-}).success(function (msg) {
-  console.log(msg.data.logSearchEvent);
 }).fail(function (xhr, textStatus ) {
-  console.log('Failure looking up search in Tacos:');
   console.log(xhr);
 });

--- a/app/views/search/bento.html.erb
+++ b/app/views/search/bento.html.erb
@@ -55,4 +55,9 @@
   <%= render partial: "trigger_search", locals: { target: 'timdex', id: 'aspace_content'} %>
 
   <%= render partial: "trigger_hint" %>
+
+  <% if ENV.has_key?('TACOS_URL') %>
+    <%= render partial: "trigger_tacos" %>
+  <% end %>
+
 </script>


### PR DESCRIPTION
This defines a new env variable, TACOS_URL, which stores the endpoint
for the TACOS GraphQL service. When defined, the search results page
will then direct the user agent to send the search string to the TACOS
system, which will eventually respond with any additional information
we can detect about the search string.

For now, the only response will be to reflect the search string back
into the console, along with the originating system.


### Developer

#### Ticket

- https://mitlibraries.atlassian.net/browse/ENGX-267 (this change to Bento)
- https://mitlibraries.atlassian.net/browse/ENGX-266 (the related TACOS change to CORS behavior)

#### Environment
- [x] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod

#### Accessibility
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] There are no user-facing UI changes that need a11y testing

#### Stakeholders
- [ ] Stakeholder approval has been confirmed (or is not needed)
- [x] Stakeholder approval is not needed at this time

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
