### PR TITLE
Update global alert styles per USE changes

### DIFF
--- a/app/assets/stylesheets/_bento.scss
+++ b/app/assets/stylesheets/_bento.scss
@@ -24,9 +24,26 @@
   margin-bottom: 15%;
 }
 
-.wrap-notices .title {
-  font-size: 1.2rem;
-  line-height: 1.4;
+.wrap-notices {
+  background-color: #007899;
+
+  .title {
+    color: #e5f9ff;
+    font-size: 1.7rem;
+    font-weight: 600;
+    line-height: 1.4;
+
+    a {
+      text-underline-offset: 0.5rem;
+      text-decoration-color: #00c8ff;
+      color: #fff;
+
+      &:hover,
+      &:focus {
+        text-decoration-color: #99E9FF;
+      }
+    }
+  }
 }
 
 .wrap-outer-header-local {


### PR DESCRIPTION
Our desired styling for global alerts is changing, taking the lead of the Unified Search project. Particularly with the coming launch of that platform, we want to update how global alerts are rendered across other properties.

**Relevant ticket(s):**

https://mitlibraries.atlassian.net/browse/use-445

**How does this address that need:**

This updates the rendering of the global alert banner, according to styles developed by the UX group.

**Document any side effects to this change:**

This is a bespoke addition to the Bento codebase that ideally will be rolled into the theme gem in the future, but that coming change will be much more involved than a handful of styles in the alert area. For now, our best option is to introduce a bespoke override like this.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
