### PR TITLE
Remove sqlite version requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ DEPENDENCIES
   simplecov
   simplecov-lcov
   skylight
-  sqlite3 (< 2)
+  sqlite3
   stringex
   uglifier
   vcr


### PR DESCRIPTION
I had temporarily prevented sqlite from installing because it will fail until we upgrade Rails. Because we've enabled the frozen config in bundler, Heroku builds won't work until this is either removed from Gemfile.lock or added to the Gemfile. I'd prefer not to add it to the Gemfile, because we might then forget to upgrade the gem when we upgrade Rails.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
