### PR TITLE
Restrict ruby and rails upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>MITLibraries/renovate-config:renovate-ruby"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ruby"
+      ],
+      "allowedVersions": "<3.3"
+    },
+    {
+      "matchPackageNames": [
+        "rails"
+      ],
+      "allowedVersions": "<7.2"
+    }
   ]
 }


### PR DESCRIPTION
Why are these changes being introduced:

* Ruby and Rails should keep versions in line with recommendations
* This pins Ruby to version 3.2.x and Rails to 7.1.x
* When we upgrade to Rails 7.2, we will bump Ruby to 3.3

